### PR TITLE
feat(export): add 3 slides per page to PDF export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2060,7 +2060,7 @@ export default function App() {
             </div>
             <div style={{ fontSize: 12, color: 'var(--text-label)', marginBottom: 8 }}>Slides per page</div>
             <div style={{ display: 'flex', gap: 8, marginBottom: 20 }}>
-              {[1, 2, 4, 6].map((n) => (
+              {[1, 2, 3, 4, 6].map((n) => (
                 <button
                   key={n}
                   className={pdfPerPage === n ? 'btn btn-primary' : 'btn'}

--- a/src/engine/export/__tests__/pdfLayout.test.ts
+++ b/src/engine/export/__tests__/pdfLayout.test.ts
@@ -7,6 +7,7 @@ describe('pdfLayout', () => {
   it('picks grid columns per sheet size', () => {
     expect(nupCols(1)).toBe(1);
     expect(nupCols(2)).toBe(2);
+    expect(nupCols(3)).toBe(2);
     expect(nupCols(4)).toBe(2);
     expect(nupCols(6)).toBe(3);
   });
@@ -38,6 +39,13 @@ describe('pdfLayout', () => {
     expect(p.rows).toBe(2);
     expect(960 * p.slideScale).toBeLessThanOrEqual(p.cellWpx + 0.01);
     expect(p.slideNativeHpx * p.slideScale).toBeLessThanOrEqual(p.cellHpx + 0.01);
+  });
+
+  it('lays out 3-up as a 2×2 grid with two columns', () => {
+    const p = planPage(AR, { perPage: 3 });
+    expect(p.mode).toBe('nup');
+    expect(p.cols).toBe(2);
+    expect(p.rows).toBe(2);
   });
 
   it('reserves a notes band below the slide', () => {

--- a/src/engine/export/pdfLayout.ts
+++ b/src/engine/export/pdfLayout.ts
@@ -6,7 +6,7 @@ import type { AspectRatio } from '../types';
 export type PaperSize = 'a4' | 'letter';
 
 export interface PdfExportOpts {
-  perPage?: number;                 // slides per page: 1 (default), 2, 4, 6
+  perPage?: number;                 // slides per page: 1 (default), 2, 3, 4, 6
   notes?: (string | undefined)[];   // speaker notes per slide; enables handout at 1-up
   paper?: PaperSize;                // default 'a4'
   fullBleed?: boolean;              // page = slide size, no margins (HTML export)


### PR DESCRIPTION
## Summary
- Adds **3** to the PDF export dialog's "Slides per page" options (alongside 1, 2, 4, 6)
- Uses the existing 2×2 N-up grid in `pdfLayout.ts` (third cell on second row unused)
- Adds `nupCols(3)` and `planPage({ perPage: 3 })` tests

## Test plan
- [x] File → Export → PDF — select **3** slides per page and export
- [x] Confirm PDF shows three slides per sheet in a 2-column layout
- [x] Speaker notes checkbox remains disabled when not at 1-up