### PR TITLE
feat: native macOS integration (traffic lights, menu bar, file association, Open Recent)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2015,6 +2015,8 @@ dependencies = [
  "gio",
  "gtk",
  "notify",
+ "objc2",
+ "objc2-app-kit",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2340,9 +2342,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2362,6 +2372,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -2420,6 +2431,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,12 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 sha2 = "0.10"
 tauri-plugin-window-state = "2.4.1"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Hide the native window title text under titleBarStyle: Overlay (setTitle("")
+# doesn't clear it). Versions match what tauri already pulls in transitively.
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", features = ["NSWindow", "NSResponder"] }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18", features = [] }
 gdk = { version = "0.18", features = [] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -424,6 +424,16 @@ pub struct AppState {
     /// `RunEvent::ExitRequested` handler in lib.rs so the retried `app.exit()`
     /// below isn't intercepted a second time.
     pub exit_confirmed: std::sync::atomic::AtomicBool,
+    /// File paths from macOS "Open With" / double-click that arrived (via
+    /// `RunEvent::Opened`) before the frontend mounted its listener. Drained
+    /// once on startup by `take_pending_open`.
+    pub pending_open: Mutex<Vec<String>>,
+}
+
+/// Drain file paths that macOS delivered before the webview was ready to listen.
+#[tauri::command]
+pub fn take_pending_open(state: State<'_, AppState>) -> Vec<String> {
+    std::mem::take(&mut *state.pending_open.lock().unwrap())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,28 @@ pub fn run() {
         .manage(AppState {
             watch: Mutex::new(WatchState { current_file: None, watcher: None }),
             exit_confirmed: AtomicBool::new(false),
+            pending_open: Mutex::new(Vec::new()),
+        })
+        .setup(|app| {
+            // macOS: titleBarStyle Overlay still draws the window title text next
+            // to the traffic lights, and setTitle("") doesn't clear it. Hide it at
+            // the NSWindow level so only the in-app centered doctitle shows.
+            #[cfg(target_os = "macos")]
+            {
+                use objc2_app_kit::{NSWindow, NSWindowTitleVisibility};
+                if let Some(win) = app.get_webview_window("main") {
+                    if let Ok(ptr) = win.ns_window() {
+                        let ns: &NSWindow = unsafe { &*(ptr as *const NSWindow) };
+                        unsafe {
+                            ns.setTitleVisibility(NSWindowTitleVisibility::Hidden);
+                            ns.setTitlebarAppearsTransparent(true);
+                        }
+                    }
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            let _ = app;
+            Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             commands::read_file,
@@ -63,6 +85,7 @@ pub fn run() {
             commands::read_clipboard_image,
             commands::fetch_url_b64,
             commands::confirm_exit,
+            commands::take_pending_open,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
@@ -74,6 +97,23 @@ pub fn run() {
     // an app-level quit. Intercept here so unsaved changes get the same
     // confirmation prompt regardless of which gesture the user used to quit.
     app.run(move |app_handle, event| {
+        // macOS file association: double-click / "Open With" delivers paths here.
+        // Emit for a running app; also buffer so a launch-with-file isn't lost
+        // before the frontend mounts its listener (drained via take_pending_open).
+        #[cfg(target_os = "macos")]
+        if let tauri::RunEvent::Opened { urls } = &event {
+            let paths: Vec<String> = urls
+                .iter()
+                .filter_map(|u| u.to_file_path().ok())
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect();
+            if !paths.is_empty() {
+                let state = app_handle.state::<AppState>();
+                state.pending_open.lock().unwrap().extend(paths.iter().cloned());
+                let _ = app_handle.emit("open-file", paths);
+            }
+            return;
+        }
         if let tauri::RunEvent::ExitRequested { api, .. } = event {
             let state = app_handle.state::<AppState>();
             if state.exit_confirmed.load(Ordering::SeqCst) {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "Kova",
+        "width": 1400,
+        "height": 860,
+        "minWidth": 900,
+        "minHeight": 600,
+        "titleBarStyle": "Overlay",
+        "trafficLightPosition": { "x": 14, "y": 13 }
+      }
+    ]
+  },
+  "bundle": {
+    "fileAssociations": [
+      {
+        "ext": ["md", "markdown"],
+        "name": "Markdown Document",
+        "description": "Markdown presentation",
+        "role": "Editor"
+      }
+    ]
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,9 @@ import { MissingThemeBanner } from './components/MissingThemeBanner';
 import { loadSettings, saveSettings, EDITOR_FONT_OPTIONS } from './store/settings';
 import type { AppSettings } from './store/settings';
 import { loadLastSession, saveLastSession } from './store/lastSession';
+import { loadRecentFiles, addRecentFile, clearRecentFiles } from './store/recentFiles';
+import { buildMacMenu } from './macMenu';
+import type { MacMenuHandlers } from './macMenu';
 import { loadKeybindings, matchShortcut, getCombo, formatCombo } from './engine/keybindings';
 import type { Keybindings } from './engine/keybindings';
 
@@ -98,6 +101,7 @@ export default function App() {
   const [showThemeLibrary, setShowThemeMarketplace] = useState(false);
   const [showImport, setShowImport]       = useState(false);
   const [showInspector, setShowInspector] = useState(true);
+  const [recents, setRecents] = useState<string[]>(() => loadRecentFiles());
   const [presenterMode, setPresenterMode] = useState(false);
   const [confirmCloseAction, setConfirmCloseAction] = useState<(() => void) | null>(null);
   const [availableUpdate, setAvailableUpdate] = useState<string | null>(null);
@@ -343,7 +347,9 @@ export default function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // intentionally runs once on mount
 
-  // Window title
+  // Window title — used by the taskbar/switcher/Mission Control. On macOS the
+  // title text is hidden at the NSWindow level (see lib.rs setup) so it doesn't
+  // duplicate the in-app centered doctitle next to the traffic lights.
   useEffect(() => {
     const name = frontmatter.title ?? filePath?.split(/[\\/]/).pop() ?? 'Kova';
     getCurrentWindow().setTitle(isDirty ? `${name} • — Kova` : `${name} — Kova`).catch(() => {});
@@ -742,6 +748,11 @@ export default function App() {
     saveLastSession(filePath ? { path: filePath, slideIndex: safeSlideIndex } : null);
   }, [filePath, safeSlideIndex]);
 
+  // Maintain the "Open Recent" list whenever a file becomes the open document.
+  useEffect(() => {
+    if (filePath) setRecents(addRecentFile(filePath));
+  }, [filePath]);
+
   const handleMarkdownDrop = useCallback((path: string) => {
     const doOpen = async () => {
       try {
@@ -1051,6 +1062,62 @@ export default function App() {
   const handleSaveRef = useRef(handleSave);
   handleSaveRef.current = handleSave;
 
+  // ── macOS native menu bar ──────────────────────────────────────────────────
+  // Latest menu actions, refreshed every render. The native menu is rebuilt only
+  // when `recents` changes, so its items delegate through this ref (below) to
+  // always run current logic without rebuilding on every keystroke.
+  const menuHandlersRef = useRef<MacMenuHandlers>({} as MacMenuHandlers);
+  menuHandlersRef.current = {
+    newFile: handleNewFile,
+    openFile: handleOpenFile,
+    openRecent: handleMarkdownDrop,
+    clearRecent: () => { clearRecentFiles(); setRecents([]); },
+    save: handleSave,
+    saveAs: () => { void handleSaveAs(); },
+    import: () => guardDirty(() => setShowImport(true)),
+    export: handleExport,
+    exportPdf: handleExportPdf,
+    print: handlePrint,
+    present: () => { void handlePresentEnter(); },
+    toggleInspector: () => setShowInspector((v) => !v),
+    openSettings: () => setShowSettings(true),
+  };
+  const stableMenuHandlers = useRef<MacMenuHandlers>({
+    newFile: () => menuHandlersRef.current.newFile(),
+    openFile: () => menuHandlersRef.current.openFile(),
+    openRecent: (p) => menuHandlersRef.current.openRecent(p),
+    clearRecent: () => menuHandlersRef.current.clearRecent(),
+    save: () => menuHandlersRef.current.save(),
+    saveAs: () => menuHandlersRef.current.saveAs(),
+    import: () => menuHandlersRef.current.import(),
+    export: () => menuHandlersRef.current.export(),
+    exportPdf: () => menuHandlersRef.current.exportPdf(),
+    print: () => menuHandlersRef.current.print(),
+    present: () => menuHandlersRef.current.present(),
+    toggleInspector: () => menuHandlersRef.current.toggleInspector(),
+    openSettings: () => menuHandlersRef.current.openSettings(),
+  }).current;
+
+  useEffect(() => {
+    if (!isMac) return;
+    void buildMacMenu(stableMenuHandlers, recents);
+  }, [recents, stableMenuHandlers]);
+
+  // macOS file association: open files delivered via double-click / "Open With".
+  // Drain any that arrived before mount (launch-with-file), then listen for live
+  // opens. ponytail: opens the first path only — single-window editor, no tabs.
+  useEffect(() => {
+    if (!isMac) return;
+    invoke<string[]>('take_pending_open')
+      .then((paths) => { if (paths[0]) handleMarkdownDrop(paths[0]); })
+      .catch(() => {});
+    const un = listen<string[]>('open-file', (e) => {
+      const p = e.payload?.[0];
+      if (p) handleMarkdownDrop(p);
+    });
+    return () => { un.then((f) => f()); };
+  }, [handleMarkdownDrop]);
+
   // Autosave — only when enabled, a file path exists, and there are unsaved changes.
   // Deliberately excludes `handleSave` from the dependency array: if it were
   // included, the timer would be torn down and restarted on every keystroke
@@ -1195,35 +1262,11 @@ export default function App() {
         />
       )}
       <div className="app-toolbar">
-        {isMac && (
-          <div className="wm-controls wm-controls--mac">
-            <button
-              className="wm-btn wm-btn--close"
-              onMouseDown={(e) => { e.preventDefault(); guardDirty(actuallyCloseWindow); }}
-              title="Close"
-            >
-              <svg width="11" height="11" viewBox="0 0 11 11">
-                <line x1="1" y1="1" x2="10" y2="10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-                <line x1="10" y1="1" x2="1" y2="10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-              </svg>
-            </button>
-            <button
-              className="wm-btn"
-              onMouseDown={(e) => { e.preventDefault(); getCurrentWindow().minimize(); }}
-              title="Minimise"
-            >
-              <svg width="12" height="2" viewBox="0 0 12 2"><rect width="12" height="2" rx="1" fill="currentColor"/></svg>
-            </button>
-            <button
-              className="wm-btn"
-              onMouseDown={(e) => { e.preventDefault(); getCurrentWindow().toggleMaximize(); }}
-              title="Maximise / Restore"
-            >
-              <svg width="11" height="11" viewBox="0 0 11 11"><rect x="1" y="1" width="9" height="9" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.5"/></svg>
-            </button>
-          </div>
-        )}
-        <div className="btn-group" ref={fileMenuRef}>
+        {/* macOS uses native traffic lights (titleBarStyle: Overlay) + the native
+            menu bar, so reserve a draggable strip for the lights and drop the
+            custom window buttons + in-window File/Edit menus here. */}
+        {isMac && <div className="mac-traffic-pad" data-tauri-drag-region />}
+        {!isMac && <div className="btn-group" ref={fileMenuRef}>
           <button className="btn" onClick={() => setFileMenuOpen((o) => !o)}>
             File
           </button>
@@ -1264,8 +1307,8 @@ export default function App() {
               </button>
             </div>
           )}
-        </div>
-        <div className="btn-group" ref={editMenuRef}>
+        </div>}
+        {!isMac && <div className="btn-group" ref={editMenuRef}>
           <button className="btn" onClick={() => setEditMenuOpen((o) => !o)}>
             Edit
           </button>
@@ -1293,7 +1336,7 @@ export default function App() {
               </button>
             </div>
           )}
-        </div>
+        </div>}
         <div className="toolbar-spacer" data-tauri-drag-region />
         {isRenaming ? (
           <input

--- a/src/macMenu.ts
+++ b/src/macMenu.ts
@@ -1,0 +1,106 @@
+// Native macOS menu bar. Built once on the Mac (Windows/Linux keep the
+// in-window File/Edit buttons). Items call into App.tsx handlers; we rebuild
+// only when the recent-files list changes — everything else routes through a
+// stable handlers ref, so menu items stay correct without per-state churn.
+//
+// ponytail: menu items are always enabled and the handlers guard invalid calls
+// (e.g. Save with nothing to save). Add per-item setEnabled() if users complain.
+
+import { Menu, Submenu } from '@tauri-apps/api/menu';
+import { getVersion } from '@tauri-apps/api/app';
+
+export interface MacMenuHandlers {
+  newFile: () => void;
+  openFile: () => void;
+  openRecent: (path: string) => void;
+  clearRecent: () => void;
+  save: () => void;
+  saveAs: () => void;
+  import: () => void;
+  export: () => void;
+  exportPdf: () => void;
+  print: () => void;
+  present: () => void;
+  toggleInspector: () => void;
+  openSettings: () => void;
+}
+
+const base = (p: string) => p.split(/[\\/]/).pop() || p;
+
+export async function buildMacMenu(h: MacMenuHandlers, recents: string[]): Promise<void> {
+  const version = await getVersion().catch(() => '');
+
+  const recentItems = recents.length
+    ? [
+        ...recents.map((p) => ({ text: base(p), action: () => h.openRecent(p) })),
+        { item: 'Separator' as const },
+        { text: 'Clear Menu', action: () => h.clearRecent() },
+      ]
+    : [{ text: 'No Recent Files', enabled: false }];
+
+  const menu = await Menu.new({
+    items: [
+      await Submenu.new({
+        text: 'Kova',
+        items: [
+          { item: { About: { name: 'Kova', version } } },
+          { item: 'Separator' },
+          { text: 'Settings…', accelerator: 'CmdOrCtrl+,', action: () => h.openSettings() },
+          { item: 'Separator' },
+          { item: 'Services' },
+          { item: 'Separator' },
+          { item: 'Hide' },
+          { item: 'HideOthers' },
+          { item: 'ShowAll' },
+          { item: 'Separator' },
+          { item: 'Quit' },
+        ],
+      }),
+      await Submenu.new({
+        text: 'File',
+        items: [
+          { text: 'New', accelerator: 'CmdOrCtrl+N', action: () => h.newFile() },
+          { text: 'Open…', accelerator: 'CmdOrCtrl+O', action: () => h.openFile() },
+          await Submenu.new({ text: 'Open Recent', items: recentItems }),
+          { item: 'Separator' },
+          { text: 'Save', accelerator: 'CmdOrCtrl+S', action: () => h.save() },
+          { text: 'Save As…', accelerator: 'CmdOrCtrl+Shift+S', action: () => h.saveAs() },
+          { text: 'Import from PowerPoint…', action: () => h.import() },
+          { item: 'Separator' },
+          { text: 'Export PowerPoint (.pptx)', action: () => h.export() },
+          { text: 'Export PDF (.pdf)', action: () => h.exportPdf() },
+          { text: 'Print…', accelerator: 'CmdOrCtrl+P', action: () => h.print() },
+          { item: 'Separator' },
+          { item: 'Quit' },
+        ],
+      }),
+      await Submenu.new({
+        text: 'Edit',
+        items: [
+          { item: 'Undo' },
+          { item: 'Redo' },
+          { item: 'Separator' },
+          { item: 'Cut' },
+          { item: 'Copy' },
+          { item: 'Paste' },
+          { item: 'SelectAll' },
+        ],
+      }),
+      await Submenu.new({
+        text: 'View',
+        items: [
+          { text: 'Toggle Inspector', action: () => h.toggleInspector() },
+          { text: 'Present', accelerator: 'F5', action: () => h.present() },
+          { item: 'Separator' },
+          { item: 'Fullscreen' },
+        ],
+      }),
+      await Submenu.new({
+        text: 'Window',
+        items: [{ item: 'Minimize' }, { item: 'Maximize' }],
+      }),
+    ],
+  });
+
+  await menu.setAsAppMenu();
+}

--- a/src/store/recentFiles.ts
+++ b/src/store/recentFiles.ts
@@ -1,0 +1,27 @@
+// Most-recently-opened file paths, newest first. Feeds the macOS native
+// "File ▸ Open Recent" submenu. App-managed state, not a user preference.
+
+const KEY = 'kova:recentFiles';
+const MAX = 10;
+
+export function loadRecentFiles(): string[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((p): p is string => typeof p === 'string').slice(0, MAX) : [];
+  } catch {
+    return [];
+  }
+}
+
+// Prepend `path` (deduped), cap at MAX, persist, return the new list.
+export function addRecentFile(path: string): string[] {
+  const next = [path, ...loadRecentFiles().filter((p) => p !== path)].slice(0, MAX);
+  try { localStorage.setItem(KEY, JSON.stringify(next)); } catch { /* full/unavailable — recents are a convenience */ }
+  return next;
+}
+
+export function clearRecentFiles(): void {
+  try { localStorage.removeItem(KEY); } catch { /* ignore */ }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -127,6 +127,14 @@ html, body, #root {
   height: 100%;
 }
 
+/* Reserve a draggable strip for the native macOS traffic lights, which overlay
+   the toolbar's top-left corner under titleBarStyle: Overlay. */
+.mac-traffic-pad {
+  width: 60px;
+  height: 100%;
+  flex-shrink: 0;
+}
+
 .toolbar-doctitle {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
macOS-only desktop integration. Windows/Linux keep the existing custom titlebar and in-window File/Edit menus unchanged.

## What
- **Native traffic lights** — `titleBarStyle: Overlay` (`tauri.macos.conf.json`); drops the custom mac window buttons, reserves a draggable strip for the lights.
- **Hidden native title** — the window title text duplicated the in-app doctitle next to the lights and `setTitle("")` doesn't clear it under Overlay, so it's hidden at the NSWindow level (`titleVisibility = Hidden`).
- **Native menu bar** — Kova/File/Edit/View/Window via `@tauri-apps/api/menu`, delegating to existing handlers; in-window File/Edit hidden on macOS. Edit uses native predefined Undo/Cut/Copy/Paste.
- **`.md` file association** — `RunEvent::Opened` emits + buffers paths; `take_pending_open` drains launch-with-file before the listener mounts; reuses the drag-drop open flow (dirty-guard + confirm).
- **Open Recent** — File ▸ Open Recent submenu backed by a localStorage recent-files list.

## Gating
All native chrome is gated by `#[cfg(target_os = "macos")]`, platform config, or `isMac`. `objc2`/`objc2-app-kit` are under a macOS-only target table. Two inert-on-other-platforms no-ops left ungated deliberately: the `pending_open` command (forking `generate_handler!` per platform isn't worth it) and recent-files tracking (only the mac menu reads it).

## Skipped (YAGNI)
Windows/Linux open-on-launch (argv + single-instance), per-menu-item enable/disable, multi-file open, Dock/Help menus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)