### PR TITLE
test: cover extractWords tilde fences and Unicode

### DIFF
--- a/src/engine/__tests__/spellCheckExtension.test.ts
+++ b/src/engine/__tests__/spellCheckExtension.test.ts
@@ -71,4 +71,25 @@ describe('extractWords', () => {
     expect(ranges[0]).toEqual({ from: 0, to: 4, word: 'Line' });
     expect(ranges[ranges.length - 1]).toEqual({ from: 14, to: 17, word: 'two' });
   });
+
+  it('skips words inside tilde-fenced code blocks', () => {
+    const doc = [
+      'Intro text',
+      '~~~',
+      'const hello = 1',
+      'function world() {}',
+      '~~~',
+      'After code',
+    ].join('\n');
+    expect(words(doc)).toEqual(['Intro', 'text', 'After', 'code']);
+  });
+
+  it('extracts accented Unicode letters', () => {
+    expect(words('café résumé über')).toEqual(['café', 'résumé', 'über']);
+  });
+
+  it('treats a standalone ??? line as containing no words', () => {
+    const doc = 'Before notes\n???\nAfter notes';
+    expect(words(doc)).toEqual(['Before', 'notes', 'After', 'notes']);
+  });
 });


### PR DESCRIPTION
## Summary
- Extends `spellCheckExtension.test.ts` with three gaps in `extractWords()`:
  - Words inside `~~~` tilde-fenced code blocks are skipped (backtick fences were already covered)
  - Accented Unicode letters (`café`, `über`) are extracted via `\p{L}`
  - A standalone `???` line contributes no words; surrounding text is still extracted

## Test plan
- [x] `npm test -- --run src/engine/__tests__/spellCheckExtension.test.ts` — 13 tests pass