### PR TITLE
fix: honor markdown table column alignments (#23)

### DIFF
--- a/src/components/preview/SlideRenderer.tsx
+++ b/src/components/preview/SlideRenderer.tsx
@@ -644,11 +644,11 @@ function ElementNode({ el }: { el: SlideElement }) {
       return (
         <table className="sl-table">
           <thead>
-            <tr>{el.headers.map((h, i) => <th key={i}>{h}</th>)}</tr>
+            <tr>{el.headers.map((h, i) => <th key={i} style={{ textAlign: el.align?.[i] || undefined }}>{h}</th>)}</tr>
           </thead>
           <tbody>
             {el.rows.map((row, i) => (
-              <tr key={i}>{row.map((cell, j) => <td key={j}>{cell}</td>)}</tr>
+              <tr key={i}>{row.map((cell, j) => <td key={j} style={{ textAlign: el.align?.[j] || undefined }}>{cell}</td>)}</tr>
             ))}
           </tbody>
         </table>

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -211,7 +211,7 @@ function convertRoot(tree: Root, placeholders: Map<number, SlideElement>): Conve
         const [headerRow, ...bodyRows] = t.children;
         const headers = (headerRow?.children ?? []).map((cell) => toString(cell));
         const rows = bodyRows.map((row) => row.children.map((cell) => toString(cell)));
-        elements.push({ type: 'table', headers, rows });
+        elements.push({ type: 'table', headers, rows, align: t.align ?? undefined });
         break;
       }
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -27,7 +27,7 @@ export type SlideElement =
   | { type: 'mermaid'; value: string }
   | { type: 'math'; value: string; display: boolean }
   | { type: 'blockquote'; text: string; attribution?: string }
-  | { type: 'table'; headers: string[]; rows: string[][] }
+  | { type: 'table'; headers: string[]; rows: string[][]; align?: ('left' | 'right' | 'center' | null)[] }
   | { type: 'youtube';  label: string; url: string }
   | { type: 'poll';     label: string; url: string }
   | { type: 'progress'; label: string; value: number }


### PR DESCRIPTION
## Problem

Table column alignment specs (`:---`, `---:`, `:--:`) were ignored — every column rendered left-aligned. Reported in #23.

## Cause

The markdown parser read the GFM table via remark but discarded mdast `table.align`, so the per-column alignment never reached the renderer.

## Fix

- Capture `t.align` in `markdownToSlides.ts` and store it on the `table` `SlideElement`.
- Add optional `align` to the table element type.
- Apply per-column `text-align` in `SlideRenderer`. Inline style beats the CSS `text-align: left` default (no `!important`), so default columns are unaffected.

3 files, 4 lines. Typecheck clean.

Out of scope: PPTX/HTML export table alignment (preview only).

Fixes #23