### PR TITLE
feat: slide hiding + thumbnail context menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,9 @@ export default function App() {
   const [currentSlideIndex, setCurrentSlideIndex] = useState(0);
   const [focusMode, setFocusMode]         = useState(false);
   const [presentMode, setPresentMode]     = useState(false);
+  // Index into visibleSlides (hidden slides skipped) while presenting — kept
+  // separate from currentSlideIndex (which indexes the full editor deck).
+  const [presentIndex, setPresentIndex]   = useState(0);
   const [settings, setSettings]           = useState<AppSettings>(loadSettings);
   const [showSettings, setShowSettings]   = useState(false);
   const [settingsScrollToUpdates, setSettingsScrollToUpdates] = useState(false);
@@ -268,6 +271,13 @@ export default function App() {
     ? Math.min(currentSlideIndex, slides.length - 1)
     : 0;
 
+  // Deck used for presentation + export — hidden slides removed. Reference-equal
+  // to entries in `slides`, so index translation uses indexOf/indexOf.
+  const visibleSlides = useMemo(() => slides.filter((s) => !s.hidden), [slides]);
+  const safePresentIndex = visibleSlides.length > 0
+    ? Math.min(presentIndex, visibleSlides.length - 1)
+    : 0;
+
   const aspectRatio = useMemo(
     () => parseAspectRatio(frontmatter.aspect_ratio as string | undefined),
     [frontmatter.aspect_ratio],
@@ -432,16 +442,21 @@ export default function App() {
     } catch { /* ignore */ }
     setPresentMode(false);
     setPresenterMode(false);
+    // Land the editor on whatever slide we exited on (translate visible→full).
+    const full = slides.indexOf(visibleSlides[safePresentIndex]);
+    if (full >= 0) setCurrentSlideIndex(full);
     await getCurrentWindow().setFullscreen(false).catch(() => {});
     isExitingRef.current = false;
-  }, []);
+  }, [slides, visibleSlides, safePresentIndex]);
 
   const handlePresentEnter = useCallback(async (e?: React.MouseEvent) => {
-    if (slides.length === 0) return;
+    if (visibleSlides.length === 0) return;
     isExitingRef.current = false;
     const sessionId = ++presentSessionRef.current;
-    const startIndex = e?.altKey ? safeSlideIndex : 0;
-    if (!e?.altKey) setCurrentSlideIndex(0);
+    // "Present from current" (alt) maps the editor's slide into visible space;
+    // if that slide is hidden, indexOf is -1 → start from the first visible.
+    const startIndex = e?.altKey ? Math.max(0, visibleSlides.indexOf(slides[safeSlideIndex])) : 0;
+    setPresentIndex(startIndex);
 
     // Resolve 'auto': detect monitors first, then pick mode.
     // Use currentMonitor() (not primaryMonitor()) to find the monitor Kova is
@@ -474,7 +489,7 @@ export default function App() {
 
       if (external) {
         const initPayload: PresentInitPayload = {
-          slides,
+          slides: visibleSlides,
           theme: activeTheme,
           index: startIndex,
           aspectRatio,
@@ -564,7 +579,7 @@ export default function App() {
 
     setPresentMode(true);
     await getCurrentWindow().setFullscreen(true).catch(() => {});
-  }, [slides, safeSlideIndex, activeTheme, aspectRatio, frontmatter.title, settings.presentationMode]);
+  }, [slides, visibleSlides, safeSlideIndex, activeTheme, aspectRatio, frontmatter.title, settings.presentationMode]);
 
   // Prevent display sleep while presenting; release on exit.
   // Covers all exit paths (normal, error, external window close).
@@ -638,8 +653,8 @@ export default function App() {
   // PresentationOverlay drives navigation but never emits present:navigate.
   useEffect(() => {
     if (!presentMode) return;
-    emitTo('audience', 'present:navigate', { index: safeSlideIndex }).catch(() => {});
-  }, [presentMode, safeSlideIndex]);
+    emitTo('audience', 'present:navigate', { index: safePresentIndex }).catch(() => {});
+  }, [presentMode, safePresentIndex]);
 
   const handleThemeSelect = useCallback((id: string) => {
     setActiveThemeId(id);
@@ -876,9 +891,9 @@ export default function App() {
   }, [filePath, content, buildSaveContent]);
 
   const handleExport = useCallback(async () => {
-    if (slides.length === 0) return;
+    if (visibleSlides.length === 0) return;
     try {
-      const { base64, warnings } = await exportToPptx(slides, frontmatter, activeTheme);
+      const { base64, warnings } = await exportToPptx(visibleSlides, frontmatter, activeTheme);
       const defaultPath = filePath
         ? filePath.replace(/\.(md|markdown)$/i, '.pptx')
         : 'presentation.pptx';
@@ -896,10 +911,10 @@ export default function App() {
       console.error('Export failed:', err);
       window.alert(`PPTX export failed: ${String(err)}`);
     }
-  }, [slides, frontmatter, activeTheme, filePath]);
+  }, [visibleSlides, frontmatter, activeTheme, filePath]);
 
   const handleExportPdf = useCallback(async () => {
-    if (slides.length === 0) return;
+    if (visibleSlides.length === 0) return;
     const defaultPath = filePath
       ? filePath.replace(/\.(md|markdown)$/i, '.pdf')
       : 'presentation.pdf';
@@ -912,18 +927,18 @@ export default function App() {
     pdfSlideRefs.current.clear();
     await new Promise<void>(resolve => {
       pdfExportResolveRef.current = resolve;
-      setPdfExportContext({ slides: [...slides], savePath });
+      setPdfExportContext({ slides: [...visibleSlides], savePath });
     });
-  }, [slides, filePath]);
+  }, [visibleSlides, filePath]);
 
   const handlePrint = useCallback(async () => {
-    if (slides.length === 0) return;
+    if (visibleSlides.length === 0) return;
     printSlideRefs.current.clear();
     await new Promise<void>(resolve => {
       printResolveRef.current = resolve;
-      setPrintContext({ slides: [...slides] });
+      setPrintContext({ slides: [...visibleSlides] });
     });
-  }, [slides]);
+  }, [visibleSlides]);
 
   const handleCopyWithAssets = useCallback(async () => {
     if (!filePath) return;
@@ -986,6 +1001,25 @@ export default function App() {
     setIsDirty(true);
     setCurrentSlideIndex(toIndex);
     setTimeout(() => editorRef.current?.scrollToSlide(toIndex), 50);
+  }, []);
+
+  const handleToggleHidden = useCallback((index: number) => {
+    setContent((prev) => {
+      const fmMatch = prev.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/);
+      const fmBlock = fmMatch ? fmMatch[0] : '';
+      const body = prev.slice(fmBlock.length);
+      // Edit ONLY the target segment; keep every other segment + the `---`
+      // delimiters byte-identical so the parser's positional cache still hits
+      // for unchanged slides (no thumbnail remount → scroll position preserved).
+      const segments = body.split(/^---$/m);
+      if (index < 0 || index >= segments.length) return prev;
+      const seg = segments[index];
+      segments[index] = /<!--\s*hidden\s*-->/.test(seg)
+        ? seg.replace(/[ \t]*<!--\s*hidden\s*-->[ \t]*\r?\n?/, '')
+        : seg.replace(/^(\s*)/, '$1<!-- hidden -->\n');
+      return fmBlock + segments.join('---');
+    });
+    setIsDirty(true);
   }, []);
 
   const handleWarn = useCallback((msg: string) => {
@@ -1142,20 +1176,20 @@ export default function App() {
       )}
       {presentMode && (
         <PresentationOverlay
-          slides={slides}
-          currentIndex={safeSlideIndex}
+          slides={visibleSlides}
+          currentIndex={safePresentIndex}
           theme={activeTheme}
           docTitle={frontmatter.title}
           aspectRatio={aspectRatio}
           laserColor={settings.laserColor}
-          onNavigate={setCurrentSlideIndex}
+          onNavigate={setPresentIndex}
           onExit={handlePresentExit}
         />
       )}
       {presenterMode && (
         <PresenterOverlay
-          slides={slides}
-          currentIndex={safeSlideIndex}
+          slides={visibleSlides}
+          currentIndex={safePresentIndex}
           theme={activeTheme}
           docTitle={frontmatter.title}
           aspectRatio={aspectRatio}
@@ -1163,7 +1197,7 @@ export default function App() {
           showTimer={settings.presenterShowTimer}
           notesFontSize={settings.presenterNotesFontSize}
           laserColor={settings.laserColor}
-          onNavigate={setCurrentSlideIndex}
+          onNavigate={setPresentIndex}
           onExit={handlePresentExit}
         />
       )}
@@ -1368,6 +1402,7 @@ export default function App() {
               currentIndex={safeSlideIndex}
               onSelect={handleThumbnailSelect}
               onReorder={handleSlideReorder}
+              onToggleHidden={handleToggleHidden}
               theme={activeTheme}
               docTitle={frontmatter.title}
               aspectRatio={aspectRatio}

--- a/src/components/layout/ThumbnailPanel.tsx
+++ b/src/components/layout/ThumbnailPanel.tsx
@@ -9,6 +9,7 @@ interface Props {
   currentIndex: number;
   onSelect: (index: number) => void;
   onReorder?: (fromIndex: number, toIndex: number) => void;
+  onToggleHidden?: (index: number) => void;
   theme?: Theme;
   docTitle?: string;
   aspectRatio?: AspectRatio;
@@ -17,7 +18,7 @@ interface Props {
 const SLIDE_W = 960;
 const THUMB_W = 140;
 
-export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, theme = DEFAULT_THEME, docTitle, aspectRatio = { w: 16, h: 9 } }: Props) {
+export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onToggleHidden, theme = DEFAULT_THEME, docTitle, aspectRatio = { w: 16, h: 9 } }: Props) {
   const slideH = Math.round(SLIDE_W * aspectRatio.h / aspectRatio.w);
 
   // Observe the outer panel div (no overflow) so a scrollbar appearing in the
@@ -26,6 +27,7 @@ export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, them
   const [scale, setScale] = useState(THUMB_W / SLIDE_W);
   const [dragFromIndex, setDragFromIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const [menu, setMenu] = useState<{ index: number; x: number; y: number } | null>(null);
 
   // Mutable drag state for use inside stable event listeners (avoids stale closures).
   const dragRef     = useRef<{ fromIndex: number; overIndex: number | null } | null>(null);
@@ -162,6 +164,29 @@ export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, them
     document.body.style.userSelect = 'none';
   }, [onReorder]);
 
+  const handleThumbContextMenu = useCallback((index: number, e: React.MouseEvent) => {
+    e.preventDefault();
+    setMenu({ index, x: e.clientX, y: e.clientY });
+  }, []);
+
+  // Dismiss the context menu on any outside interaction.
+  useEffect(() => {
+    if (!menu) return;
+    const close = () => setMenu(null);
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') close(); };
+    window.addEventListener('mousedown', close);
+    window.addEventListener('resize', close);
+    window.addEventListener('keydown', onKey);
+    const sc = scrollRef.current;
+    sc?.addEventListener('scroll', close);
+    return () => {
+      window.removeEventListener('mousedown', close);
+      window.removeEventListener('resize', close);
+      window.removeEventListener('keydown', onKey);
+      sc?.removeEventListener('scroll', close);
+    };
+  }, [menu]);
+
   const thumbH = Math.round(slideH * scale);
 
   return (
@@ -187,8 +212,11 @@ export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, them
                   isActive={i === currentIndex}
                   isDragSource={dragFromIndex === i}
                   canDrag={Boolean(onReorder)}
+                  isHidden={slide.hidden}
                   onSelect={onSelect}
+                  onToggleHidden={onToggleHidden}
                   onDragStart={handleThumbMouseDown}
+                  onContextMenu={handleThumbContextMenu}
                   theme={theme}
                   docTitle={docTitle}
                   scale={scale}
@@ -201,7 +229,56 @@ export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, them
           })
         )}
       </div>
+
+      {menu && (
+        // ponytail: fixed at cursor, may clip near the viewport edge; add flip
+        // logic only if users actually hit it.
+        <div
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{
+            position: 'fixed', left: menu.x, top: menu.y, zIndex: 1000,
+            minWidth: 140, padding: 4, borderRadius: 6,
+            background: 'var(--bg-panel, #2a2a2a)', border: '1px solid var(--border)',
+            boxShadow: '0 4px 16px rgba(0,0,0,0.4)', fontSize: 12,
+          }}
+        >
+          <MenuItem
+            label="Move up"
+            disabled={!onReorder || menu.index === 0}
+            onClick={() => { onReorder?.(menu.index, menu.index - 1); setMenu(null); }}
+          />
+          <MenuItem
+            label="Move down"
+            disabled={!onReorder || menu.index === slides.length - 1}
+            onClick={() => { onReorder?.(menu.index, menu.index + 1); setMenu(null); }}
+          />
+          <MenuItem
+            label={slides[menu.index]?.hidden ? 'Show slide' : 'Hide slide'}
+            disabled={!onToggleHidden}
+            onClick={() => { onToggleHidden?.(menu.index); setMenu(null); }}
+          />
+        </div>
+      )}
     </div>
+  );
+}
+
+function MenuItem({ label, disabled, onClick }: { label: string; disabled?: boolean; onClick: () => void }) {
+  return (
+    <button
+      disabled={disabled}
+      onClick={onClick}
+      style={{
+        display: 'block', width: '100%', textAlign: 'left',
+        padding: '5px 8px', border: 'none', borderRadius: 4,
+        background: 'transparent', color: 'var(--text)', cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.4 : 1,
+      }}
+      onMouseEnter={(e) => { if (!disabled) e.currentTarget.style.background = 'var(--accent)'; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -223,8 +300,11 @@ interface ThumbnailProps {
   isActive: boolean;
   isDragSource: boolean;
   canDrag: boolean;
+  isHidden: boolean;
   onSelect: (index: number) => void;
+  onToggleHidden?: (index: number) => void;
   onDragStart: (index: number, e: React.MouseEvent) => void;
+  onContextMenu: (index: number, e: React.MouseEvent) => void;
   theme: Theme;
   docTitle?: string;
   slideH: number;
@@ -239,7 +319,7 @@ interface ThumbnailProps {
 // keystroke. `onSelect`/`onDragStart` are forwarded as stable function
 // references (bound internally below) rather than passed as pre-bound
 // closures, specifically so they don't defeat this memoization.
-const Thumbnail = memo(function Thumbnail({ slide, index, totalSlides, isActive, isDragSource, canDrag, onSelect, onDragStart, theme, docTitle, slideH, scale, thumbH }: ThumbnailProps) {
+const Thumbnail = memo(function Thumbnail({ slide, index, totalSlides, isActive, isDragSource, canDrag, isHidden, onSelect, onToggleHidden, onDragStart, onContextMenu, theme, docTitle, slideH, scale, thumbH }: ThumbnailProps) {
   const thumbRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -252,6 +332,7 @@ const Thumbnail = memo(function Thumbnail({ slide, index, totalSlides, isActive,
       data-slide-index={index}
       onClick={() => onSelect(index)}
       onMouseDown={(e) => onDragStart(index, e)}
+      onContextMenu={(e) => onContextMenu(index, e)}
       style={{
         marginBottom: 8,
         cursor: canDrag ? 'grab' : 'pointer',
@@ -260,10 +341,26 @@ const Thumbnail = memo(function Thumbnail({ slide, index, totalSlides, isActive,
         overflow: 'hidden',
         position: 'relative',
         userSelect: 'none',
-        opacity: isDragSource ? 0.4 : 1,
+        opacity: isDragSource ? 0.4 : isHidden ? 0.45 : 1,
         transition: 'opacity 0.1s',
       }}
     >
+      {onToggleHidden && (
+        <button
+          title={isHidden ? 'Show slide in presentation/export' : 'Hide slide from presentation/export'}
+          onClick={(e) => { e.stopPropagation(); onToggleHidden(index); }}
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{
+            position: 'absolute', top: 4, right: 5, zIndex: 1,
+            width: 20, height: 20, padding: 0, lineHeight: '20px',
+            fontSize: 11, textAlign: 'center', cursor: 'pointer',
+            border: 'none', borderRadius: 3, color: '#fff',
+            background: 'rgba(0,0,0,0.55)',
+          }}
+        >
+          {isHidden ? '🚫' : '👁'}
+        </button>
+      )}
       {/* Scaled slide render */}
       <div
         style={{ width: '100%', height: thumbH, overflow: 'hidden', position: 'relative' }}

--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -331,6 +331,15 @@ describe('layout override comment', () => {
   });
 });
 
+describe('hidden slide marker', () => {
+  it('<!-- hidden --> sets hidden true and is not a visible element', () => {
+    const { slides } = parseDocument(doc('## A\n\n---\n\n<!-- hidden -->\n\n## B\n\n- Item\n'));
+    expect(slides.map((s) => s.hidden)).toEqual([false, true]);
+    const paras = slides[1].elements.filter((e) => e.type === 'paragraph');
+    expect(paras.every((p) => p.type === 'paragraph' && !p.text.includes('hidden'))).toBe(true);
+  });
+});
+
 // ── Full document round-trip ──────────────────────────────────────────────────
 
 describe('full document', () => {

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -49,6 +49,8 @@ function parseSlide(raw: string, index: number): Slide {
     ? (layoutOverrideMatch[1] as LayoutType)
     : undefined;
 
+  const hidden = /<!--\s*hidden\s*-->/.test(raw);
+
   // Preprocess before speaker-notes extraction so ??? inside custom URLs is not
   // misinterpreted as speaker-note markers. Custom elements become inline HTML
   // comment placeholders so remark preserves their position in the element list.
@@ -60,7 +62,7 @@ function parseSlide(raw: string, index: number): Slide {
 
   const layout = layoutOverride ?? detectLayout(elements, titleLevel, !!title);
 
-  return { index, raw, title, titleLevel, elements, speakerNotes: notes, layout, layoutOverride };
+  return { index, raw, title, titleLevel, elements, speakerNotes: notes, layout, layoutOverride, hidden };
 }
 
 // ── Custom syntax pre-processor ──────────────────────────────────────────────
@@ -114,8 +116,9 @@ function preprocess(content: string): PreprocessResult {
       continue;
     }
 
-    // Strip layout override comments (already captured above)
+    // Strip layout override + hidden comments (already captured above)
     if (/^<!--\s*layout:/.test(t)) continue;
+    if (/^<!--\s*hidden\s*-->$/.test(t)) continue;
 
     // Expand single-line $$...$$ to multi-line so remark-math treats it as a block
     const dm = t.match(DISPLAY_MATH_RE);

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -42,6 +42,7 @@ export interface Slide {
   speakerNotes: string;
   layout: LayoutType;
   layoutOverride?: LayoutType;
+  hidden: boolean;        // skipped in presentation + export; set via <!-- hidden --> marker
 }
 
 export interface AspectRatio { w: number; h: number }


### PR DESCRIPTION
## What

Hide individual slides from presentation and export, plus a right-click context menu on slide thumbnails.

## How

- **Hiding** via a per-slide `<!-- hidden -->` marker — mirrors the existing `<!-- layout: -->` comment pattern, so it round-trips through save/reload with no extra persistence.
  - `Slide.hidden` parsed from the marker; marker stripped from rendered output.
  - Presentation + PPTX/PDF/print run on a filtered `visibleSlides` deck with a separate present-index space; entry/exit translate to/from the full editor deck.
- **Thumbnail panel**
  - Hidden slides dimmed + one-click eye toggle.
  - Right-click context menu: Move up / Move down / Hide-Show.
  - Toggle edits only the target markdown segment, so the parser's positional cache still hits for unchanged slides — no thumbnail remount, scroll position preserved.

Reordering already existed (drag); the menu adds keyboard-free Move up/down on top.

## Test

- `parser.test.ts`: added hidden-marker parse + strip case.
- Manual: hide/show, context menu, present + export skip hidden, scroll holds on toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)