### PR TITLE
Fix paste failing

### DIFF
--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -891,9 +891,14 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
           const { from, to } = view.state.selection.main;
           const text = await navigator.clipboard.readText();
           if (!text) return;
+          // CodeMirror normalises \r\n → \n internally, so the inserted length
+          // may be shorter than text.length. Use the normalised form to compute
+          // the correct cursor position; otherwise the dispatch is silently
+          // rejected when the cursor would land past the end of the new document.
+          const normalised = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
           view.dispatch({
-            changes: { from, to, insert: text },
-            selection: EditorSelection.cursor(from + text.length),
+            changes: { from, to, insert: normalised },
+            selection: EditorSelection.cursor(from + normalised.length),
           });
           view.focus();
         } catch {


### PR DESCRIPTION
Fixes #13

navigator.clipboard.readText() on Windows returns text with \r\n line endings. CodeMirror normalises these to \n on insert, making the actual inserted length shorter than text.length. The cursor position was computed from the raw length, landing past the end of the new document — CodeMirror silently rejects such dispatches, so paste appeared to do nothing.

The threshold depends on cursor position + number of \r\n pairs in the clipboard, which explains why the same text pastes fine closer to the beginning but fails near the end.

Fix: normalise line endings before dispatching.

Tested locally and confirmed to work. On non-Windows should not change anything :)