### PR TITLE
fix: Remove 'file changed externally' on OneDrive based folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tauri-app",
-  "version": "0.6.7",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tauri-app",
-      "version": "0.6.7",
+      "version": "0.6.9",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -190,8 +190,8 @@ pub async fn setup_audience_window(
     app: AppHandle,
     x: f64,
     y: f64,
-    physical_x: f64,
-    physical_y: f64,
+    _physical_x: f64,
+    _physical_y: f64,
 ) -> Result<(), String> {
     // Wait for the audience window to appear in the manager, up to 5 s.
     // This replaces a single fixed sleep: on fast machines we proceed sooner;
@@ -223,7 +223,7 @@ pub async fn setup_audience_window(
     #[cfg(target_os = "linux")]
     {
         #[cfg(debug_assertions)]
-        eprintln!("[kova] setup_audience_window: logical x={x:.0} y={y:.0}  physical x={physical_x:.0} y={physical_y:.0}");
+        eprintln!("[kova] setup_audience_window: logical x={x:.0} y={y:.0}  physical x={_physical_x:.0} y={_physical_y:.0}");
         let app2 = app.clone();
         app.run_on_main_thread(move || {
             use gtk::prelude::GtkWindowExt;
@@ -286,7 +286,7 @@ pub async fn setup_audience_window(
                 &[(x as i32 + 1, y as i32 + 1)]
             } else {
                 &[
-                    (physical_x as i32 + 1, physical_y as i32 + 1),
+                    (_physical_x as i32 + 1, _physical_y as i32 + 1),
                     (x as i32 + 1, y as i32 + 1),
                 ]
             };
@@ -1394,12 +1394,12 @@ mod platform_windows {
                     .ok()
                     .and_then(|env6| unsafe { env6.CreatePrintSettings() }.ok())
                     .and_then(|s| unsafe {
-                        let _ = s.put_PageWidth(width_mm / 25.4);
-                        let _ = s.put_PageHeight(height_mm / 25.4);
-                        let _ = s.put_MarginTop(0.0);
-                        let _ = s.put_MarginBottom(0.0);
-                        let _ = s.put_MarginLeft(0.0);
-                        let _ = s.put_MarginRight(0.0);
+                        let _ = s.SetPageWidth(width_mm / 25.4);
+                        let _ = s.SetPageHeight(height_mm / 25.4);
+                        let _ = s.SetMarginTop(0.0);
+                        let _ = s.SetMarginBottom(0.0);
+                        let _ = s.SetMarginLeft(0.0);
+                        let _ = s.SetMarginRight(0.0);
                         Some(s)
                     });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -549,6 +549,10 @@ export default function App() {
         newContent = await invoke('read_file', { path });
       } catch (err) {
         console.error('Failed to reload file:', err);
+        if (isDirtyRef.current) {
+          externalChangePathRef.current = path;
+          setShowExternalChangeDialog(true);
+        }
         return;
       }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -558,6 +558,7 @@ export default function App() {
 
       if (isDirtyRef.current) {
         // Unsaved edits — block with a modal; user must choose reload or save-as.
+        diskContentRef.current = newContent;
         externalChangePathRef.current = path;
         setShowExternalChangeDialog(true);
       } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -305,6 +305,9 @@ export default function App() {
   showFrontmatterRef.current = settings.showFrontmatter;
   const contentRef = useRef(content);
   contentRef.current = content;
+  // Last content known to be persisted on disk for the currently watched file.
+  // External-change events that do not alter this snapshot are ignored.
+  const diskContentRef = useRef(content);
   // Updated in render body (not useEffect) so the file-changed listener always
   // sees the current dirty state when it fires synchronously after a watcher event.
   const isDirtyRef = useRef(isDirty);
@@ -541,21 +544,29 @@ export default function App() {
     const unlisten = listen<void>('file-changed', async () => {
       const path = filePathRef.current;
       if (!path) return;
+      let newContent: string;
+      try {
+        newContent = await invoke('read_file', { path });
+      } catch (err) {
+        console.error('Failed to reload file:', err);
+        return;
+      }
+
+      // OneDrive and other sync clients can touch file metadata frequently
+      // without changing the markdown bytes. Ignore those watcher events.
+      if (newContent === diskContentRef.current) return;
+
       if (isDirtyRef.current) {
         // Unsaved edits — block with a modal; user must choose reload or save-as.
         externalChangePathRef.current = path;
         setShowExternalChangeDialog(true);
       } else {
         // No unsaved edits — reload silently then surface a dismissable banner.
-        try {
-          const newContent: string = await invoke('read_file', { path });
-          setContent(newContent);
-          setIsDirty(false);
-          externalChangePathRef.current = path;
-          setShowExternalChangeDialog(true);
-        } catch (err) {
-          console.error('Failed to reload file:', err);
-        }
+        setContent(newContent);
+        setIsDirty(false);
+        diskContentRef.current = newContent;
+        externalChangePathRef.current = path;
+        setShowExternalChangeDialog(true);
       }
     });
     return () => { unlisten.then((fn) => fn()); };
@@ -904,6 +915,7 @@ export default function App() {
     setFilePath(path);
     setContent(text);
     setIsDirty(false);
+    diskContentRef.current = text;
     setCurrentSlideIndex(0);
     if (path) await invoke('start_watching', { path }).catch(console.error);
     setMarpPrompt(isMarp(text) ? { text, dir: dirOf(path) } : null);
@@ -1100,6 +1112,7 @@ export default function App() {
       const toWrite = buildSaveContent();
       await invoke('write_file', { path: filePath, content: toWrite });
       if (toWrite !== content) setContent(toWrite);
+      diskContentRef.current = toWrite;
       // Re-register the watcher: atomic_write replaces the file's inode via
       // rename, which causes inotify to drop the watch on the old inode.
       // Explicitly re-watching after each save ensures external changes are
@@ -1129,6 +1142,7 @@ export default function App() {
       if (toWrite !== content) setContent(toWrite);
       setFilePath(target);
       setIsDirty(false);
+      diskContentRef.current = toWrite;
       await invoke('start_watching', { path: target }).catch(console.error);
       return target;
     } catch (err) { console.error('Save As failed:', err); setWarnMessage(`Save failed: ${err}`); return null; }
@@ -1975,6 +1989,7 @@ export default function App() {
                         const newContent: string = await invoke('read_file', { path });
                         setContent(newContent);
                         setIsDirty(false);
+                        diskContentRef.current = newContent;
                       } catch (err) { console.error('Failed to reload file:', err); }
                     }}
                   >Reload</button>


### PR DESCRIPTION
If the kova markdown file is stored in a OneDrive folder, the 'file changed externally' message appears every few seconds after the file was stored.

<img width="257" height="120" alt="image" src="https://github.com/user-attachments/assets/9bd9e430-898f-44ca-ab6f-f47c73ed1097" />

This PR introduces a file content based check, to remove this message.

In addition, at least on my setup (Windows based) with the dependencies used in the lock files, I got errors regarding webvie2 API. I have replaced the APIs and removed some warnings.

<img width="650" height="280" alt="image" src="https://github.com/user-attachments/assets/0bdd2ba0-0509-4d69-8ddb-0262ea10c1fe" />
