### PR TITLE
test: detectOsLanguage unit coverage

### DIFF
--- a/src/engine/__tests__/spellChecker.test.ts
+++ b/src/engine/__tests__/spellChecker.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { detectOsLanguage } from '../spellcheck/spellChecker';
+
+function withLanguage(language: string) {
+  vi.stubGlobal('navigator', { language });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('detectOsLanguage', () => {
+  it('maps en-GB to en_GB', () => {
+    withLanguage('en-GB');
+    expect(detectOsLanguage()).toBe('en_GB');
+  });
+
+  it('maps de-DE to de_DE', () => {
+    withLanguage('de-DE');
+    expect(detectOsLanguage()).toBe('de_DE');
+  });
+
+  it('falls back to en_US for an unknown locale', () => {
+    withLanguage('xx-YY');
+    expect(detectOsLanguage()).toBe('en_US');
+  });
+
+  it('maps fr-CA to fr_FR via primary subtag', () => {
+    withLanguage('fr-CA');
+    expect(detectOsLanguage()).toBe('fr_FR');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `spellChecker.test.ts` with unit tests for `detectOsLanguage()`
- `en-GB` → `en_GB` (exact locale match)
- `de-DE` → `de_DE` (exact locale match)
- `xx-YY` → `en_US` (unknown locale fallback)
- `fr-CA` → `fr_FR` (primary subtag fallback)

## Test plan
- [x] `npm test -- --run src/engine/__tests__/spellChecker.test.ts` — 4 tests pass