### PR TITLE
fix(editor): don't mark CRLF files dirty on open (#95)

### DIFF
--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -995,12 +995,16 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
     return () => el.removeEventListener('wheel', handler);
   }, []);
 
-  // Sync external content changes
+  // Sync external content changes. CodeMirror normalises \r\n→\n internally, so
+  // a CRLF file on disk always "differs" from the LF doc — ignore CR-only diffs,
+  // else opening an unedited CRLF file fires a spurious change (issue #95).
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
     const current = view.state.doc.toString();
-    if (current !== content) {
+    // `current !== content` is the fast path (equal on every keystroke); only
+    // when they differ do we pay the CRLF-normalising compare.
+    if (current !== content && current !== content.replace(/\r\n/g, '\n')) {
       view.dispatch({ changes: { from: 0, to: current.length, insert: content } });
     }
   }, [content]);


### PR DESCRIPTION
Closes #95.

Opening an unedited CRLF file (Windows) showed the dirty asterisk and prompted to save on exit.

CodeMirror normalises `\r\n`→`\n` internally, so a CRLF file read from disk always differs from the editor doc. The content-sync effect saw that diff, dispatched an insert → `onChange` → dirty, the moment the file opened. LF files matched, so it was Windows-only.

Fix: ignore CR-only differences in the sync check (`EditorPanel.tsx`). Line endings on disk are untouched.

tsc clean. Not unit-tested — the fix is one predicate inside a CodeMirror effect that needs a DOM/editor harness; verified by tracing the open path.