### PR TITLE
test: parseAspectRatio completeness

### DIFF
--- a/src/engine/__tests__/types.test.ts
+++ b/src/engine/__tests__/types.test.ts
@@ -14,6 +14,18 @@ describe('parseAspectRatio', () => {
     expect(parseAspectRatio('4:3')).toEqual({ w: 4, h: 3 });
   });
 
+  it('returns 16:10 for the "16:10" string', () => {
+    expect(parseAspectRatio('16:10')).toEqual({ w: 16, h: 10 });
+  });
+
+  it('uses fallback when primary is undefined', () => {
+    expect(parseAspectRatio(undefined, '4:3')).toEqual({ w: 4, h: 3 });
+  });
+
+  it('uses fallback over default 16:9 when primary is undefined', () => {
+    expect(parseAspectRatio(undefined, '16:10')).toEqual({ w: 16, h: 10 });
+  });
+
   it('returns 16:9 for empty string', () => {
     expect(parseAspectRatio('')).toEqual({ w: 16, h: 9 });
   });


### PR DESCRIPTION
## Summary
- Add missing `parseAspectRatio` cases in `types.test.ts`
- `'16:10'` → `{ w: 16, h: 10 }`
- `parseAspectRatio(undefined, '4:3')` → 4:3 via fallback
- `parseAspectRatio(undefined, '16:10')` → 16:10 via fallback (not default 16:9)

## Test plan
- [x] `npm test -- --run src/engine/__tests__/types.test.ts` — 7 tests pass