### PR TITLE
feat(editor): thin divider line between slides

### DIFF
--- a/src/components/editor/slideDivider.ts
+++ b/src/components/editor/slideDivider.ts
@@ -1,0 +1,26 @@
+import { Decoration, EditorView, ViewPlugin } from '@codemirror/view';
+import { RangeSetBuilder } from '@codemirror/state';
+
+/** Thin rule under each `---` slide separator (skips the frontmatter block). */
+const line = Decoration.line({ class: 'cm-slide-divider' });
+
+function build(view: EditorView) {
+  const { doc } = view.state;
+  const b = new RangeSetBuilder<Decoration>();
+  let fm = false; // inside frontmatter
+  for (let n = 1; n <= doc.lines; n++) {
+    const l = doc.line(n);
+    if (l.text.trim() !== '---') continue;
+    if (n === 1) fm = true;        // opening fence
+    else if (fm) fm = false;       // closing fence — not a slide break
+    else b.add(l.from, l.from, line);
+  }
+  return b.finish();
+}
+
+export const slideDivider = [
+  EditorView.baseTheme({ '.cm-slide-divider': { borderBottom: '1px solid var(--border, #888)' } }),
+  ViewPlugin.define((v) => ({ decorations: build(v), update(u) { if (u.docChanged) this.decorations = build(u.view); } }), {
+    decorations: (p) => p.decorations,
+  }),
+];

--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -10,6 +10,7 @@ import { markdown } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { focusModeCompartment, focusModeExtension } from '../editor/focusMode';
+import { slideDivider } from '../editor/slideDivider';
 import { EditorContextMenu } from '../editor/EditorContextMenu';
 import type { MenuEntry } from '../editor/EditorContextMenu';
 import { isMac } from '../../engine/keybindings';
@@ -668,6 +669,7 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
           },
         ])),
         updateListener,
+        slideDivider,
         focusModeCompartment.of([]),
         spellCheckCompartment.of([]),
       ],


### PR DESCRIPTION
Thin 1px rule under each `---` separator in the editor, so slide boundaries show while writing.

`slideDivider` ViewPlugin adds a line decoration to separator lines (skips frontmatter); border uses the `--border` var so it tracks dark/light. Always on, no setting.

tsc clean; verified in `tauri dev`.