### PR TITLE
feat: Table of Contents slide discoverability (!toc)

### DIFF
--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -1250,6 +1250,11 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
           { type: 'item', label: 'Math/LaTeX Block', action: () => doInsert('$$\nE = mc^2\n$$', 3) },
           { type: 'item', label: 'Speaker Notes',   action: () => doInsert('\n\n???\n\n', 7) },
           { type: 'item', label: 'Reference',       action: () => doInsert('!ref[]', 5) },
+          {
+            type: 'item',
+            label: 'Table of Contents',
+            action: () => doInsert('## Agenda\n\n!toc\n', 3),
+          },
         ],
       },
       { type: 'divider' },
@@ -1340,6 +1345,7 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
             <span style={{ fontSize: 28, opacity: 0.3 }}>📄</span>
             <span>{mod}+N — new presentation</span>
             <span>{mod}+O — open file</span>
+            <span>Right-click → Insert → Table of Contents</span>
           </div>
         )}
       </div>

--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -404,6 +404,30 @@ describe('custom syntax pre-processor', () => {
   });
 });
 
+// ── Table of contents (!toc) ────────────────────────────────────────────────
+
+describe('!toc table of contents', () => {
+  it('parses a standalone !toc line as a toc element', () => {
+    const { slides } = parseDocument(doc('## Agenda\n\n!toc\n'));
+    const toc = slides[0].elements.find((e) => e.type === 'toc');
+    expect(toc?.type === 'toc' && toc.entries).toEqual([]);
+  });
+
+  it('does not parse !toc inside a code fence', () => {
+    const { slides } = parseDocument(doc('## Slide\n\n```\n!toc\n```\n'));
+    expect(slides[0].elements.some((e) => e.type === 'toc')).toBe(false);
+    const code = slides[0].elements.find((e) => e.type === 'code');
+    expect(code?.type === 'code' && code.value).toContain('!toc');
+  });
+
+  it('treats a malformed !toc variant as plain text', () => {
+    const { slides } = parseDocument(doc('## Slide\n\n!toc[Agenda]\n'));
+    expect(slides[0].elements.some((e) => e.type === 'toc')).toBe(false);
+    const para = slides[0].elements.find((e) => e.type === 'paragraph');
+    expect(para?.type === 'paragraph' && para.text).toContain('!toc');
+  });
+});
+
 // ── Academic references (!ref) ────────────────────────────────────────────────
 
 describe('!ref academic references', () => {


### PR DESCRIPTION
## Summary
- `!toc` already worked end-to-end (parser, preview, PPTX export, entry resolution in App) but was undiscoverable
- **Insert → Table of Contents** inserts an Agenda slide (`## Agenda` + `!toc`) in one click
- Empty-editor placeholder hints: Right-click → Insert → Table of Contents
- Parser tests: standalone `!toc` → `toc` element, skipped inside code fences, malformed variants fall back to plain text

## Test plan
- [x] `npm test -- --run src/engine/__tests__/parser.test.ts` — 70 tests pass
- [x] Manual: right-click editor → Insert → Table of Contents → preview shows numbered list of titled slides (excluding cover H1)