### PR TITLE
feat: table of contents (!toc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Kova turns plain Markdown into polished slides — with live preview, multiple l
 - **PPTX export** — export to PowerPoint (16:9 and 4:3)
 - **Academic references** — cite sources with `!ref[Author, Year. Title]`; renders as small bottom-right text on the slide and exports to PPTX
 - **YouTube & poll embeds** — `!youtube[label](url)` and `!poll[label](url)`
+- **Table of contents** — `!toc` lists the titles of all following slides
 - **File watcher** — reloads automatically when the file is edited externally
 - **Keybindings** — configurable via `~/.config/kova/keybindings.yaml`
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -318,7 +318,10 @@ export default function App() {
     const { cache } = cacheHolder;
 
     return rawSlides.map((slide) => {
-      const cached = cache.get(slide);
+      // TOC entries depend on *other* slides' titles, so a TOC slide can't use the
+      // per-slide cache (it'd go stale when a later title changes) — rebuild it each time.
+      const hasToc = slide.elements.some((e) => e.type === 'toc');
+      const cached = !hasToc && cache.get(slide);
       if (cached) return cached;
       const resolved: Slide = {
         ...slide,
@@ -326,10 +329,13 @@ export default function App() {
           if (el.type === 'image')     return { ...el, src: resolveImageSrc(el.src, docDir) };
           if (el.type === 'paragraph') return { ...el, html: resolveHtmlSrcs(el.html, docDir) };
           if (el.type === 'list')      return { ...el, items: el.items.map(resolveItem) };
+          if (el.type === 'toc')       return { ...el, entries: rawSlides
+            .filter((s) => s.index > slide.index && s.title)
+            .map((s) => ({ title: s.title, index: s.index })) };
           return el;
         }),
       };
-      cache.set(slide, resolved);
+      if (!hasToc) cache.set(slide, resolved);
       return resolved;
     });
   }, [rawSlides, filePath, importDir]);

--- a/src/components/preview/SlideRenderer.css
+++ b/src/components/preview/SlideRenderer.css
@@ -422,6 +422,10 @@
 .sl-poll__label { font-family: var(--sl-font-title); font-size: clamp(10px, 2.5cqi, 22px); font-weight: 700; text-align: center; color: var(--sl-text); }
 .sl-poll__url { font-size: clamp(8px, 1.8cqi, 14px); color: var(--sl-accent); text-align: center; }
 
+.sl-toc { width: 100%; }
+.sl-toc__list { list-style: decimal inside; display: flex; flex-direction: column; gap: 1.5cqi; margin: 0; padding: 0; }
+.sl-toc__item { font-family: var(--sl-font-body); font-size: clamp(10px, 2.4cqi, 20px); color: var(--sl-text); padding-left: 1cqi; }
+
 /* ── highlight.js override — let the slide supply the background ─────────── */
 
 /* Background comes from --sl-code-bg; base text from --sl-code-text (computed

--- a/src/components/preview/SlideRenderer.tsx
+++ b/src/components/preview/SlideRenderer.tsx
@@ -740,6 +740,9 @@ function ElementNode({ el }: { el: SlideElement }) {
     case 'progress':
       return <ProgressBar el={el} />;
 
+    case 'toc':
+      return <TocList el={el} />;
+
     case 'column-break':
       return null;
 
@@ -869,6 +872,19 @@ function ProgressBar({ el }: { el: Extract<SlideElement, { type: 'progress' }> }
       <div className="sl-progress__track">
         <div className="sl-progress__fill" style={{ width: `${pct}%` }} />
       </div>
+    </div>
+  );
+}
+
+function TocList({ el }: { el: Extract<SlideElement, { type: 'toc' }> }) {
+  const entries = el.entries ?? [];
+  return (
+    <div className="sl-toc">
+      <ol className="sl-toc__list">
+        {entries.map((e) => (
+          <li key={e.index} className="sl-toc__item">{e.title}</li>
+        ))}
+      </ol>
     </div>
   );
 }

--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -351,6 +351,11 @@ describe('custom syntax pre-processor', () => {
     expect(poll?.type === 'poll' && poll.label).toBe('Vote here');
   });
 
+  it('parses !toc', () => {
+    const toc = parseDocument(doc('## Agenda\n\n!toc\n')).slides[0].elements.find((e) => e.type === 'toc');
+    expect(toc?.type).toBe('toc');
+  });
+
   it('parses !progress with integer value', () => {
     const { slides } = parseDocument(doc('## Slide\n\n!progress[Done](75)\n'));
     const prog = slides[0].elements.find((e) => e.type === 'progress');

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -1099,6 +1099,12 @@ function addElements(s: PS, elements: SlideElement[], t: Theme, area: Area, warn
         runs.push({ text: el.value, options: { fontFace: firstFont(t.fonts.code), fontSize: 15, breakLine: true } });
         break;
 
+      case 'toc':
+        for (const entry of el.entries ?? []) {
+          runs.push({ text: entry.title, options: { bullet: { type: 'number', style: 'arabicPeriod' } as const, fontSize: 18, paraSpaceAfter: 4, breakLine: true } });
+        }
+        break;
+
       // Images and tables handled separately below
       default:
         break;

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -74,6 +74,7 @@ interface PreprocessResult {
 }
 
 const YOUTUBE_RE      = /^!youtube\[([^\]]*)\]\(([^)]*)\)$/;
+const TOC_RE          = /^!toc$/;
 const POLL_RE         = /^!poll\[([^\]]*)\]\(([^)]*)\)$/;
 const PROGRESS_RE     = /^!progress\[([^\]]*)\]\((\d+(?:\.\d+)?)\)$/;
 const REF_RE          = /^!ref\[([^\]]*)\]$/;
@@ -110,6 +111,14 @@ function preprocess(content: string): PreprocessResult {
     if (yt) {
       const idx = nextIdx++;
       placeholders.set(idx, { type: 'youtube', label: yt[1], url: yt[2] });
+      cleanLines.push(`<!-- kova-el:${idx} -->`);
+      continue;
+    }
+
+    const toc = t.match(TOC_RE);
+    if (toc) {
+      const idx = nextIdx++;
+      placeholders.set(idx, { type: 'toc' });
       cleanLines.push(`<!-- kova-el:${idx} -->`);
       continue;
     }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -32,6 +32,7 @@ export type SlideElement =
   | { type: 'youtube';  label: string; url: string }
   | { type: 'poll';     label: string; url: string }
   | { type: 'progress'; label: string; value: number }
+  | { type: 'toc'; entries?: { title: string; index: number }[] }
   | { type: 'column-break' };
 
 export interface Slide {


### PR DESCRIPTION
Closes #57.

`!toc` on its own line renders a numbered list of the titles of all *following* slides — so the title slide (before) and the TOC slide itself are excluded, no filtering needed. Entries recompute in the resolve pass so they track title edits live.

Skipped the issue's bonuses (intra-slide links, scripting, includes) — separate features.