### PR TITLE
feat: local video support (!video)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Kova turns plain Markdown into polished slides — with live preview, multiple l
 - **PPTX export** — export to PowerPoint (16:9 and 4:3)
 - **Academic references** — cite sources with `!ref[Author, Year. Title]`; renders as small bottom-right text on the slide and exports to PPTX
 - **YouTube & poll embeds** — `!youtube[label](url)` and `!poll[label](url)`
+- **Local video** — `!video[label](path.mp4)` plays an inline file (relative to the document or absolute)
 - **File watcher** — reloads automatically when the file is edited externally
 - **Keybindings** — configurable via `~/.config/kova/keybindings.yaml`
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
         "enable": true,
         "scope": ["**"]
       },
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: asset: tauri:; font-src 'self' data: asset: https:; connect-src 'self' ipc: http://ipc.localhost https://api.github.com https://raw.githubusercontent.com https://themes.kova.md; object-src 'none'; base-uri 'self'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: asset: tauri:; media-src 'self' blob: data: asset: tauri: https:; font-src 'self' data: asset: https:; connect-src 'self' ipc: http://ipc.localhost https://api.github.com https://raw.githubusercontent.com https://themes.kova.md; object-src 'none'; base-uri 'self'"
     }
   },
   "plugins": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -323,7 +323,7 @@ export default function App() {
       const resolved: Slide = {
         ...slide,
         elements: slide.elements.map((el) => {
-          if (el.type === 'image')     return { ...el, src: resolveImageSrc(el.src, docDir) };
+          if (el.type === 'image' || el.type === 'video') return { ...el, src: resolveImageSrc(el.src, docDir) };
           if (el.type === 'paragraph') return { ...el, html: resolveHtmlSrcs(el.html, docDir) };
           if (el.type === 'list')      return { ...el, items: el.items.map(resolveItem) };
           return el;

--- a/src/components/preview/SlideRenderer.css
+++ b/src/components/preview/SlideRenderer.css
@@ -405,7 +405,7 @@
 
 .sl-media { height: 100%; display: flex; flex-direction: column; }
 .sl-media__title { padding-bottom: 2%; }
-.sl-media__body { flex: 1; display: flex; align-items: center; justify-content: center; padding: 2% 8% 5%; }
+.sl-media__body { flex: 1; min-height: 0; display: flex; align-items: center; justify-content: center; padding: 2% 8% 5%; }
 
 .sl-youtube { display: flex; flex-direction: column; align-items: center; gap: 2%; width: 100%; }
 .sl-youtube--clickable { cursor: pointer; }
@@ -415,6 +415,12 @@
 .sl-youtube__placeholder { width: 100%; max-width: 320px; aspect-ratio: 16/9; background: #111; color: #fff; display: flex; align-items: center; justify-content: center; font-size: clamp(12px, 3cqi, 24px); border-radius: 4px; transition: opacity 0.15s, box-shadow 0.15s; }
 .sl-youtube__label { font-size: clamp(9px, 2cqi, 16px); font-weight: 600; color: var(--sl-text); text-align: center; font-family: var(--sl-font-body); }
 .sl-youtube__open-hint { font-size: clamp(7px, 1.4cqi, 11px); color: color-mix(in srgb, var(--sl-accent) 80%, transparent); text-align: center; }
+.sl-video { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2%; width: 100%; height: 100%; min-height: 0; }
+/* Fill the available media box, preserving aspect: landscape binds on width,
+   portrait on height. Needs min-height:0 up the flex chain (.sl-media__body)
+   so the box height stays definite instead of growing to the video. */
+.sl-video__player { flex: 1; min-height: 0; max-width: 100%; max-height: 100%; object-fit: contain; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.2); background: #000; }
+.sl-video__label { font-size: clamp(9px, 2cqi, 16px); font-weight: 600; color: var(--sl-text); text-align: center; font-family: var(--sl-font-body); }
 
 .sl-poll { display: flex; flex-direction: column; align-items: center; gap: 3%; padding: 4%; background: color-mix(in srgb, var(--sl-accent) 10%, var(--sl-bg)); border: 2px solid var(--sl-accent); border-radius: 8px; width: 75%; }
 .sl-poll__icon { font-size: clamp(20px, 5cqi, 44px); }

--- a/src/components/preview/SlideRenderer.tsx
+++ b/src/components/preview/SlideRenderer.tsx
@@ -601,12 +601,14 @@ function GridLayout({ slide }: { slide: Slide }) {
 
 function MediaLayout({ slide }: { slide: Slide }) {
   const yt = slide.elements.find((e) => e.type === 'youtube');
+  const vid = slide.elements.find((e) => e.type === 'video');
   const poll = slide.elements.find((e) => e.type === 'poll');
   return (
     <div className="sl-media">
       {slide.title && <div className="sl-heading sl-media__title">{slide.title}</div>}
       <div className="sl-media__body">
         {yt && yt.type === 'youtube' && <YoutubeEmbed embed={yt} />}
+        {vid && vid.type === 'video' && <VideoEmbed embed={vid} />}
         {poll && poll.type === 'poll' && <PollEmbed embed={poll} />}
       </div>
     </div>
@@ -734,6 +736,9 @@ function ElementNode({ el }: { el: SlideElement }) {
     case 'youtube':
       return <YoutubeEmbed embed={el} />;
 
+    case 'video':
+      return <VideoEmbed embed={el} />;
+
     case 'poll':
       return <PollEmbed embed={el} />;
 
@@ -791,6 +796,17 @@ function YoutubeEmbed({ embed }: { embed: Extract<SlideElement, { type: 'youtube
       }
       <div className="sl-youtube__label">{embed.label}</div>
       {!isThumbnail && <div className="sl-youtube__open-hint">Click to open in browser</div>}
+    </div>
+  );
+}
+
+function VideoEmbed({ embed }: { embed: Extract<SlideElement, { type: 'video' }> }) {
+  const { isThumbnail } = useContext(SlideCtx);
+  return (
+    // stopPropagation so the player's controls don't trigger slide navigation.
+    <div className="sl-video" onClick={(e) => e.stopPropagation()}>
+      <video className="sl-video__player" src={embed.src} controls={!isThumbnail} preload="metadata" playsInline />
+      {embed.label && <div className="sl-video__label">{embed.label}</div>}
     </div>
   );
 }

--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -345,6 +345,13 @@ describe('custom syntax pre-processor', () => {
     expect(yt?.type === 'youtube' && yt.url).toBe('https://youtu.be/abc123');
   });
 
+  it('parses !video', () => {
+    const { slides } = parseDocument(doc('## Slide\n\n!video[Clip](media/demo.mp4)\n'));
+    const vid = slides[0].elements.find((e) => e.type === 'video');
+    expect(vid?.type === 'video' && vid.label).toBe('Clip');
+    expect(vid?.type === 'video' && vid.src).toBe('media/demo.mp4');
+  });
+
   it('parses !poll', () => {
     const { slides } = parseDocument(doc('## Slide\n\n!poll[Vote here](https://pollev.com/xyz)\n'));
     const poll = slides[0].elements.find((e) => e.type === 'poll');

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -606,7 +606,22 @@ function addMediaSlide(s: PS, slide: Slide, t: Theme, cy: number, ch: number) {
   const bodyY = cy + hh + 0.1;
   const bodyH = ch - hh - 0.1;
   const yt    = slide.elements.find((e) => e.type === 'youtube');
+  const vid   = slide.elements.find((e) => e.type === 'video');
   const poll  = slide.elements.find((e) => e.type === 'poll');
+
+  // ponytail: PPTX can't embed local video without bundling the file — emit a
+  // labelled placeholder, same as the YouTube branch. Real embed is the upgrade path.
+  if (vid && vid.type === 'video') {
+    s.addText([
+      { text: '▶ ', options: { fontSize: 30, bold: true } },
+      { text: vid.label || 'Video', options: { fontSize: 20, breakLine: true } },
+      { text: vid.src, options: { fontSize: 11, color: hex(t.colors.accent) } },
+    ], {
+      x: M, y: bodyY, w: W - M * 2, h: bodyH,
+      color: hex(t.colors.text), fontFace: firstFont(t.fonts.body),
+      align: 'center', valign: 'middle', wrap: true,
+    });
+  }
 
   const both  = yt && poll;
   const halfH = (bodyH - 0.2) / 2;

--- a/src/engine/layout/autoLayout.ts
+++ b/src/engine/layout/autoLayout.ts
@@ -92,7 +92,7 @@ export function detectLayout(
 
   // ── Highest-priority special types ───────────────────────────────────────
 
-  if (has('youtube') || has('poll')) return 'media';
+  if (has('youtube') || has('poll') || has('video')) return 'media';
   if (has('column-break')) return 'two-column';
 
   // ── Code-only ────────────────────────────────────────────────────────────

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -74,6 +74,7 @@ interface PreprocessResult {
 }
 
 const YOUTUBE_RE      = /^!youtube\[([^\]]*)\]\(([^)]*)\)$/;
+const VIDEO_RE        = /^!video\[([^\]]*)\]\(([^)]*)\)$/;
 const POLL_RE         = /^!poll\[([^\]]*)\]\(([^)]*)\)$/;
 const PROGRESS_RE     = /^!progress\[([^\]]*)\]\((\d+(?:\.\d+)?)\)$/;
 const REF_RE          = /^!ref\[([^\]]*)\]$/;
@@ -110,6 +111,14 @@ function preprocess(content: string): PreprocessResult {
     if (yt) {
       const idx = nextIdx++;
       placeholders.set(idx, { type: 'youtube', label: yt[1], url: yt[2] });
+      cleanLines.push(`<!-- kova-el:${idx} -->`);
+      continue;
+    }
+
+    const vid = t.match(VIDEO_RE);
+    if (vid) {
+      const idx = nextIdx++;
+      placeholders.set(idx, { type: 'video', label: vid[1], src: vid[2] });
       cleanLines.push(`<!-- kova-el:${idx} -->`);
       continue;
     }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -30,6 +30,7 @@ export type SlideElement =
   | { type: 'blockquote'; text: string; attribution?: string }
   | { type: 'table'; headers: string[]; rows: string[][]; align?: ('left' | 'right' | 'center' | null)[] }
   | { type: 'youtube';  label: string; url: string }
+  | { type: 'video';    label: string; src: string }
   | { type: 'poll';     label: string; url: string }
   | { type: 'progress'; label: string; value: number }
   | { type: 'column-break' };


### PR DESCRIPTION
Closes #20.

`!video[label](path)` plays an inline `<video>` — local or relative path, resolved through the existing `asset://` pipeline. Mirrors `!youtube`.

- New `video` element + parser rule + `media` layout
- `VideoEmbed` (`<video controls>`; sized to fit the slide box, both orientations)
- CSP gains `media-src` (was absent → `<video>` blocked)
- PPTX export: labelled placeholder (can't bundle the file)

Tested: `tsc` clean, parser test added.