### PR TITLE
test: cover matchShortcut modifier-less combos

### DIFF
--- a/src/engine/__tests__/keybindings.test.ts
+++ b/src/engine/__tests__/keybindings.test.ts
@@ -69,6 +69,26 @@ describe('matchShortcut', () => {
     const e = mockEvent({ ctrlKey: true, altKey: true, key: 's' });
     expect(matchShortcut(e, 'ctrl+s')).toBe(false);
   });
+
+  it('matches a modifier-less single-key combo', () => {
+    const e = mockEvent({ key: 'a' });
+    expect(matchShortcut(e, 'a')).toBe(true);
+  });
+
+  it('matches a modifier-less combo case-insensitively', () => {
+    const e = mockEvent({ key: 'A' });
+    expect(matchShortcut(e, 'a')).toBe(true);
+  });
+
+  it('rejects a modifier-less combo when ctrl is held', () => {
+    const e = mockEvent({ ctrlKey: true, key: 'a' });
+    expect(matchShortcut(e, 'a')).toBe(false);
+  });
+
+  it('rejects a modifier-less combo when shift is held', () => {
+    const e = mockEvent({ shiftKey: true, key: 'a' });
+    expect(matchShortcut(e, 'a')).toBe(false);
+  });
 });
 
 // ── formatCombo ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Every existing `matchShortcut` test uses a ctrl/shift/alt modifier; this covers the modifier-less branch
- A single-key combo (`'a'`) matches a bare key event
- The match is case-insensitive (`key: 'A'` vs combo `'a'`)
- A modifier-less combo is rejected when `ctrl` or `shift` is held (no accidental matches)

## Test plan
- [x] `npm test -- --run src/engine/__tests__/keybindings.test.ts` — 25 tests pass