### PR TITLE
fix(theme): templated header/footer text no longer reverts to default

### DIFF
--- a/src/engine/__tests__/theme.test.ts
+++ b/src/engine/__tests__/theme.test.ts
@@ -166,16 +166,17 @@ describe('sanitiseThemeOverrides', () => {
     expect(result.footer?.show).toBe(true);
     expect(result.footer?.text).toBe('Confidential');
     expect(result.footer?.show_slide_number).toBe(true);
-    expect(result.header?.text).toBeUndefined();
+    // Text renders as escaped content, not CSS — `;` is allowed.
+    expect(result.header?.text).toBe('bad; css');
   });
 
-  it('drops footer/header text containing template braces (CSS-injection guard)', () => {
+  it('keeps footer/header text containing template braces (issue #55)', () => {
     const result = sanitiseThemeOverrides({
-      footer: { text: 'Page {title}' },
+      footer: { text: '{date} | {title} | {slide_number} / {total}' },
       header: { text: '{title}' },
     });
-    expect(result.footer?.text).toBeUndefined();
-    expect(result.header?.text).toBeUndefined();
+    expect(result.footer?.text).toBe('{date} | {title} | {slide_number} / {total}');
+    expect(result.header?.text).toBe('{title}');
   });
 
   it('clamps logo_opacity and accepts valid logo paths', () => {

--- a/src/engine/theme.ts
+++ b/src/engine/theme.ts
@@ -502,19 +502,21 @@ export function sanitiseThemeOverrides(raw: Record<string, unknown>): Partial<Th
     result.logo_opacity = Math.min(1, Math.max(0, raw.logo_opacity));
   }
 
-  // Header/footer: validate individual fields rather than blindly passing through.
+  // Header/footer text skips the colors/fonts CSS-injection guard: it renders as
+  // React-escaped text, and `{title}`/`{date}` braces are its template syntax — the
+  // `[;{}]` check would wrongly drop every templated footer (issue #55).
   if (raw.header && typeof raw.header === 'object') {
     const h = raw.header as Record<string, unknown>;
     const header: Record<string, unknown> = {};
     if (typeof h.show === 'boolean') header.show = h.show;
-    if (typeof h.text === 'string' && !/[;{}]/.test(h.text)) header.text = h.text;
+    if (typeof h.text === 'string') header.text = h.text;
     if (Object.keys(header).length > 0) result.header = header as unknown as ThemeHeader;
   }
   if (raw.footer && typeof raw.footer === 'object') {
     const f = raw.footer as Record<string, unknown>;
     const footer: Record<string, unknown> = {};
     if (typeof f.show === 'boolean') footer.show = f.show;
-    if (typeof f.text === 'string' && !/[;{}]/.test(f.text)) footer.text = f.text;
+    if (typeof f.text === 'string') footer.text = f.text;
     if (typeof f.show_slide_number === 'boolean') footer.show_slide_number = f.show_slide_number;
     if (Object.keys(footer).length > 0) result.footer = footer as unknown as ThemeFooter;
   }


### PR DESCRIPTION
Closes #55.

The CSS-injection guard `/[;{}]/` was applied to header/footer text, dropping any `{title}`/`{date}` template → footer reverted to default. That text renders as React-escaped content (not CSS/HTML), so the guard never applied. Removed for those two fields; colors/fonts keep it.