### PR TITLE
test: extractFrontmatter scalar edge cases

### DIFF
--- a/src/engine/__tests__/frontmatter.test.ts
+++ b/src/engine/__tests__/frontmatter.test.ts
@@ -29,6 +29,41 @@ describe('extractFrontmatter', () => {
     expect(body).toBe(input);
   });
 
+  it('preserves boolean and number scalar types', () => {
+    const { frontmatter } = extractFrontmatter('---\npaginate: true\ndate: 2024\n---\n\n# Slide\n');
+    expect(frontmatter['paginate']).toBe(true);
+    expect(frontmatter['date']).toBe(2024);
+  });
+
+  it('returns an empty body when nothing follows the closing ---', () => {
+    const { frontmatter, body } = extractFrontmatter('---\ntitle: X\n---\n');
+    expect(frontmatter.title).toBe('X');
+    expect(body).toBe('');
+  });
+
+  it('returns the full content as body when frontmatter YAML is malformed', () => {
+    const input = '---\n: bad: yaml:\n---\n\n# Slide\n';
+    const { frontmatter, body } = extractFrontmatter(input);
+    expect(frontmatter).toEqual({});
+    // Body retains the entire document so a downstream parse still sees the heading.
+    expect(body).toBe(input);
+    expect(body).toContain('# Slide');
+  });
+
+  it('extracts a partial theme_overrides map with only colors', () => {
+    const input = [
+      '---',
+      'theme_overrides:',
+      '  colors:',
+      '    primary: "#FF0000"',
+      '---',
+      '',
+      '# Slide',
+    ].join('\n');
+    const { frontmatter } = extractFrontmatter(input);
+    expect(frontmatter.theme_overrides).toEqual({ colors: { primary: '#FF0000' } });
+  });
+
   it('parses nested theme_overrides maps', () => {
     const input = [
       '---',


### PR DESCRIPTION
## Summary
- Add `extractFrontmatter` edge cases in `frontmatter.test.ts` (complements patchFrontmatter #62)
- Boolean/number scalars preserved: `paginate: true` → boolean, `date: 2024` → number
- Empty body when nothing follows the closing `---`
- Malformed frontmatter YAML → empty frontmatter and the full content returned as body (heading still present)
- Partial nested `theme_overrides` map (colors only) extracted

## Test plan
- [x] `npm test -- --run src/engine/__tests__/frontmatter.test.ts` — 18 tests pass