### PR TITLE
fix(present): type a digit to jump to a slide

### DIFF
--- a/src/components/presentation/PresentationOverlay.tsx
+++ b/src/components/presentation/PresentationOverlay.tsx
@@ -128,6 +128,12 @@ export function PresentationOverlay({
           break;
         case 'Escape':
           e.preventDefault(); e.stopPropagation(); onExit(); break;
+        default:
+          // Type a digit to open the slide-jump input (then Enter to go).
+          if (/^[0-9]$/.test(e.key)) {
+            e.preventDefault(); e.stopPropagation();
+            setJumpInput(e.key);
+          }
       }
     };
     window.addEventListener('keydown', handler, true);


### PR DESCRIPTION
Part of #54.

A digit key now opens the jump-to-slide input pre-filled (Enter jumps). Before, it only opened by clicking the HUD counter, so number+Enter did nothing.

Scroll-wheel half of #54 already fixed in cdc19df.