### PR TITLE
test: normalizePath edge cases

### DIFF
--- a/src/engine/__tests__/resolvePath.test.ts
+++ b/src/engine/__tests__/resolvePath.test.ts
@@ -16,4 +16,22 @@ describe('normalizePath', () => {
   it('keeps the Windows drive letter and uses backslashes', () => {
     expect(normalizePath('C:\\docs\\talks', '..\\img\\x.png')).toBe('C:\\docs\\img\\x.png');
   });
+
+  it('normalizes Windows paths with mixed forward and backslash separators', () => {
+    expect(normalizePath('C:\\docs\\talks', '../img/x.png')).toBe('C:\\docs\\img\\x.png');
+    expect(normalizePath('C:/docs/talks', '..\\img\\x.png')).toBe('C:/docs/img/x.png');
+    expect(normalizePath('C:\\docs/talks', 'sub/y.png')).toBe('C:\\docs\\talks\\sub\\y.png');
+  });
+
+  it("doesn't climb above the Windows drive root", () => {
+    expect(normalizePath('C:\\docs', '..\\..\\..\\x.png')).toBe('C:\\x.png');
+    expect(normalizePath('C:\\', '..\\x.png')).toBe('C:\\x.png');
+  });
+
+  it('collapses empty and absolute path segments', () => {
+    expect(normalizePath('/docs/talks', '/img/x.png')).toBe('/docs/talks/img/x.png');
+    expect(normalizePath('/docs/talks', '')).toBe('/docs/talks');
+    expect(normalizePath('/docs//talks', 'sub//y.png')).toBe('/docs/talks/sub/y.png');
+    expect(normalizePath('C:\\docs\\\\talks', 'sub//y.png')).toBe('C:\\docs\\talks\\sub\\y.png');
+  });
 });


### PR DESCRIPTION
## Summary
- Add edge-case tests for `normalizePath` in `resolvePath.test.ts`
- Windows mixed `/` and `\` separators resolve correctly (output separator follows `docDir`)
- `..` at the drive root does not escape above `C:\`
- Empty segments and leading-slash relative paths collapse cleanly

## Test plan
- [x] `npm test -- --run src/engine/__tests__/resolvePath.test.ts` — 6 tests pass