### PR TITLE
test: spellChecker custom-word and ignore behavior

### DIFF
--- a/src/engine/__tests__/spellChecker.test.ts
+++ b/src/engine/__tests__/spellChecker.test.ts
@@ -1,5 +1,23 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { detectOsLanguage } from '../spellcheck/spellChecker';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  detectOsLanguage,
+  initSpellChecker,
+  isSpellCheckerReady,
+  spellCheck,
+  addCustomWord,
+  removeCustomWord,
+  ignoreSpellingFor,
+  getCustomWords,
+} from '../spellcheck/spellChecker';
+
+// Mock the dictionary engine so it reports every word misspelled except
+// "correct" — this lets the custom-word / ignore overrides be observed.
+vi.mock('typo-js', () => ({
+  default: class {
+    check(word: string) { return word === 'correct'; }
+    suggest() { return []; }
+  },
+}));
 
 function withLanguage(language: string) {
   vi.stubGlobal('navigator', { language });
@@ -28,5 +46,52 @@ describe('detectOsLanguage', () => {
   it('maps fr-CA to fr_FR via primary subtag', () => {
     withLanguage('fr-CA');
     expect(detectOsLanguage()).toBe('fr_FR');
+  });
+});
+
+// Runs before any dictionary is initialised, so `active` is still null.
+describe('spellCheck before initialisation', () => {
+  it('reports ready=false and treats every word as correct', () => {
+    expect(isSpellCheckerReady()).toBe(false);
+    expect(spellCheck('definitelynotaword')).toBe(true);
+  });
+});
+
+describe('custom words and ignore list', () => {
+  beforeEach(async () => {
+    const store: Record<string, string> = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, text: async () => '' })));
+    await initSpellChecker('en_US');
+  });
+
+  it('marks the dictionary ready and flags unknown words after init', () => {
+    expect(isSpellCheckerReady()).toBe(true);
+    expect(spellCheck('mispeld')).toBe(false);
+  });
+
+  it('addCustomWord makes spellCheck return true for that word', () => {
+    expect(spellCheck('kova')).toBe(false);
+    addCustomWord('kova');
+    expect(spellCheck('kova')).toBe(true);
+    expect(getCustomWords()).toContain('kova');
+  });
+
+  it('ignoreSpellingFor persists across repeated checks', () => {
+    ignoreSpellingFor('teh');
+    expect(spellCheck('teh')).toBe(true);
+    expect(spellCheck('teh')).toBe(true);
+  });
+
+  it('removeCustomWord drops the word from the custom set', () => {
+    addCustomWord('widgetly');
+    expect(getCustomWords()).toContain('widgetly');
+    removeCustomWord('widgetly');
+    expect(getCustomWords()).not.toContain('widgetly');
+    expect(spellCheck('widgetly')).toBe(false);
   });
 });

--- a/src/engine/__tests__/spellChecker.test.ts
+++ b/src/engine/__tests__/spellChecker.test.ts
@@ -1,14 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  detectOsLanguage,
-  initSpellChecker,
-  isSpellCheckerReady,
-  spellCheck,
-  addCustomWord,
-  removeCustomWord,
-  ignoreSpellingFor,
-  getCustomWords,
-} from '../spellcheck/spellChecker';
+import { detectOsLanguage } from '../spellcheck/spellChecker';
 
 // Mock the dictionary engine so it reports every word misspelled except
 // "correct" — this lets the custom-word / ignore overrides be observed.
@@ -18,6 +9,25 @@ vi.mock('typo-js', () => ({
     suggest() { return []; }
   },
 }));
+
+type SpellMod = typeof import('../spellcheck/spellChecker');
+
+// spellChecker.ts keeps module-level singletons (customWords, ignored, active,
+// currentLang) that nothing resets. Reset the module registry and re-import a
+// fresh instance per test so state can't bleed between cases or make them
+// order-sensitive. localStorage/fetch are stubbed before the fresh import so
+// the module loads against a clean, isolated store.
+async function freshModule(): Promise<SpellMod> {
+  const store: Record<string, string> = {};
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+  });
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, text: async () => '' })));
+  vi.resetModules();
+  return import('../spellcheck/spellChecker');
+}
 
 function withLanguage(language: string) {
   vi.stubGlobal('navigator', { language });
@@ -49,49 +59,49 @@ describe('detectOsLanguage', () => {
   });
 });
 
-// Runs before any dictionary is initialised, so `active` is still null.
 describe('spellCheck before initialisation', () => {
-  it('reports ready=false and treats every word as correct', () => {
-    expect(isSpellCheckerReady()).toBe(false);
-    expect(spellCheck('definitelynotaword')).toBe(true);
+  it('reports ready=false and treats every word as correct', async () => {
+    const mod = await freshModule();
+    expect(mod.isSpellCheckerReady()).toBe(false);
+    expect(mod.spellCheck('definitelynotaword')).toBe(true);
   });
 });
 
 describe('custom words and ignore list', () => {
+  let mod: SpellMod;
+
   beforeEach(async () => {
-    const store: Record<string, string> = {};
-    vi.stubGlobal('localStorage', {
-      getItem: (k: string) => store[k] ?? null,
-      setItem: (k: string, v: string) => { store[k] = v; },
-      removeItem: (k: string) => { delete store[k]; },
-    });
-    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, text: async () => '' })));
-    await initSpellChecker('en_US');
+    mod = await freshModule();
+    await mod.initSpellChecker('en_US');
   });
 
   it('marks the dictionary ready and flags unknown words after init', () => {
-    expect(isSpellCheckerReady()).toBe(true);
-    expect(spellCheck('mispeld')).toBe(false);
+    expect(mod.isSpellCheckerReady()).toBe(true);
+    expect(mod.spellCheck('mispeld')).toBe(false);
   });
 
   it('addCustomWord makes spellCheck return true for that word', () => {
-    expect(spellCheck('kova')).toBe(false);
-    addCustomWord('kova');
-    expect(spellCheck('kova')).toBe(true);
-    expect(getCustomWords()).toContain('kova');
+    expect(mod.spellCheck('kova')).toBe(false);
+    mod.addCustomWord('kova');
+    expect(mod.spellCheck('kova')).toBe(true);
+    expect(mod.getCustomWords()).toContain('kova');
   });
 
   it('ignoreSpellingFor persists across repeated checks', () => {
-    ignoreSpellingFor('teh');
-    expect(spellCheck('teh')).toBe(true);
-    expect(spellCheck('teh')).toBe(true);
+    mod.ignoreSpellingFor('teh');
+    expect(mod.spellCheck('teh')).toBe(true);
+    expect(mod.spellCheck('teh')).toBe(true);
   });
 
   it('removeCustomWord drops the word from the custom set', () => {
-    addCustomWord('widgetly');
-    expect(getCustomWords()).toContain('widgetly');
-    removeCustomWord('widgetly');
-    expect(getCustomWords()).not.toContain('widgetly');
-    expect(spellCheck('widgetly')).toBe(false);
+    mod.addCustomWord('widgetly');
+    expect(mod.getCustomWords()).toContain('widgetly');
+    mod.removeCustomWord('widgetly');
+    expect(mod.getCustomWords()).not.toContain('widgetly');
+    expect(mod.spellCheck('widgetly')).toBe(false);
+  });
+
+  it('keeps custom words isolated between tests (no bleed from earlier cases)', () => {
+    expect(mod.getCustomWords()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Extend `spellChecker.test.ts` (beyond `detectOsLanguage` from #60) with custom-word / ignore coverage
- `typo-js` is mocked (every word misspelled except "correct"); `localStorage` and `fetch` are stubbed
- `addCustomWord` → `spellCheck` returns true for that word
- `ignoreSpellingFor` persists across repeated checks
- `removeCustomWord` drops the word from the custom set (spellCheck reverts to false)
- Before init: `isSpellCheckerReady()` is false and `spellCheck` treats every word as correct

## Test plan
- [x] `npm test -- --run src/engine/__tests__/spellChecker.test.ts` — 9 tests pass
- [x] `npm test -- --run` — full suite 285 tests pass (no mock leakage)