### PR TITLE
test: multi-slide layout assignment

### DIFF
--- a/src/engine/__tests__/parserLayoutIntegration.test.ts
+++ b/src/engine/__tests__/parserLayoutIntegration.test.ts
@@ -190,3 +190,50 @@ describe('parser → layout integration', () => {
     expect(slides[0].speakerNotes).toContain('Presenter notes only');
   });
 });
+
+describe('parser → layout integration (multi-slide deck)', () => {
+  it('assigns the correct layout to each slide of a realistic deck', () => {
+    const md = [
+      '---',
+      'title: Realistic Deck',
+      '---',
+      '',
+      '# Title slide',
+      '',
+      '---',
+      '',
+      '## Section',
+      '',
+      '---',
+      '',
+      '## Content',
+      '',
+      'Some body text',
+      '',
+      '---',
+      '',
+      '## Code',
+      '',
+      '```js',
+      'const x = 1',
+      '```',
+      '',
+      '---',
+      '',
+      '![](img.png)',
+    ].join('\n');
+    const { slides } = parseDocument(md);
+    expect(slides).toHaveLength(5);
+    expect(slides.map((s) => s.layout)).toEqual([
+      'title',
+      'section',
+      'title-content',
+      'code',
+      'full-bleed',
+    ]);
+    expect(slides[0].title).toBe('Title slide');
+    expect(slides[1].title).toBe('Section');
+    expect(slides[4].title).toBe('');
+    expect(slides[4].elements.find((e) => e.type === 'image')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a multi-slide integration test in `parserLayoutIntegration.test.ts`
- One realistic deck asserts per-slide layout end-to-end through `parseDocument`:
  - `# Title slide` → `title`
  - `## Section` → `section`
  - `## Content` + body → `title-content`
  - `## Code` + fenced block → `code`
  - `![](img.png)` (no heading) → `full-bleed`

## Test plan
- [x] `npm test -- --run src/engine/__tests__/parserLayoutIntegration.test.ts` — 17 tests pass