### PR TITLE
fix(editor): also normalise lone \r line endings in CRLF dirty-check

### DIFF
--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -1003,8 +1003,9 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
     if (!view) return;
     const current = view.state.doc.toString();
     // `current !== content` is the fast path (equal on every keystroke); only
-    // when they differ do we pay the CRLF-normalising compare.
-    if (current !== content && current !== content.replace(/\r\n/g, '\n')) {
+    // when they differ do we pay the line-ending-normalising compare. CodeMirror
+    // collapses lone \r as well as \r\n, so both must be normalised here too.
+    if (current !== content && current !== content.replace(/\r\n/g, '\n').replace(/\r/g, '\n')) {
       view.dispatch({ changes: { from: 0, to: current.length, insert: content } });
     }
   }, [content]);


### PR DESCRIPTION
## Summary
- Follow-up to #96 (issue #95). That fix only stripped `\r\n` pairs when comparing the loaded file content to CodeMirror's normalised doc string, missing files that use lone `\r` (classic Mac) line endings — the same false-dirty bug would still trigger for those.
- Normalises both `\r\n` and lone `\r`, matching the two-step normalisation already used elsewhere in this file (paste handler) and in markdownToSlides.ts.
- This commit already existed on the `fix/crlf-false-dirty` branch but was pushed after #96 merged, so it never made it into `main`. Cherry-picked here onto its own branch off current `main`.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manually open a file with lone-`\r` line endings and confirm no dirty asterisk appears