### PR TITLE
test: parser → layout integration (round 2)

### DIFF
--- a/src/engine/__tests__/parserLayoutIntegration.test.ts
+++ b/src/engine/__tests__/parserLayoutIntegration.test.ts
@@ -45,4 +45,55 @@ describe('parser → layout integration', () => {
     expect(yt?.type === 'youtube' && yt.label).toBe('My Video');
     expect(yt?.type === 'youtube' && yt.url).toBe('https://youtu.be/abc123');
   });
+
+  it('H2 section break with no body → layout: section', () => {
+    const { slides } = parseDocument(doc('## Section\n'));
+    expect(slides[0].layout).toBe('section');
+    expect(slides[0].title).toBe('Section');
+    expect(slides[0].titleLevel).toBe(2);
+    expect(slides[0].elements).toHaveLength(0);
+  });
+
+  it('block math only → layout: math', () => {
+    const { slides } = parseDocument(doc([
+      '## Slide',
+      '',
+      '$$',
+      'E = mc^2',
+      '$$',
+    ].join('\n')));
+    expect(slides[0].layout).toBe('math');
+    const math = slides[0].elements.find((e) => e.type === 'math');
+    expect(math?.type === 'math' && math.display).toBe(true);
+    expect(math?.type === 'math' && math.value.trim()).toBe('E = mc^2');
+  });
+
+  it('!poll embed → layout: media', () => {
+    const { slides } = parseDocument(doc([
+      '## Slide',
+      '',
+      '!poll[Vote](https://pollev.com/xyz)',
+    ].join('\n')));
+    expect(slides[0].layout).toBe('media');
+    const poll = slides[0].elements.find((e) => e.type === 'poll');
+    expect(poll?.type === 'poll' && poll.label).toBe('Vote');
+    expect(poll?.type === 'poll' && poll.url).toBe('https://pollev.com/xyz');
+  });
+
+  it('image-only slide with no heading → layout: full-bleed', () => {
+    const { slides } = parseDocument(doc('![](assets/photo.jpg)\n'));
+    expect(slides[0].layout).toBe('full-bleed');
+    expect(slides[0].title).toBe('');
+    expect(slides[0].titleLevel).toBe(0);
+    const img = slides[0].elements.find((e) => e.type === 'image');
+    expect(img?.type === 'image' && img.src).toBe('assets/photo.jpg');
+  });
+
+  it('long bullet list triggers overflow two-column layout', () => {
+    const items = Array.from({ length: 12 }, (_, i) => `- Item ${i + 1}`).join('\n');
+    const { slides } = parseDocument(doc(['## Slide', '', items].join('\n')));
+    expect(slides[0].layout).toBe('two-column');
+    const list = slides[0].elements.find((e) => e.type === 'list');
+    expect(list?.type === 'list' && list.items).toHaveLength(12);
+  });
 });


### PR DESCRIPTION
## Summary
- Extend `parserLayoutIntegration.test.ts` with five end-to-end layout cases through `parseDocument`
- H2 section break with no body → `layout: 'section'`
- Block math only → `layout: 'math'`
- `!poll` embed → `layout: 'media'`
- Image-only slide (no heading) → `layout: 'full-bleed'`
- Long bullet list (12 items) → `layout: 'two-column'` (overflow guard)

## Test plan
- [x] `npm test -- --run src/engine/__tests__/parserLayoutIntegration.test.ts` — 8 tests pass