### PR TITLE
feat(editor): add YouTube and Poll to Insert menu

### DIFF
--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -1253,6 +1253,16 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
           { type: 'item', label: 'Reference',       action: () => doInsert('!ref[]', 5) },
           {
             type: 'item',
+            label: 'YouTube Video',
+            action: () => doInsert('\n!youtube[My Video](https://youtu.be/VIDEO_ID)\n', 10),
+          },
+          {
+            type: 'item',
+            label: 'Poll (Poll Everywhere)',
+            action: () => doInsert('\n!poll[Vote here](https://pollev.com/your-poll)\n', 7),
+          },
+          {
+            type: 'item',
             label: 'Table of Contents',
             action: () => doInsert('## Agenda\n\n!toc\n', 3),
           },


### PR DESCRIPTION
## Summary
- Adds **Insert → YouTube Video** — inserts `!youtube[My Video](https://youtu.be/VIDEO_ID)` with cursor on the label
- Adds **Insert → Poll (Poll Everywhere)** — inserts `!poll[Vote here](https://pollev.com/your-poll)` with cursor on the label
- Parser and renderer already support both directives; this improves discoverability (same pattern as Table of Contents)

## Test plan
- [x] Right-click in editor → Insert → YouTube Video — placeholder appears, preview renders after editing URL
- [x] Insert → Poll — placeholder appears, poll iframe renders after editing URL