### PR TITLE
fix: de-bundle libwayland from release AppImage (#3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # linuxdeploy bundles libwayland-* (ubuntu-22.04 vintage) into the AppImage.
+      # The host's Mesa libEGL then loads those stale wayland libs, breaking the
+      # Wayland-EGL handshake → "EGL_BAD_PARAMETER. Aborting..." on newer hosts
+      # (issue #3, confirmed on Arch). Strip them and repack so the AppImage uses
+      # host libwayland, then clobber the broken one tauri-action already uploaded.
+      - name: Fix AppImage — de-bundle libwayland (issue #3)
+        if: matrix.platform == 'ubuntu-22.04'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd src-tauri/target/release/bundle/appimage
+          APP=$(ls *.AppImage | head -1)
+          ./"$APP" --appimage-extract >/dev/null
+          rm -f squashfs-root/usr/lib/libwayland-*.so*
+          wget -qO /tmp/appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x /tmp/appimagetool
+          rm -f "$APP"
+          ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 /tmp/appimagetool squashfs-root "$APP"
+          gh release upload "${{ github.ref_name }}" "$APP" --clobber
+
   # Runs after all platform builds. Adds stable-named (version-free) download
   # aliases so README links never need updating, then removes .sig files to
   # keep the release page clean for non-technical users.


### PR DESCRIPTION
## Problem

Released `.AppImage` fails on Wayland: `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...` (#3).

## Cause

No libEGL/Mesa is bundled — only ubuntu-22.04 `libwayland-*`. The host's Mesa libEGL loads those stale wayland libs, the Wayland-EGL handshake fails, EGL aborts. A packaging bug, not a WebKit/Tauri EGL issue — the unbundled deb/rpm/tar.gz run fine.

## Fix

After build, strip the bundled `libwayland-*`, repack with appimagetool, and clobber the broken AppImage tauri-action uploaded. 

## Caveat

Repacking invalidates the AppImage updater signature. The broken AppImage never launched, so appimage self-update never worked anyway — but for functional auto-update the tarball needs re-signing (or disable `createUpdaterArtifacts` for the appimage target). mac/Windows unaffected.