### PR TITLE
feat(settings): UI interface scale (XS–XL)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import { ImportUrlModal } from './components/ImportUrlModal';
 import { InfoBanner } from './components/InfoBanner';
 import { isMarp, importMarp } from './engine/import/marp';
 import { MissingThemeBanner } from './components/MissingThemeBanner';
-import { loadSettings, saveSettings, EDITOR_FONT_OPTIONS } from './store/settings';
+import { loadSettings, saveSettings, EDITOR_FONT_OPTIONS, UI_SCALE_OPTIONS } from './store/settings';
 import type { AppSettings } from './store/settings';
 import { loadLastSession, saveLastSession } from './store/lastSession';
 import { loadRecentFiles, addRecentFile, removeRecentFile, clearRecentFiles } from './store/recentFiles';
@@ -1221,6 +1221,12 @@ export default function App() {
       return () => mq.removeEventListener('change', apply);
     }
   }, [settings.uiTheme]);
+
+  // Apply UI scale via the --ui-scale var (drives `html { zoom }` in global.css)
+  useEffect(() => {
+    const s = UI_SCALE_OPTIONS.find(o => o.value === settings.uiScale)?.scale ?? 1;
+    document.documentElement.style.setProperty('--ui-scale', String(s));
+  }, [settings.uiScale]);
 
   // handleSave gets a new identity on every keystroke (it depends on `content`
   // via buildSaveContent). A ref lets the autosave timer below call the latest

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { useState, useMemo, useEffect, useRef } from 'react';
 import type { AppSettings, PresentationMode, NotesFontSize, LaserColor, StartupBehavior } from '../store/settings';
-import { EDITOR_FONT_OPTIONS, LASER_COLOR_OPTIONS } from '../store/settings';
+import { EDITOR_FONT_OPTIONS, LASER_COLOR_OPTIONS, UI_SCALE_OPTIONS } from '../store/settings';
 import type { Theme } from '../engine/theme';
 import { isFontAvailable } from '../engine/fontDetect';
 import { fetchUpdate, canSelfUpdate, restartApp } from '../engine/updater';
@@ -308,6 +308,17 @@ export function SettingsModal({ settings, availableUpdate, allThemes, isDirty, s
               Follows your operating system's appearance setting.
             </div>
           )}
+        </div>
+
+        <div style={{ padding: '10px 0' }}>
+          <div style={{ fontSize: 13, color: 'var(--text-primary)', marginBottom: 8 }}>Interface scale</div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            {UI_SCALE_OPTIONS.map(({ value, label }) => (
+              <button key={value} type="button" onClick={() => set('uiScale', value)}
+                style={groupBtnStyle(settings.uiScale === value)}
+              >{label}</button>
+            ))}
+          </div>
         </div>
 
         <div style={{ padding: '10px 0' }}>

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -13,6 +13,15 @@ export const LASER_COLOR_OPTIONS = [
 ] as const;
 export type LaserColor = typeof LASER_COLOR_OPTIONS[number]['value'];
 export type UiTheme           = 'auto' | 'dark' | 'light';
+export type UiScale           = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export const UI_SCALE_OPTIONS: { value: UiScale; label: string; scale: number }[] = [
+  { value: 'xs', label: 'XS', scale: 0.8  },
+  { value: 'sm', label: 'S',  scale: 0.9  },
+  { value: 'md', label: 'M',  scale: 1    },
+  { value: 'lg', label: 'L',  scale: 1.15 },
+  { value: 'xl', label: 'XL', scale: 1.3  },
+];
 export type EditorFont        = 'ibm-plex-mono' | 'jetbrains-mono' | 'fira-code' | 'cascadia-code' | 'source-code-pro' | 'ubuntu-mono' | 'inconsolata' | 'system';
 export type { SpellCheckLanguage } from '../engine/spellcheck/spellChecker';
 
@@ -30,6 +39,7 @@ export const EDITOR_FONT_OPTIONS: { value: EditorFont; label: string; family: st
 export interface AppSettings {
   settingsVersion: number;
   uiTheme: UiTheme;
+  uiScale: UiScale;
   editorFont: EditorFont;
   autosave: boolean;
   autosaveIntervalSeconds: number; // 15 | 30 | 60 | 300
@@ -59,6 +69,7 @@ function buildDefaults(): AppSettings {
   return {
     settingsVersion: 1,
     uiTheme: 'auto',
+    uiScale: 'md',
     editorFont: 'ibm-plex-mono',
     autosave: true,
     autosaveIntervalSeconds: 30,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -93,11 +93,19 @@ html, body, #root {
   -webkit-font-smoothing: antialiased;
 }
 
+/* UI scale (Settings → Appearance). zoom keeps 100vw/100vh meaning "full window",
+   so the whole chrome rescales like browser zoom. Presentation counter-zooms below
+   so slides stay pixel-exact regardless of UI scale. WebKit/WebKitGTK support zoom. */
+html { zoom: var(--ui-scale, 1); }
+.pres-overlay, .pres-presenter { zoom: calc(1 / var(--ui-scale, 1)); }
+
 .app {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  width: 100vw;
+  /* divide by scale so html's zoom multiplies back to exactly the full window
+     (WebKit zoom doesn't remap vw/vh, so plain 100vw/100vh overflows at scale≠1) */
+  height: calc(100vh / var(--ui-scale, 1));
+  width: calc(100vw / var(--ui-scale, 1));
   overflow: hidden;
 }
 


### PR DESCRIPTION
Settings → Appearance → **Interface scale**: XS / S / M / L / XL, default M. Scales the whole app chrome like browser zoom.

- `--ui-scale` var drives `html { zoom }`; `.app` is sized by inverse scale so it fills the window at any scale (WebKit zoom doesn't remap vw/vh).
- Presentation overlays counter-zoom (`calc(1/var)`) → slides stay pixel-exact.

Tested via tauri dev on macOS — all five steps fit the window; presentation unaffected.