### PR TITLE
feat(export): PDF handout with speaker notes and N-up layouts

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2029,6 +2029,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "webkit2gtk",
  "webview2-com",
  "windows",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSWindow", "NSResponder"] }
 # Native PDF export via WKWebView.createPDFWithConfiguration:completionHandler:
 objc2-web-kit = { version = "0.3", features = ["WKWebView", "WKPDFConfiguration"] }
-objc2-foundation = { version = "0.3", features = ["NSData", "NSError"] }
+objc2-foundation = { version = "0.3", features = ["NSData", "NSError", "NSGeometry"] }
 block2 = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -51,4 +51,6 @@ windows = { version = "0.61", features = [] }
 gtk = { version = "0.18", features = [] }
 gdk = { version = "0.18", features = [] }
 gio = "0.18"
+# Native PDF export via WebKitPrintOperation. Pinned to what wry already pulls in.
+webkit2gtk = "=2.0.2"
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,7 @@
 fn main() {
+    // PDFKit is used to merge per-page captures into one multipage PDF (macOS export).
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-lib=framework=PDFKit");
+    }
     tauri_build::build()
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1162,18 +1162,6 @@ fn sort_dedup_fonts(mut fonts: Vec<String>) -> Vec<String> {
 // ── Native PDF export ────────────────────────────────────────────────────────
 
 /// Render a self-contained HTML document to a PDF file using the platform's
-/// Returns Ok if native PDF export is available on this platform; returns
-/// Err("not yet implemented") on platforms where only the JS raster fallback
-/// is used. Callers should check this before building the HTML document to
-/// avoid sending a large payload over IPC unnecessarily.
-#[tauri::command]
-pub fn check_native_pdf() -> Result<(), String> {
-    #[cfg(target_os = "linux")]
-    return Err("not yet implemented".into());
-    #[cfg(not(target_os = "linux"))]
-    Ok(())
-}
-
 /// native WebView print API (WKWebView on macOS, WebView2 on Windows).
 /// The HTML must be fully self-contained (all fonts and images embedded as
 /// data: URIs) so the hidden render window needs no network or asset:// access.
@@ -1184,6 +1172,9 @@ pub async fn export_pdf_native(
     output_path: String,
     width_mm: f64,
     height_mm: f64,
+    page_count: u32,
+    page_width_px: f64,
+    page_height_px: f64,
 ) -> Result<(), String> {
     use tauri::Manager;
 
@@ -1204,18 +1195,16 @@ pub async fn export_pdf_native(
 
     let html_path_str = html_path.to_str().ok_or("html_path is non-UTF-8")?.to_string();
 
-    // Linux: no native PDF backend — fall through to the raster path in JS.
-    #[cfg(target_os = "linux")]
+    // Load the HTML in a hidden WebviewWindow and print it with the platform's
+    // native WebView print API (WKWebView / WebView2 / WebKitGTK).
     {
-        let _ = (width_mm, height_mm, html_path_str, output_path);
-        let _ = std::fs::remove_file(&html_path);
-        return Err("not yet implemented".into());
-    }
+        // Per-page rect params are macOS-only; Windows and Linux paginate from
+        // @page using width_mm/height_mm. Silence what each target doesn't use.
+        #[cfg(not(target_os = "macos"))]
+        let _ = (page_count, page_width_px, page_height_px);
+        #[cfg(target_os = "macos")]
+        let _ = (width_mm, height_mm);
 
-    // macOS / Windows: load the HTML in a hidden WebviewWindow and use the
-    // platform's native WebView printing API.
-    #[cfg(not(target_os = "linux"))]
-    {
         // Produce a valid file:// URL.
         // On Windows: C:\foo\bar.html → file:///C:/foo/bar.html (triple slash required)
         // On Unix:    /path/bar.html  → file:///path/bar.html
@@ -1268,11 +1257,18 @@ pub async fn export_pdf_native(
         .ok();
 
         #[cfg(target_os = "macos")]
-        let result = platform_macos::generate_pdf(&window, &output_path).await;
+        let result = platform_macos::generate_pdf(
+            &window, &output_path, page_count, page_width_px, page_height_px,
+        )
+        .await;
 
         #[cfg(target_os = "windows")]
         let result =
             platform_windows::generate_pdf(&window, &output_path, width_mm, height_mm).await;
+
+        #[cfg(target_os = "linux")]
+        let result =
+            platform_linux::generate_pdf(&window, &output_path, width_mm, height_mm).await;
 
         let _ = window.destroy();
         let _ = std::fs::remove_file(&html_path);
@@ -1281,67 +1277,136 @@ pub async fn export_pdf_native(
     }
 }
 
-// ── macOS: WKWebView.createPDFWithConfiguration:completionHandler: ────────────
+// ── macOS: per-page WKWebView.createPDF + PDFKit merge (paginates the export) ──
+//
+// createPDFWithConfiguration snapshots a region as a SINGLE page, so we capture
+// one page-sized rect per logical page (slide / N-up sheet / handout) and merge
+// them into one multipage PDF with PDFKit. This stays on the async completion-
+// block path (no NSPrintOperation.runOperation, which blocks the main thread).
 
 #[cfg(target_os = "macos")]
 mod platform_macos {
     use tauri::WebviewWindow;
 
-    pub async fn generate_pdf(window: &WebviewWindow, output_path: &str) -> Result<(), String> {
+    pub async fn generate_pdf(
+        window: &WebviewWindow,
+        output_path: &str,
+        page_count: u32,
+        page_w: f64,
+        page_h: f64,
+    ) -> Result<(), String> {
+        if page_count == 0 {
+            return Err("no pages to export".into());
+        }
+        let mut pages: Vec<Vec<u8>> = Vec::with_capacity(page_count as usize);
+        for i in 0..page_count {
+            pages.push(capture_page(window, f64::from(i) * page_h, page_w, page_h).await?);
+        }
+        let merged = unsafe { merge_pdfs(&pages) }?;
+        std::fs::write(output_path, &merged).map_err(|e| format!("write PDF: {e}"))
+    }
+
+    // Capture a single page-sized rect of the web content as a one-page PDF.
+    async fn capture_page(
+        window: &WebviewWindow,
+        y: f64,
+        w: f64,
+        h: f64,
+    ) -> Result<Vec<u8>, String> {
         let (tx, rx) = std::sync::mpsc::sync_channel::<Result<Vec<u8>, String>>(1);
-        let output = output_path.to_string();
 
         window
             .with_webview(move |wv| {
                 use block2::RcBlock;
                 use objc2::{msg_send, runtime::AnyObject};
+                use objc2_foundation::{NSPoint, NSRect, NSSize};
 
-                // wv.inner() is the raw WKWebView id pointer.
                 let webview = wv.inner() as *mut AnyObject;
-
-                // Allocate a WKPDFConfiguration with default settings.
                 let config: *mut AnyObject = unsafe {
                     let cls = objc2::runtime::AnyClass::get(c"WKPDFConfiguration")
                         .expect("WKPDFConfiguration");
                     msg_send![cls, new]
                 };
+                // rect is in the web view's coordinate space (top-left origin, CSS px).
+                let rect = NSRect::new(NSPoint::new(0.0, y), NSSize::new(w, h));
+                unsafe {
+                    let _: () = msg_send![config, setRect: rect];
+                }
 
                 let tx2 = tx.clone();
-                let block =
-                    RcBlock::new(move |data: *mut AnyObject, error: *mut AnyObject| {
-                        if !error.is_null() || data.is_null() {
-                            let _ = tx2.send(Err("WKWebView PDF creation failed".into()));
-                            return;
-                        }
-                        let bytes: Vec<u8> = unsafe {
-                            let len: usize = msg_send![data, length];
-                            let ptr: *const u8 = msg_send![data, bytes];
-                            std::slice::from_raw_parts(ptr, len).to_vec()
-                        };
-                        let _ = tx2.send(Ok(bytes));
-                    });
+                let block = RcBlock::new(move |data: *mut AnyObject, error: *mut AnyObject| {
+                    if !error.is_null() || data.is_null() {
+                        let _ = tx2.send(Err("WKWebView PDF creation failed".into()));
+                        return;
+                    }
+                    let bytes: Vec<u8> = unsafe {
+                        let len: usize = msg_send![data, length];
+                        let ptr: *const u8 = msg_send![data, bytes];
+                        std::slice::from_raw_parts(ptr, len).to_vec()
+                    };
+                    let _ = tx2.send(Ok(bytes));
+                });
 
                 unsafe {
                     let _: () = msg_send![
                         webview,
-                        createPDFWithConfiguration: config
+                        createPDFWithConfiguration: config,
                         completionHandler: &*block
                     ];
-                    // config was +1 from `new`; balance it now that the call has retained it.
                     let _: () = msg_send![config, release];
                 }
             })
             .map_err(|e| format!("with_webview: {e}"))?;
 
-        let bytes = tauri::async_runtime::spawn_blocking(move || {
+        tauri::async_runtime::spawn_blocking(move || {
             rx.recv_timeout(std::time::Duration::from_secs(60))
                 .map_err(|_| "PDF generation timed out".to_string())
                 .and_then(|r| r)
         })
         .await
-        .map_err(|e| format!("{e}"))??;
+        .map_err(|e| format!("{e}"))?
+    }
 
-        std::fs::write(&output, &bytes).map_err(|e| format!("write PDF: {e}"))
+    // Merge single-page PDFs into one document via PDFKit.
+    unsafe fn merge_pdfs(pages: &[Vec<u8>]) -> Result<Vec<u8>, String> {
+        use objc2::{class, msg_send, runtime::AnyObject};
+        use objc2_foundation::NSData;
+
+        let master: *mut AnyObject = msg_send![class!(PDFDocument), new];
+        let mut idx: usize = 0;
+        for bytes in pages {
+            let data = NSData::with_bytes(bytes);
+            let doc: *mut AnyObject = msg_send![class!(PDFDocument), alloc];
+            let doc: *mut AnyObject = msg_send![doc, initWithData: &*data];
+            if doc.is_null() {
+                let _: () = msg_send![master, release];
+                return Err("PDFDocument init failed".into());
+            }
+            let n: usize = msg_send![doc, pageCount];
+            for p in 0..n {
+                let page: *mut AnyObject = msg_send![doc, pageAtIndex: p];
+                if page.is_null() {
+                    continue;
+                }
+                // Copy the page so it survives releasing its source document.
+                let page_copy: *mut AnyObject = msg_send![page, copy];
+                let _: () = msg_send![master, insertPage: page_copy, atIndex: idx];
+                let _: () = msg_send![page_copy, release];
+                idx += 1;
+            }
+            let _: () = msg_send![doc, release];
+        }
+
+        let out: *mut AnyObject = msg_send![master, dataRepresentation];
+        if out.is_null() {
+            let _: () = msg_send![master, release];
+            return Err("PDFDocument dataRepresentation returned nil".into());
+        }
+        let len: usize = msg_send![out, length];
+        let ptr: *const u8 = msg_send![out, bytes];
+        let bytes = std::slice::from_raw_parts(ptr, len).to_vec();
+        let _: () = msg_send![master, release];
+        Ok(bytes)
     }
 }
 
@@ -1447,7 +1512,82 @@ mod platform_windows {
     }
 }
 
-// ── Linux: no native PDF backend ──────────────────────────────────────────────
-//
-// The export_pdf_native command returns "not yet implemented" on Linux so
-// App.tsx falls back to the PNG raster path via jsPDF.
+// ── Linux: WebKitPrintOperation → PDF file (paginates by @page) ───────────────
+
+#[cfg(target_os = "linux")]
+mod platform_linux {
+    use tauri::WebviewWindow;
+
+    pub async fn generate_pdf(
+        window: &WebviewWindow,
+        output_path: &str,
+        width_mm: f64,
+        height_mm: f64,
+    ) -> Result<(), String> {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Result<(), String>>(1);
+        let output = output_path.to_string();
+
+        window
+            .with_webview(move |wv| {
+                use webkit2gtk::{PrintOperation, PrintOperationExt};
+
+                const MM_TO_PT: f64 = 72.0 / 25.4;
+
+                // Custom paper at the exact (already-landscape) page size, no margins.
+                let paper = gtk::PaperSize::new_custom(
+                    "kova",
+                    "Kova",
+                    width_mm * MM_TO_PT,
+                    height_mm * MM_TO_PT,
+                    gtk::Unit::Points,
+                );
+                let page_setup = gtk::PageSetup::new();
+                page_setup.set_paper_size(&paper);
+                page_setup.set_top_margin(0.0, gtk::Unit::Points);
+                page_setup.set_bottom_margin(0.0, gtk::Unit::Points);
+                page_setup.set_left_margin(0.0, gtk::Unit::Points);
+                page_setup.set_right_margin(0.0, gtk::Unit::Points);
+                page_setup.set_orientation(gtk::PageOrientation::Portrait);
+
+                // Print straight to a PDF file — no dialog. The GTK file backend's
+                // "Print to File" printer must be named explicitly, else the
+                // operation fails with "Printer not found". filename_to_uri
+                // percent-encodes spaces / non-ASCII so ordinary paths work.
+                let uri = match gtk::glib::filename_to_uri(&output, None) {
+                    Ok(u) => u,
+                    Err(e) => {
+                        let _ = tx.send(Err(format!("bad output path: {e}")));
+                        return;
+                    }
+                };
+                let settings = gtk::PrintSettings::new();
+                settings.set("printer", Some("Print to File"));
+                settings.set("output-uri", Some(uri.as_str()));
+                settings.set("output-file-format", Some("pdf"));
+
+                let op = PrintOperation::new(&wv.inner());
+                op.set_page_setup(&page_setup);
+                op.set_print_settings(&settings);
+
+                let tx_done = tx.clone();
+                op.connect_finished(move |_| {
+                    let _ = tx_done.send(Ok(()));
+                });
+                let tx_err = tx.clone();
+                op.connect_failed(move |_, err| {
+                    let _ = tx_err.send(Err(format!("WebKit print failed: {err}")));
+                });
+
+                op.print();
+            })
+            .map_err(|e| format!("with_webview: {e}"))?;
+
+        tauri::async_runtime::spawn_blocking(move || {
+            rx.recv_timeout(std::time::Duration::from_secs(60))
+                .map_err(|_| "PDF generation timed out".to_string())
+                .and_then(|r| r)
+        })
+        .await
+        .map_err(|e| format!("{e}"))?
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,7 +99,6 @@ pub fn run() {
             commands::fetch_url_text,
             commands::confirm_exit,
             commands::take_pending_open,
-            commands::check_native_pdf,
             commands::export_pdf_native,
         ])
         .build(tauri::generate_context!())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ import { fetchUpdate } from './engine/updater';
 import { normalizePath } from './engine/resolvePath';
 import { exportToPptx } from './engine/export/exportPptx';
 import { exportToPdf, printPresentation } from './engine/export/exportPdf';
-import { exportPdfNative, buildPrintDocument } from './engine/export/exportPdfNative';
+import { exportPdfNative, buildPrintDocument, type PdfExportOpts } from './engine/export/exportPdfNative';
 import { SlideRenderer } from './components/preview/SlideRenderer';
 import { BUILT_IN_THEMES, DEFAULT_THEME, parseThemeYaml, sanitiseThemeOverrides, type ThemeParseResult } from './engine/theme';
 import { registerBundledFonts, registerCachedFont } from './engine/bundledFonts';
@@ -141,6 +141,9 @@ export default function App() {
   const [warnMessage, setWarnMessage]     = useState<string | null>(null);
   const warnTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [showExternalChangeDialog, setShowExternalChangeDialog] = useState(false);
+  const [pdfOptionsOpen, setPdfOptionsOpen] = useState(false);
+  const [pdfPerPage, setPdfPerPage]         = useState(1);
+  const [pdfNotesOn, setPdfNotesOn]         = useState(false);
   const [isRenaming, setIsRenaming]       = useState(false);
   const [renameValue, setRenameValue]     = useState('');
   const [resolvedUiTheme, setResolvedUiTheme] = useState<'dark' | 'light'>('dark');
@@ -1199,7 +1202,7 @@ export default function App() {
     }
   });
 
-  const handleExportPdf = useCallback(async () => {
+  const handleExportPdf = useCallback(async (opts: PdfExportOpts = {}) => {
     if (visibleSlides.length === 0) return;
     const defaultPath = filePath
       ? filePath.replace(/\.(md|markdown)$/i, '.pdf')
@@ -1210,12 +1213,6 @@ export default function App() {
     });
     if (!target) return;
     const savePath = target.toLowerCase().endsWith('.pdf') ? target : `${target}.pdf`;
-    // Determine native vs raster BEFORE mounting off-screen slides so the runner
-    // body contains no intermediate async IPC calls between element capture and
-    // exportToPdf — any await between the two gives React a chance to flush a
-    // pending update and unmount the slides, producing 0-width elements.
-    let useNative = false;
-    try { await invoke('check_native_pdf'); useNative = true; } catch { /* Linux or not supported */ }
 
     const visSlides = [...visibleSlides];
     pdfSlideRefs.current.clear();
@@ -1229,14 +1226,18 @@ export default function App() {
             (_, i) => pdfSlideRefs.current.get(i),
           ).filter((el): el is HTMLElement => Boolean(el));
 
-          if (useNative) {
-            await exportPdfNative(elements, aspectRatio, savePath);
-          } else {
+          try {
+            await exportPdfNative(elements, aspectRatio, savePath, opts);
+          } catch (nativeErr) {
+            // Native backend unavailable/failed — degrade to the raster renderer.
+            // It's one-slide-per-page and ignores handout/N-up/paper options.
+            console.error('Native PDF failed, falling back to raster:', nativeErr);
             const { base64, warnings } = await exportToPdf(elements, activeTheme, aspectRatio);
             await invoke('write_file_bytes', { path: savePath, data: base64 });
-            if (warnings.length > 0) {
-              window.alert(`PDF export complete with ${warnings.length} warning(s):\n\n${warnings.join('\n')}`);
-            }
+            window.alert(
+              `Used the basic PDF renderer (native export unavailable); handout/N-up/paper options were not applied.` +
+              (warnings.length ? `\n\n${warnings.join('\n')}` : ''),
+            );
           }
         } catch (err) {
           console.error('PDF export failed:', err);
@@ -1275,7 +1276,7 @@ export default function App() {
             (_, i) => pdfSlideRefs.current.get(i),
           ).filter((el): el is HTMLElement => Boolean(el));
 
-          const html = await buildPrintDocument(elements, aspectRatio);
+          const html = await buildPrintDocument(elements, aspectRatio, { fullBleed: true });
           await invoke('write_file', { path: savePath, content: html });
         } catch (err) {
           console.error('HTML export failed:', err);
@@ -1460,7 +1461,7 @@ export default function App() {
     importUrl: () => guardDirty(() => setShowImportUrl(true)),
     importMarp: handleImportMarp,
     export: handleExport,
-    exportPdf: handleExportPdf,
+    exportPdf: () => { setPdfPerPage(1); setPdfNotesOn(false); setPdfOptionsOpen(true); },
     exportHtml: handleExportHtml,
     print: handlePrint,
     present: () => { void handlePresentEnter(); },
@@ -1660,7 +1661,7 @@ export default function App() {
               <button className="btn-group-menu-item" disabled={slides.length === 0 || pdfExportContext !== null} onClick={() => { setFileMenuOpen(false); handleExport(); }}>
                 Export PowerPoint (.pptx)
               </button>
-              <button className="btn-group-menu-item" disabled={slides.length === 0 || pdfExportContext !== null} onClick={() => { setFileMenuOpen(false); handleExportPdf(); }}>
+              <button className="btn-group-menu-item" disabled={slides.length === 0 || pdfExportContext !== null} onClick={() => { setFileMenuOpen(false); setPdfPerPage(1); setPdfNotesOn(false); setPdfOptionsOpen(true); }}>
                 {pdfExportContext ? 'Exporting PDF…' : 'Export PDF (.pdf)'}
               </button>
               <button className="btn-group-menu-item" disabled={slides.length === 0 || pdfExportContext !== null} onClick={() => { setFileMenuOpen(false); handleExportHtml(); }}>
@@ -2012,6 +2013,59 @@ export default function App() {
                   OK
                 </button>
               )}
+            </div>
+          </div>
+        </>
+      )}
+
+      {pdfOptionsOpen && (
+        <>
+          <div style={{ position: 'fixed', inset: 0, background: 'var(--backdrop)', zIndex: 2000 }} onClick={() => setPdfOptionsOpen(false)} />
+          <div style={{
+            position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%,-50%)',
+            background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 8,
+            boxShadow: '0 16px 48px rgba(0,0,0,0.6)', zIndex: 2001,
+            padding: '24px 28px', width: 360, maxWidth: '90vw',
+          }}>
+            <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 16 }}>
+              Export PDF
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--text-label)', marginBottom: 8 }}>Slides per page</div>
+            <div style={{ display: 'flex', gap: 8, marginBottom: 20 }}>
+              {[1, 2, 4, 6].map((n) => (
+                <button
+                  key={n}
+                  className={pdfPerPage === n ? 'btn btn-primary' : 'btn'}
+                  style={{ flex: 1 }}
+                  onClick={() => { setPdfPerPage(n); if (n !== 1) setPdfNotesOn(false); }}
+                >{n}</button>
+              ))}
+            </div>
+            {(() => {
+              const hasNotes = visibleSlides.some((s) => s.speakerNotes.trim());
+              const notesOk = pdfPerPage === 1 && hasNotes;
+              return (
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: notesOk ? 'var(--text-primary)' : 'var(--text-secondary)', opacity: notesOk ? 1 : 0.5, marginBottom: 20 }}>
+                  <input
+                    type="checkbox"
+                    checked={notesOk && pdfNotesOn}
+                    disabled={!notesOk}
+                    onChange={(e) => setPdfNotesOn(e.target.checked)}
+                  />
+                  Include speaker notes (handout){pdfPerPage === 1 && !hasNotes ? ' — none in this deck' : ''}
+                </label>
+              );
+            })()}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <button className="btn" onClick={() => setPdfOptionsOpen(false)}>Cancel</button>
+              <button
+                className="btn btn-primary"
+                onClick={() => {
+                  setPdfOptionsOpen(false);
+                  const notes = pdfPerPage === 1 && pdfNotesOn ? visibleSlides.map((s) => s.speakerNotes) : undefined;
+                  void handleExportPdf({ perPage: pdfPerPage, notes, paper: settings.pdfPageSize });
+                }}
+              >Export</button>
             </div>
           </div>
         </>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -585,6 +585,23 @@ export function SettingsModal({ settings, availableUpdate, allThemes, isDirty, s
           </div>
         </div>
 
+        <div style={{ padding: '10px 0' }}>
+          <div style={{ fontSize: 13, color: 'var(--text-primary)', marginBottom: 4 }}>PDF page size</div>
+          <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 10, lineHeight: 1.5 }}>
+            Paper size for PDF export. Pages are laid out landscape.
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            {([
+              { value: 'a4',     label: 'A4'     },
+              { value: 'letter', label: 'Letter' },
+            ] as { value: AppSettings['pdfPageSize']; label: string }[]).map(({ value, label }) => (
+              <button key={value} type="button" onClick={() => set('pdfPageSize', value)}
+                style={groupBtnStyle(settings.pdfPageSize === value)}
+              >{label}</button>
+            ))}
+          </div>
+        </div>
+
         {/* Presentation */}
         <Section label="Presentation" />
 

--- a/src/engine/export/__tests__/pdfLayout.test.ts
+++ b/src/engine/export/__tests__/pdfLayout.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { nupCols, notesEnabled, planPage } from '../pdfLayout';
+
+const AR = { w: 16, h: 9 };
+
+describe('pdfLayout', () => {
+  it('picks grid columns per sheet size', () => {
+    expect(nupCols(1)).toBe(1);
+    expect(nupCols(2)).toBe(2);
+    expect(nupCols(4)).toBe(2);
+    expect(nupCols(6)).toBe(3);
+  });
+
+  it('enables notes only at 1-up with a non-empty note', () => {
+    expect(notesEnabled({ perPage: 1, notes: ['hi'] })).toBe(true);
+    expect(notesEnabled({ perPage: 1, notes: ['', '  '] })).toBe(false);
+    expect(notesEnabled({ perPage: 4, notes: ['hi'] })).toBe(false);
+    expect(notesEnabled({})).toBe(false);
+  });
+
+  it('lays A4 out landscape by default', () => {
+    const p = planPage(AR, { perPage: 1 });
+    expect(p.mode).toBe('single');
+    expect([p.pageWmm, p.pageHmm]).toEqual([297, 210]); // A4 landscape
+    expect(p.pageWpx).toBeGreaterThan(p.pageHpx);
+    expect(p.cols).toBe(1);
+  });
+
+  it('honours Letter paper', () => {
+    const p = planPage(AR, { perPage: 1, paper: 'letter' });
+    expect([p.pageWmm, p.pageHmm]).toEqual([279, 216]);
+  });
+
+  it('scales a slide to fit its cell without overflow', () => {
+    const p = planPage(AR, { perPage: 4 });
+    expect(p.mode).toBe('nup');
+    expect(p.cols).toBe(2);
+    expect(p.rows).toBe(2);
+    expect(960 * p.slideScale).toBeLessThanOrEqual(p.cellWpx + 0.01);
+    expect(p.slideNativeHpx * p.slideScale).toBeLessThanOrEqual(p.cellHpx + 0.01);
+  });
+
+  it('reserves a notes band below the slide', () => {
+    const p = planPage(AR, { perPage: 1, notes: ['speaker note'] });
+    expect(p.mode).toBe('notes');
+    expect(p.notesTopPx).toBeGreaterThan(p.marginPx);
+    expect(p.notesTopPx).toBeLessThan(p.pageHpx - p.marginPx);
+  });
+});

--- a/src/engine/export/exportPdfNative.ts
+++ b/src/engine/export/exportPdfNative.ts
@@ -2,11 +2,9 @@ import { invoke } from '@tauri-apps/api/core';
 import type { AspectRatio } from '../types';
 import { mermaidSvgCache } from './mermaidSvgCache';
 import { imageMime } from './imageMime';
+import { type PdfExportOpts, planPage, SLIDE_PX_W } from './pdfLayout';
 
-// At 96 CSS DPI: 254mm = 960px exactly. Slides are rendered off-screen at 960px
-// wide, so this page size maps one-to-one with no scaling required.
-const PDF_W_MM  = 254;
-const SLIDE_PX_W = 960;
+export type { PdfExportOpts };
 
 // ── Public entry point ───────────────────────────────────────────────────────
 
@@ -14,13 +12,21 @@ export async function exportPdfNative(
   slideElements: HTMLElement[],
   aspectRatio: AspectRatio,
   savePath: string,
+  opts: PdfExportOpts = {},
 ): Promise<void> {
-  const html = await buildPrintDocument(slideElements, aspectRatio);
+  const html = await buildPrintDocument(slideElements, aspectRatio, opts);
+  const plan = planPage(aspectRatio, opts);
+  const perPage = opts.perPage ?? 1;
+  const pageCount = perPage > 1 ? Math.ceil(slideElements.length / perPage) : slideElements.length;
   await invoke('export_pdf_native', {
     htmlContent: html,
     outputPath: savePath,
-    widthMm: PDF_W_MM,
-    heightMm: pageMm(aspectRatio),
+    widthMm: plan.pageWmm,
+    heightMm: plan.pageHmm,
+    // Per-page capture rects for the macOS path (one createPDF per page, then merge).
+    pageCount,
+    pageWidthPx: plan.pageWpx,
+    pageHeightPx: plan.pageHpx,
   });
 }
 
@@ -29,9 +35,10 @@ export async function exportPdfNative(
 export async function buildPrintDocument(
   slideElements: HTMLElement[],
   aspectRatio: AspectRatio,
+  opts: PdfExportOpts = {},
 ): Promise<string> {
-  const slideH = Math.round(SLIDE_PX_W * aspectRatio.h / aspectRatio.w);
-  const H_MM   = pageMm(aspectRatio);
+  const plan = planPage(aspectRatio, opts);
+  const perPage = opts.perPage ?? 1;
 
   // Read slide background color from the live DOM before cloning.
   const slideFrame = slideElements[0]?.querySelector('.slide-frame');
@@ -50,10 +57,29 @@ export async function buildPrintDocument(
   // 2. Extract all document CSS with font URLs resolved to data URIs.
   const css = await extractAllCss();
 
-  // 3. Assemble the final HTML document.
-  const pages = clones
-    .map((el) => `<div class="kova-page">${el.outerHTML}</div>`)
-    .join('\n');
+  // Each slide is a 960×native box scaled into a frame sized to the slide's own
+  // proportions (so the N-up border hugs the slide), centred in its slot.
+  const slot = (el: HTMLElement) =>
+    `<div class="kova-slot"><div class="kova-frame"><div class="kova-scale">${el.outerHTML}</div></div></div>`;
+
+  // 3. Assemble pages — slides scaled/centred onto a standard paper page.
+  let pages: string;
+  if (plan.mode === 'nup') {
+    const sheets: HTMLElement[][] = [];
+    for (let i = 0; i < clones.length; i += perPage) sheets.push(clones.slice(i, i + perPage));
+    pages = sheets.map((sheet) =>
+      `<div class="kova-page"><div class="kova-content kova-grid">${sheet.map(slot).join('')}</div></div>`,
+    ).join('\n');
+  } else if (plan.mode === 'notes') {
+    pages = clones.map((el, i) => {
+      const note = escapeHtml((opts.notes?.[i] ?? '').trim());
+      return `<div class="kova-page"><div class="kova-content kova-col">${slot(el)}<div class="kova-notes">${note}</div></div></div>`;
+    }).join('\n');
+  } else {
+    pages = clones.map((el) =>
+      `<div class="kova-page"><div class="kova-content kova-center">${slot(el)}</div></div>`,
+    ).join('\n');
+  }
 
   const bgCss = slideBg ? `background: ${slideBg} !important;` : '';
 
@@ -64,7 +90,7 @@ export async function buildPrintDocument(
 <style>
 ${css}
 @page {
-  size: ${PDF_W_MM}mm ${H_MM}mm;
+  size: ${plan.pageWmm}mm ${plan.pageHmm}mm;
   margin: 0;
 }
 *, *::before, *::after {
@@ -91,21 +117,73 @@ html, body {
   max-height: none !important;
   overflow: visible !important;
   zoom: 1 !important;
-  ${bgCss}
 }
 .kova-page {
   display: block !important;
-  width: ${SLIDE_PX_W}px !important;
-  height: ${slideH}px !important;
+  width: ${plan.pageWpx}px !important;
+  height: ${plan.pageHpx}px !important;
   overflow: hidden !important;
   break-after: page;
   page-break-after: always;
   position: relative !important;
   margin: 0 !important;
+  background: ${slideBg || '#fff'} !important;
 }
 .kova-page:last-child {
   break-after: avoid;
   page-break-after: avoid;
+}
+.kova-content {
+  position: absolute !important;
+  inset: ${plan.marginPx}px !important;
+  box-sizing: border-box !important;
+}
+.kova-center { display: flex !important; align-items: center !important; justify-content: center !important; }
+.kova-col    { display: flex !important; flex-direction: column !important; }
+.kova-grid {
+  display: grid !important;
+  grid-template-columns: repeat(${plan.cols}, ${plan.cellWpx}px) !important;
+  grid-auto-rows: ${plan.cellHpx}px !important;
+  gap: ${plan.gapPx}px !important;
+  align-content: center !important;
+  justify-content: center !important;
+}
+.kova-slot {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  overflow: hidden !important;
+}
+.kova-grid .kova-slot { width: ${plan.cellWpx}px !important; height: ${plan.cellHpx}px !important; }
+.kova-col  .kova-slot { width: 100% !important; height: ${plan.cellHpx}px !important; flex: 0 0 auto !important; }
+.kova-center .kova-slot { width: 100% !important; height: 100% !important; }
+.kova-frame {
+  position: relative !important;
+  box-sizing: border-box !important;
+  width: ${SLIDE_PX_W * plan.slideScale}px !important;
+  height: ${plan.slideNativeHpx * plan.slideScale}px !important;
+  overflow: hidden !important;
+  flex: 0 0 auto !important;
+  ${bgCss}
+}
+.kova-grid .kova-frame { border: 1px solid #c8c8c8 !important; }
+.kova-scale {
+  width: ${SLIDE_PX_W}px !important;
+  height: ${plan.slideNativeHpx}px !important;
+  transform: scale(${plan.slideScale}) !important;
+  transform-origin: top left !important;
+}
+.kova-notes {
+  flex: 1 1 auto !important;
+  box-sizing: border-box !important;
+  margin-top: ${plan.gapPx}px !important;
+  padding: 20px 24px !important;
+  font: 18px/1.55 -apple-system, system-ui, sans-serif !important;
+  color: #111 !important;
+  background: #fff !important;
+  white-space: pre-wrap !important;
+  overflow: hidden !important;
+  border-top: 2px solid #999 !important;
 }
 </style>
 </head>
@@ -247,8 +325,8 @@ async function resolveFontUrls(css: string): Promise<string> {
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 
-function pageMm(ar: AspectRatio): number {
-  return Math.round((PDF_W_MM * ar.h / ar.w) * 100) / 100;
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>]/g, (c) => (c === '&' ? '&amp;' : c === '<' ? '&lt;' : '&gt;'));
 }
 
 function blobToDataUrl(blob: Blob): Promise<string> {

--- a/src/engine/export/pdfLayout.ts
+++ b/src/engine/export/pdfLayout.ts
@@ -1,0 +1,105 @@
+// Layout math for PDF export. Slides render at 960px wide off-screen; here we
+// scale/centre them onto a standard paper page (A4/Letter, landscape). Pure (no
+// DOM) so it's unit-tested.
+import type { AspectRatio } from '../types';
+
+export type PaperSize = 'a4' | 'letter';
+
+export interface PdfExportOpts {
+  perPage?: number;                 // slides per page: 1 (default), 2, 4, 6
+  notes?: (string | undefined)[];   // speaker notes per slide; enables handout at 1-up
+  paper?: PaperSize;                // default 'a4'
+  fullBleed?: boolean;              // page = slide size, no margins (HTML export)
+}
+
+export const SLIDE_PX_W = 960;
+const PX_PER_MM  = 96 / 25.4;       // 96 CSS DPI
+const MARGIN_MM  = 10;
+const GAP_MM     = 6;               // gap between N-up cells / slide↔notes
+const NOTES_FRAC = 0.32;            // share of content height for the notes band
+
+// Portrait dimensions (mm); pages are laid out landscape.
+const PAPER: Record<PaperSize, { w: number; h: number }> = {
+  a4:     { w: 210, h: 297 },
+  letter: { w: 216, h: 279 },
+};
+
+function slideHeightPx(ar: AspectRatio): number {
+  return Math.round(SLIDE_PX_W * ar.h / ar.w);
+}
+
+// Grid columns for an N-up sheet: 2→2×1, 4→2×2, 6→3×2.
+export function nupCols(perPage: number): number {
+  if (perPage <= 1) return 1;
+  if (perPage <= 2) return 2;
+  return perPage <= 4 ? 2 : 3;
+}
+
+// Notes handout only applies at 1-per-page with at least one non-empty note.
+export function notesEnabled(opts: PdfExportOpts): boolean {
+  return (opts.perPage ?? 1) <= 1 && !!opts.notes?.some((n) => n && n.trim());
+}
+
+export interface PagePlan {
+  mode: 'single' | 'nup' | 'notes';
+  pageWpx: number; pageHpx: number;   // physical page in px (landscape)
+  pageWmm: number; pageHmm: number;   // physical page in mm (landscape)
+  marginPx: number; gapPx: number;
+  cols: number; rows: number;
+  cellWpx: number; cellHpx: number;   // area a slide is scaled into
+  slideNativeHpx: number;
+  slideScale: number;                 // scale to fit 960×slideH into a cell
+  notesTopPx: number;                 // notes mode: y of the divider; else 0
+}
+
+export function planPage(ar: AspectRatio, opts: PdfExportOpts): PagePlan {
+  // Full-bleed: page = slide, no margins (HTML export keeps the old behaviour).
+  if (opts.fullBleed) {
+    const sh = slideHeightPx(ar);
+    return {
+      mode: 'single',
+      pageWpx: SLIDE_PX_W, pageHpx: sh,
+      pageWmm: 254, pageHmm: Math.round(sh * 254 / SLIDE_PX_W * 100) / 100,
+      marginPx: 0, gapPx: 0, cols: 1, rows: 1,
+      cellWpx: SLIDE_PX_W, cellHpx: sh, slideNativeHpx: sh, slideScale: 1, notesTopPx: 0,
+    };
+  }
+  const paper = PAPER[opts.paper ?? 'a4'];
+  // Landscape: slides are wide, so swap paper w/h.
+  const pageWmm = paper.h, pageHmm = paper.w;
+  const pageWpx = Math.round(pageWmm * PX_PER_MM);
+  const pageHpx = Math.round(pageHmm * PX_PER_MM);
+  const marginPx = Math.round(MARGIN_MM * PX_PER_MM);
+  const gapPx = Math.round(GAP_MM * PX_PER_MM);
+  const slideNativeHpx = slideHeightPx(ar);
+
+  const contentW = pageWpx - 2 * marginPx;
+  const contentH = pageHpx - 2 * marginPx;
+
+  const perPage = opts.perPage ?? 1;
+
+  let mode: PagePlan['mode'] = 'single';
+  let cols = 1, rows = 1;
+  let cellWpx = contentW, cellHpx = contentH;
+  let notesTopPx = 0;
+
+  if (perPage > 1) {
+    mode = 'nup';
+    cols = nupCols(perPage);
+    rows = Math.ceil(perPage / cols);
+    cellWpx = (contentW - gapPx * (cols - 1)) / cols;
+    cellHpx = (contentH - gapPx * (rows - 1)) / rows;
+  } else if (notesEnabled(opts)) {
+    mode = 'notes';
+    const notesH = Math.round(contentH * NOTES_FRAC);
+    cellHpx = contentH - notesH - gapPx;   // slide area above the divider
+    notesTopPx = marginPx + cellHpx + gapPx;
+  }
+
+  const slideScale = Math.min(cellWpx / SLIDE_PX_W, cellHpx / slideNativeHpx);
+
+  return {
+    mode, pageWpx, pageHpx, pageWmm, pageHmm, marginPx, gapPx,
+    cols, rows, cellWpx, cellHpx, slideNativeHpx, slideScale, notesTopPx,
+  };
+}

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -50,6 +50,8 @@ export interface AppSettings {
   editorWordWrap: boolean;
   // Presentation defaults
   defaultThemeId: string;
+  // Export
+  pdfPageSize: 'a4' | 'letter';
   // Startup
   startupBehavior: StartupBehavior;
 }
@@ -76,6 +78,7 @@ function buildDefaults(): AppSettings {
     showFrontmatter: false,
     editorWordWrap: true,
     defaultThemeId: 'light',
+    pdfPageSize: 'a4',
     // Preserves existing behaviour (always launch blank) for anyone upgrading
     // — this only changes anything for users who explicitly opt in.
     startupBehavior: 'blank',


### PR DESCRIPTION
Closes #89.

**Export PDF** dialog: slides per page (1 / 2 / 4 / 6) and a speaker-notes handout (1-up). Paper size (A4 default / Letter) in Settings ▸ PDF page size.

- Slides scale/centre onto standard landscape pages.
- Notes handout: slide + notes band with a divider rule.
- N-up: grid with a per-slide border framed to the slide's proportions.

One shared self-contained print HTML, paginated natively per OS:
- **macOS** — per-page `createPDF` rect merged with PDFKit (`createPDF` alone snapshots one page; `NSPrintOperation.runOperation` blocks the main thread).
- **Windows** — WebView2 `PrintToPdf`.
- **Linux** — `WebKitPrintOperation` → PDF file.

Layout math is pure + unit-tested; tsc clean; Rust builds on macOS and Linux.

**Verified:** macOS live (1-up / N-up / notes); Linux headless (xvfb + webkit2gtk 4.1) → A4-landscape, backgrounds + text intact. Windows compiles via the existing `PrintToPdf` path, not yet run.