### PR TITLE
fix: resolve relative image paths against the document directory

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import type { Keybindings } from './engine/keybindings';
 import { parseDocument } from './engine/parser/markdownToSlides';
 import { extractFrontmatter, patchFrontmatter } from './engine/parser/frontmatter';
 import { fetchUpdate } from './engine/updater';
+import { normalizePath } from './engine/resolvePath';
 import { exportToPptx } from './engine/export/exportPptx';
 import { exportToPdf, printPresentation } from './engine/export/exportPdf';
 import { SlideRenderer } from './components/preview/SlideRenderer';
@@ -49,8 +50,7 @@ function resolveImageSrc(src: string, docDir: string): string {
   if (p.startsWith('/') || /^[A-Za-z]:[/\\]/.test(p)) return convertFileSrc(p);
   // Relative path — only resolvable when we know the document location.
   if (!docDir) return p;
-  const sep = docDir.includes('\\') ? '\\' : '/';
-  return convertFileSrc(docDir + (docDir.endsWith(sep) ? '' : sep) + p);
+  return convertFileSrc(normalizePath(docDir, p));
 }
 
 function resolveHtmlSrcs(html: string, docDir: string): string {

--- a/src/engine/__tests__/resolvePath.test.ts
+++ b/src/engine/__tests__/resolvePath.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePath } from '../resolvePath';
+
+describe('normalizePath', () => {
+  it('resolves ../ and ./ against the document directory', () => {
+    expect(normalizePath('/docs/talks', '../img/x.png')).toBe('/docs/img/x.png');
+    expect(normalizePath('/docs/talks', './x.png')).toBe('/docs/talks/x.png');
+    expect(normalizePath('/docs/talks', 'sub/y.png')).toBe('/docs/talks/sub/y.png');
+    expect(normalizePath('/docs/a/b', '../../z.png')).toBe('/docs/z.png');
+  });
+
+  it("doesn't climb above the filesystem root", () => {
+    expect(normalizePath('/docs', '../../../x.png')).toBe('/x.png');
+  });
+
+  it('keeps the Windows drive letter and uses backslashes', () => {
+    expect(normalizePath('C:\\docs\\talks', '..\\img\\x.png')).toBe('C:\\docs\\img\\x.png');
+  });
+});

--- a/src/engine/resolvePath.ts
+++ b/src/engine/resolvePath.ts
@@ -1,0 +1,14 @@
+// Join a relative image path to the document directory and collapse `.`/`..`
+// segments. The Tauri asset protocol needs a normalized filesystem path, not a
+// literal `/dir/../img/x.png`, or the image fails to load.
+export function normalizePath(docDir: string, rel: string): string {
+  const sep = docDir.includes('\\') ? '\\' : '/';
+  const out: string[] = [];
+  for (const s of `${docDir}${sep}${rel}`.split(/[/\\]+/)) {
+    if (s === '' || s === '.') continue;
+    if (s === '..') { if (out.length && !/^[A-Za-z]:$/.test(out[out.length - 1])) out.pop(); }
+    else out.push(s);
+  }
+  // POSIX paths need their leading slash back; Windows drive letters don't.
+  return (/^[A-Za-z]:$/.test(out[0] ?? '') ? '' : sep) + out.join(sep);
+}


### PR DESCRIPTION
## Bug
Relative image sources (`../img/x.png`, `./x.png`) didn't render. They were joined to the document directory but the `.`/`..` segments were never collapsed, so the Tauri asset protocol got a literal `/dir/../img/x.png` and failed to load the file.

## Fix
`normalizePath(docDir, rel)` joins the relative path to the doc dir and collapses `.`/`..` segments before `convertFileSrc` — POSIX-leading-slash and Windows-drive aware, doesn't climb above the root.

Extracted to `src/engine/resolvePath.ts` with unit tests (`../`, `./`, nested `../..`, root-climb clamp, Windows drive + backslashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)