### PR TITLE
feat(keybindings): add hide/show slide shortcut

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -696,13 +696,14 @@ const DEFAULT_KEYBINDINGS: &str = "\
 # Modifiers (combine with +):  ctrl  shift  alt
 #
 # Available actions:
-#   new_file    open_file    save    save_as    focus_mode
+#   new_file    open_file    save    save_as    focus_mode    hide_slide
 
 new_file:   ctrl+n
 open_file:  ctrl+o
 save:       ctrl+s
 save_as:    ctrl+shift+s
 focus_mode: ctrl+shift+f
+hide_slide: ctrl+shift+h
 ";
 
 /// Reads keybindings.yaml from the platform config dir, creating it from defaults if absent.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1546,10 +1546,14 @@ export default function App() {
       if (matchShortcut(e, sc('save')))      { e.preventDefault(); if (filePath) handleSave(); else handleSaveAs(); }
       if (matchShortcut(e, sc('saveAs')))    { e.preventDefault(); handleSaveAs(); }
       if (matchShortcut(e, sc('focusMode'))) { e.preventDefault(); toggleFocusMode(); }
+      if (matchShortcut(e, sc('hideSlide')) && slides.length > 0) {
+        e.preventDefault();
+        handleToggleHidden(safeSlideIndex);
+      }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [presentMode, keybindings.combos, filePath, handleNewFile, handleOpenFile, handleSave, handleSaveAs, toggleFocusMode, handlePresentEnter]);
+  }, [presentMode, keybindings.combos, filePath, slides.length, safeSlideIndex, handleNewFile, handleOpenFile, handleSave, handleSaveAs, toggleFocusMode, handlePresentEnter, handleToggleHidden]);
 
   // Close menus when the user clicks outside them.
   useEffect(() => {

--- a/src/engine/__tests__/keybindings.test.ts
+++ b/src/engine/__tests__/keybindings.test.ts
@@ -149,6 +149,7 @@ describe('getCombo', () => {
 
   it('falls back to default combo when user has not customised', () => {
     expect(getCombo({}, 'save')).toBe(DEFAULT_COMBOS.save);
+    expect(getCombo({}, 'hideSlide')).toBe('ctrl+shift+h');
   });
 
   it('falls back to empty string for unknown action', () => {
@@ -165,7 +166,7 @@ describe('getCombo', () => {
 
 describe('DEFAULT_COMBOS', () => {
   it('defines all expected actions', () => {
-    const expected = ['newFile', 'openFile', 'save', 'saveAs', 'focusMode'];
+    const expected = ['newFile', 'openFile', 'save', 'saveAs', 'focusMode', 'hideSlide'];
     for (const action of expected) {
       expect(DEFAULT_COMBOS[action], action).toBeTruthy();
     }

--- a/src/engine/keybindings.ts
+++ b/src/engine/keybindings.ts
@@ -13,6 +13,7 @@ const KEY_MAP: Record<string, string> = {
   save:       'save',
   save_as:    'saveAs',
   focus_mode: 'focusMode',
+  hide_slide: 'hideSlide',
 };
 
 export const DEFAULT_COMBOS: Record<string, string> = {
@@ -21,6 +22,7 @@ export const DEFAULT_COMBOS: Record<string, string> = {
   save:      'ctrl+s',
   saveAs:    'ctrl+shift+s',
   focusMode: 'ctrl+shift+f',
+  hideSlide: 'ctrl+shift+h',
 };
 
 export interface Keybindings {


### PR DESCRIPTION
## Summary
- Adds **Ctrl+Shift+H** (customisable via `hide_slide` in `keybindings.yaml`) to toggle `<!-- hidden -->` on the current slide
- Mirrors the existing thumbnail context-menu action from the keyboard

## Test plan
- [x] Select a slide and press Ctrl+Shift+H — slide is hidden (dimmed in thumbnails, skipped in presentation)
- [x] Press again — slide is shown
- [x] Customise `hide_slide` in keybindings.yaml and confirm the new combo works after restart