### PR TITLE
feat: 3-part header/footer layout via | separator (#30)

### DIFF
--- a/src/components/preview/SlideRenderer.css
+++ b/src/components/preview/SlideRenderer.css
@@ -73,6 +73,12 @@
 .sl-footer-bar .sl-footer-text { flex: 1; }
 .sl-footer-bar .sl-slide-num { flex-shrink: 0; }
 
+/* `|`-separated header/footer: left | center | right (issue #30) */
+.sl-bar-parts { display: flex; align-items: center; gap: 1cqi; }
+.sl-bar-parts > * { flex: 1; min-width: 0; }
+.sl-bar-parts > :nth-child(2) { text-align: center; }
+.sl-bar-parts > :nth-child(3) { text-align: right; }
+
 /* ── Floating logo (when not in header/footer) ───────────────────────────── */
 
 .sl-logo-float {

--- a/src/components/preview/SlideRenderer.tsx
+++ b/src/components/preview/SlideRenderer.tsx
@@ -146,6 +146,20 @@ function mutedSecondary(primaryHex: string): string {
   return hslToHex(h, Math.min(s, 0.35), l < 0.5 ? Math.min(l + 0.20, 0.45) : Math.max(l - 0.20, 0.55));
 }
 
+// Header/footer text. A `|` stretch separator splits it into left | center | right
+// parts (issue #30); without `|` it renders as a single left-aligned span as before.
+function BarText({ text, className }: { text: string; className: string }) {
+  if (!text.includes('|')) return <span className={className}>{text}</span>;
+  const [left = '', center = '', right = ''] = text.split('|').map((s) => s.trim());
+  return (
+    <span className={`${className} sl-bar-parts`}>
+      <span>{left}</span>
+      <span>{center}</span>
+      <span>{right}</span>
+    </span>
+  );
+}
+
 function buildMermaidInit(theme: Theme): string {
   const c = theme.colors;
   const firstFont = (stack: string) => stack.split(',')[0].trim().replace(/['"]/g, '');
@@ -249,7 +263,7 @@ export function SlideRenderer({ slide, theme = DEFAULT_THEME, slideNumber, total
                 ...(theme.logo_position === 'top-right' ? { marginLeft: 'auto' } : {}),
               }} />
           )}
-          {headerText && <span className="sl-header-text">{headerText}</span>}
+          {headerText && <BarText text={headerText} className="sl-header-text" />}
         </div>
       )}
 
@@ -278,7 +292,7 @@ export function SlideRenderer({ slide, theme = DEFAULT_THEME, slideNumber, total
                 ...(theme.logo_position === 'bottom-right' ? { marginLeft: 'auto', order: 2 } : {}),
               }} />
           )}
-          {footerText && <span className="sl-footer-text">{footerText}</span>}
+          {footerText && <BarText text={footerText} className="sl-footer-text" />}
           {theme.footer.show_slide_number && slideNumber !== undefined && (
             <span className="sl-slide-num">{slideNumber}</span>
           )}


### PR DESCRIPTION
## Request

Header and footer render left-aligned only. Issue #30 asks for left / center / right parts via a stretch separator.

## Implementation

A `|` separator in header/footer text splits it into up to three parts laid out left / center / right. Text without `|` renders as a single left-aligned span — existing decks unchanged.

```
Left header                  → left (unchanged)
{date} | caption | {total}   → three parts
| caption                    → centered
|| {slide_number}/{total}    → right-aligned
```

Empty parts still consume their third, so `| caption` centers and `|| x` right-aligns. Existing tokens ({title}, {date}, {slide_number}, {total}) work in any part.

## Changes

- `BarText` helper in `SlideRenderer.tsx`: splits on `|`, renders 1 or 3 spans.
- CSS `.sl-bar-parts`: flex thirds, center/right alignment on 2nd/3rd.

2 files, ~22 lines. Typecheck clean.

Out of scope: PPTX/HTML export (preview only); >3 parts (extra `|` segments dropped).

Closes #30