### PR TITLE
Standardise fonts: promote Inter + add IBM Plex Mono

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -49,8 +49,8 @@
   --status-bg:     #161616;
   --backdrop:      rgba(0,0,0,0.55);
   --dirty-color:   #c07a30;
-  --font-ui:  -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  --font-ui:   'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'IBM Plex Mono', 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
   --panel-min: 180px;
 }
 


### PR DESCRIPTION
## What

Promotes **Inter** to first position in `--font-ui` and adds **IBM Plex Mono** as the primary monospace font in `--font-mono`, matching the font choices now in use on kova.md and wiki.kova.md.

```diff
- --font-ui:  -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', sans-serif;
- --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+ --font-ui:   'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+ --font-mono: 'IBM Plex Mono', 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
```

## Why

kova.md now self-hosts Inter (variable woff2) and IBM Plex Mono, and wiki.kova.md loads both from Google Fonts. The app was the odd one out — Inter was listed as a low-priority fallback and IBM Plex Mono wasn't referenced at all.

## Caveat

IBM Plex Mono will render in the app only if it is installed on the user's system. JetBrains Mono and Fira Code remain in the fallback chain for users who have those but not IBM Plex Mono. A follow-up to bundle the woff2 inside the Tauri app bundle will give full consistency on all platforms without requiring user installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)