### PR TITLE
fix: auto-bump kova-bin PKGBUILD version

### DIFF
--- a/packaging/arch/kova-bin/PKGBUILD
+++ b/packaging/arch/kova-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: RDMillen <rossmillen@protonmail.ch>
 pkgname=kova-bin
-pkgver=0.6.0
+pkgver=0.6.5
 pkgrel=1
 pkgdesc="Markdown presentation authoring tool (pre-built binary)"
 arch=('x86_64')

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -42,6 +42,12 @@ const TARGETS = [
     file: 'src/version.ts',
     pattern: /^(export const APP_VERSION = ')[^']+(';)/m,
   },
+  {
+    // AUR -bin package; second capture group is the empty line-end. Note:
+    // pkgrel is not reset to 1 here — bump it by hand if rebuilding same pkgver.
+    file: 'packaging/arch/kova-bin/PKGBUILD',
+    pattern: /^(pkgver=)[^\n]+()$/m,
+  },
 ];
 
 let changedCount = 0;


### PR DESCRIPTION
The `kova-bin` PKGBUILD was added after `scripts/bump-version.mjs` and never registered in its `TARGETS` list, so every `npm run bump-version` skipped it — `pkgver` was stranded at 0.6.0 while releases moved on to 0.6.5.

- Register `packaging/arch/kova-bin/PKGBUILD` in `bump-version.mjs` so future bumps update it automatically.
- Bump the stranded `pkgver` 0.6.0 → 0.6.5.

The v0.6.5 source tarball (`Kova_0.6.5_x86_64.tar.gz`) was verified to exist and match the PKGBUILD's `package()` layout (kova binary, desktop entry, LICENSE, icons).

Context: the unbundled binary this package installs runs against the host webkit2gtk/GL stack, which is the working install path for the Arch/Manjaro users hitting the AppImage EGL_BAD_PARAMETER bundling bug (#3).

Note: the script rewrites `pkgver` only, not `pkgrel` — reset `pkgrel=1` by hand if rebuilding the same version (noted inline).