### PR TITLE
test: cover pdfLayout fullBleed mode

### DIFF
--- a/src/engine/export/__tests__/pdfLayout.test.ts
+++ b/src/engine/export/__tests__/pdfLayout.test.ts
@@ -46,4 +46,17 @@ describe('pdfLayout', () => {
     expect(p.notesTopPx).toBeGreaterThan(p.marginPx);
     expect(p.notesTopPx).toBeLessThan(p.pageHpx - p.marginPx);
   });
+
+  it('fullBleed sets page size to the slide with no margins and unit scale', () => {
+    const p = planPage(AR, { fullBleed: true });
+    expect(p.mode).toBe('single');
+    expect(p.marginPx).toBe(0);
+    expect(p.gapPx).toBe(0);
+    expect(p.pageWpx).toBe(960);
+    expect(p.slideNativeHpx).toBe(540);
+    expect(p.pageHpx).toBe(540);
+    expect(p.slideScale).toBe(1);
+    expect(p.cols).toBe(1);
+    expect(p.rows).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- `planPage` `fullBleed` path was untested (HTML export uses page = slide size, no margins)
- Asserts `mode: single`, zero `marginPx`/`gapPx`, `pageWpx: 960`, `pageHpx: 540` for 16:9, and `slideScale: 1`

## Test plan
- [x] `npm test -- --run src/engine/export/__tests__/pdfLayout.test.ts` — 7 tests pass