### PR TITLE
test: cover formatCombo composite combos

### DIFF
--- a/src/engine/__tests__/keybindings.test.ts
+++ b/src/engine/__tests__/keybindings.test.ts
@@ -97,6 +97,18 @@ describe('formatCombo', () => {
   it('handles multi-character keys', () => {
     expect(formatCombo('ctrl+escape')).toBe('Ctrl+Escape');
   });
+
+  it('formats a ctrl+alt composite combo', () => {
+    expect(formatCombo('ctrl+alt+f')).toBe('Ctrl+Alt+F');
+  });
+
+  it('formats a meta composite combo as Cmd', () => {
+    expect(formatCombo('meta+k')).toBe('Cmd+K');
+  });
+
+  it('capitalises every segment of a three-part combo with a multi-char key', () => {
+    expect(formatCombo('ctrl+shift+arrowup')).toBe('Ctrl+Shift+Arrowup');
+  });
 });
 
 // ── getCombo ──────────────────────────────────────────────────────────────────

--- a/src/engine/__tests__/keybindings.test.ts
+++ b/src/engine/__tests__/keybindings.test.ts
@@ -102,8 +102,8 @@ describe('formatCombo', () => {
     expect(formatCombo('ctrl+alt+f')).toBe('Ctrl+Alt+F');
   });
 
-  it('formats a meta composite combo as Cmd', () => {
-    expect(formatCombo('meta+k')).toBe('Cmd+K');
+  it('formats a meta composite combo as Cmd alongside another modifier', () => {
+    expect(formatCombo('meta+shift+k')).toBe('Cmd+Shift+K');
   });
 
   it('capitalises every segment of a three-part combo with a multi-char key', () => {


### PR DESCRIPTION
## Summary
- Existing `formatCombo` tests only exercise single-modifier combos; this covers multi-part combos:
  - `ctrl+alt+f` → `Ctrl+Alt+F`
  - `meta+shift+k` → `Cmd+Shift+K` (meta→Cmd mapping alongside another modifier)
  - `ctrl+shift+arrowup` → `Ctrl+Shift+Arrowup` (every segment capitalised, multi-char key)

## Test plan
- [x] `npm test -- --run src/engine/__tests__/keybindings.test.ts` — 24 tests pass