### PR TITLE
feat(parser): add !audio directive for inline audio playback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -428,7 +428,7 @@ export default function App() {
       const resolved: Slide = {
         ...slide,
         elements: slide.elements.map((el) => {
-          if (el.type === 'image' || el.type === 'video') return { ...el, src: resolveImageSrc(el.src, docDir, localImageUrls) };
+          if (el.type === 'image' || el.type === 'video' || el.type === 'audio') return { ...el, src: resolveImageSrc(el.src, docDir, localImageUrls) };
           if (el.type === 'paragraph') return { ...el, html: resolveHtmlSrcs(el.html, docDir, localImageUrls) };
           if (el.type === 'list')      return { ...el, items: el.items.map(resolveItem) };
           if (el.type === 'toc')       return { ...el, entries: tocEntries.filter((e) => e.index !== slide.index) };

--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -59,7 +59,8 @@ function encodeMarkdownPath(p: string): string {
 
 const IMAGE_EXT = /\.(png|jpe?g|gif|svg|webp|bmp|ico|avif|tiff?)$/i;
 const VIDEO_EXT = /\.(mp4|webm|ogv|mov|m4v|mkv)$/i;
-const MEDIA_EXT = new RegExp(`${IMAGE_EXT.source}|${VIDEO_EXT.source}`, 'i');
+const AUDIO_EXT = /\.(mp3|wav|ogg|m4a|aac|flac)$/i;
+const MEDIA_EXT = new RegExp(`${IMAGE_EXT.source}|${VIDEO_EXT.source}|${AUDIO_EXT.source}`, 'i');
 
 export async function buildMediaSnippet(abs: string, docPath: string, warn: (m: string) => void): Promise<string | null> {
   const label  = abs.split(/[/\\]/).pop()?.replace(/\.[^.]+$/, '') ?? 'media';
@@ -80,7 +81,9 @@ export async function buildMediaSnippet(abs: string, docPath: string, warn: (m: 
     }
   }
   const enc = encodeMarkdownPath(rel);
-  return VIDEO_EXT.test(abs) ? `!video[${label}](${enc})` : `![${label}](${enc})`;
+  if (VIDEO_EXT.test(abs)) return `!video[${label}](${enc})`;
+  if (AUDIO_EXT.test(abs)) return `!audio[${label}](${enc})`;
+  return `![${label}](${enc})`;
 }
 
 
@@ -1234,7 +1237,7 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
 
               const selected = await openFileDialog({
                 multiple: false,
-                filters: [{ name: 'Media', extensions: ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'avif', 'tiff', 'mp4', 'webm', 'ogv', 'mov', 'm4v', 'mkv'] }],
+                filters: [{ name: 'Media', extensions: ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'avif', 'tiff', 'mp4', 'webm', 'ogv', 'mov', 'm4v', 'mkv', 'mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac'] }],
               });
               if (!selected) return;
 

--- a/src/components/layout/__tests__/buildMediaSnippet.test.ts
+++ b/src/components/layout/__tests__/buildMediaSnippet.test.ts
@@ -21,8 +21,12 @@ describe('buildMediaSnippet', () => {
     expect(await buildMediaSnippet('/docs/my clip.mov', '/docs/talk.md', warn)).toBe('!video[my clip](my%20clip.mov)');
   });
 
-  it('treats .ogv as video but not .ogg', async () => {
+  it('treats .ogv as video but .ogg as audio', async () => {
     expect(await buildMediaSnippet('/docs/video.ogv', '/docs/talk.md', warn)).toBe('!video[video](video.ogv)');
-    expect(await buildMediaSnippet('/docs/audio.ogg', '/docs/talk.md', warn)).toBe('![audio](audio.ogg)');
+    expect(await buildMediaSnippet('/docs/audio.ogg', '/docs/talk.md', warn)).toBe('!audio[audio](audio.ogg)');
+  });
+
+  it('emits !audio[..] for mp3 next to the doc', async () => {
+    expect(await buildMediaSnippet('/docs/theme.mp3', '/docs/talk.md', warn)).toBe('!audio[theme](theme.mp3)');
   });
 });

--- a/src/components/preview/SlideRenderer.css
+++ b/src/components/preview/SlideRenderer.css
@@ -423,6 +423,9 @@
    so the box height stays definite instead of growing to the video. */
 .sl-video__player { flex: 1; min-height: 0; max-width: 100%; max-height: 100%; object-fit: contain; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.2); background: #000; }
 .sl-video__label { font-size: clamp(9px, 2cqi, 16px); font-weight: 600; color: var(--sl-text); text-align: center; font-family: var(--sl-font-body); }
+.sl-audio { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2%; width: 100%; height: 100%; min-height: 0; }
+.sl-audio__player { width: min(100%, 480px); max-width: 100%; border-radius: 4px; }
+.sl-audio__label { font-size: clamp(9px, 2cqi, 16px); font-weight: 600; color: var(--sl-text); text-align: center; font-family: var(--sl-font-body); }
 
 .sl-poll { display: flex; flex-direction: column; align-items: center; gap: 3%; padding: 4%; background: color-mix(in srgb, var(--sl-accent) 10%, var(--sl-bg)); border: 2px solid var(--sl-accent); border-radius: 8px; width: 75%; }
 .sl-poll__icon { font-size: clamp(20px, 5cqi, 44px); }

--- a/src/components/preview/SlideRenderer.tsx
+++ b/src/components/preview/SlideRenderer.tsx
@@ -581,6 +581,7 @@ function GridLayout({ slide }: { slide: Slide }) {
 function MediaLayout({ slide }: { slide: Slide }) {
   const yt = slide.elements.find((e) => e.type === 'youtube');
   const vid = slide.elements.find((e) => e.type === 'video');
+  const aud = slide.elements.find((e) => e.type === 'audio');
   const poll = slide.elements.find((e) => e.type === 'poll');
   return (
     <div className="sl-media">
@@ -588,6 +589,7 @@ function MediaLayout({ slide }: { slide: Slide }) {
       <div className="sl-media__body">
         {yt && yt.type === 'youtube' && <YoutubeEmbed embed={yt} />}
         {vid && vid.type === 'video' && <VideoEmbed embed={vid} />}
+        {aud && aud.type === 'audio' && <AudioEmbed embed={aud} />}
         {poll && poll.type === 'poll' && <PollEmbed embed={poll} />}
       </div>
     </div>
@@ -718,6 +720,9 @@ function ElementNode({ el }: { el: SlideElement }) {
     case 'video':
       return <VideoEmbed embed={el} />;
 
+    case 'audio':
+      return <AudioEmbed embed={el} />;
+
     case 'poll':
       return <PollEmbed embed={el} />;
 
@@ -815,6 +820,16 @@ function VideoEmbed({ embed }: { embed: Extract<SlideElement, { type: 'video' }>
     <div className="sl-video" onClick={(e) => e.stopPropagation()}>
       <video className="sl-video__player" src={embed.src} controls={!isThumbnail} preload="metadata" playsInline />
       {embed.label && <div className="sl-video__label">{embed.label}</div>}
+    </div>
+  );
+}
+
+function AudioEmbed({ embed }: { embed: Extract<SlideElement, { type: 'audio' }> }) {
+  const { isThumbnail } = useContext(SlideCtx);
+  return (
+    <div className="sl-audio" onClick={(e) => e.stopPropagation()}>
+      <audio className="sl-audio__player" src={embed.src} controls={!isThumbnail} preload="metadata" />
+      {embed.label && <div className="sl-audio__label">{embed.label}</div>}
     </div>
   );
 }

--- a/src/engine/__tests__/layout.test.ts
+++ b/src/engine/__tests__/layout.test.ts
@@ -12,6 +12,7 @@ const mermaid: SlideElement = { type: 'mermaid', value: 'pie title T\n"A":1' };
 const bq:      SlideElement = { type: 'blockquote', text: 'Quote' };
 const table:   SlideElement = { type: 'table', headers: ['A', 'B'], rows: [['1', '2']] };
 const youtube: SlideElement = { type: 'youtube', label: 'Vid', url: 'https://youtu.be/abc' };
+const audio:   SlideElement = { type: 'audio', label: 'Track', src: 'theme.mp3' };
 const poll:    SlideElement = { type: 'poll', label: 'Vote', url: 'https://poll.io' };
 const progress: SlideElement = { type: 'progress', label: 'Done', value: 75 };
 const colBreak: SlideElement = { type: 'column-break' };
@@ -57,6 +58,10 @@ describe('media layout', () => {
 
   it('poll element → media', () => {
     expect(detectLayout([poll], 2, true)).toBe('media');
+  });
+
+  it('audio element → media', () => {
+    expect(detectLayout([audio], 2, true)).toBe('media');
   });
 
   it('youtube + poll together → media', () => {

--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -352,6 +352,13 @@ describe('custom syntax pre-processor', () => {
     expect(vid?.type === 'video' && vid.src).toBe('media/demo.mp4');
   });
 
+  it('parses !audio', () => {
+    const { slides } = parseDocument(doc('## Slide\n\n!audio[Intro](media/theme.mp3)\n'));
+    const aud = slides[0].elements.find((e) => e.type === 'audio');
+    expect(aud?.type === 'audio' && aud.label).toBe('Intro');
+    expect(aud?.type === 'audio' && aud.src).toBe('media/theme.mp3');
+  });
+
   it('parses !poll', () => {
     const { slides } = parseDocument(doc('## Slide\n\n!poll[Vote here](https://pollev.com/xyz)\n'));
     const poll = slides[0].elements.find((e) => e.type === 'poll');

--- a/src/engine/export/__tests__/audioMime.test.ts
+++ b/src/engine/export/__tests__/audioMime.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { audioMime } from '../audioMime';
+
+describe('audioMime', () => {
+  it('maps common audio extensions', () => {
+    expect(audioMime('clip.mp3')).toBe('audio/mpeg');
+    expect(audioMime('clip.wav')).toBe('audio/wav');
+    expect(audioMime('clip.ogg')).toBe('audio/ogg');
+    expect(audioMime('clip.m4a')).toBe('audio/mp4');
+    expect(audioMime('clip.flac')).toBe('audio/flac');
+  });
+
+  it('accepts a bare extension', () => {
+    expect(audioMime('aac')).toBe('audio/aac');
+  });
+});

--- a/src/engine/export/audioMime.ts
+++ b/src/engine/export/audioMime.ts
@@ -1,0 +1,11 @@
+// MIME type for an audio file, given a path or a bare extension.
+export function audioMime(pathOrExt: string): string {
+  const ext = pathOrExt.replace(/^.*\./, '').toLowerCase();
+  if (ext === 'wav')  return 'audio/wav';
+  if (ext === 'ogg')  return 'audio/ogg';
+  if (ext === 'm4a')  return 'audio/mp4';
+  if (ext === 'aac')  return 'audio/aac';
+  if (ext === 'flac') return 'audio/flac';
+  if (ext === 'webm') return 'audio/webm';
+  return 'audio/mpeg';
+}

--- a/src/engine/export/exportPdfNative.ts
+++ b/src/engine/export/exportPdfNative.ts
@@ -3,6 +3,7 @@ import type { AspectRatio } from '../types';
 import { mermaidSvgCache } from './mermaidSvgCache';
 import { imageMime } from './imageMime';
 import { videoMime } from './videoMime';
+import { audioMime } from './audioMime';
 import { type PdfExportOpts, planPage, SLIDE_PX_W } from './pdfLayout';
 
 export type { PdfExportOpts };
@@ -49,7 +50,7 @@ export async function buildPrintDocument(
 
   // 1. Clone elements and resolve all image/video URLs to data URIs in place.
   const clones = slideElements.map((el) => el.cloneNode(true) as HTMLElement);
-  await Promise.all(clones.map((el) => Promise.all([resolveImages(el), resolveVideos(el)])));
+  await Promise.all(clones.map((el) => Promise.all([resolveImages(el), resolveVideos(el), resolveAudios(el)])));
   // Belt-and-suspenders: if a Mermaid container is still a placeholder (SVG
   // not yet committed to the DOM when we cloned), inject from the render cache.
   clones.forEach(injectMermaidFallbacks);
@@ -280,6 +281,29 @@ async function resolveVideos(el: HTMLElement): Promise<void> {
       }
     } catch { /* leave original src */ }
     if (dataUrl) vid.src = dataUrl;
+  }));
+}
+
+async function resolveAudios(el: HTMLElement): Promise<void> {
+  const auds = Array.from(el.querySelectorAll<HTMLAudioElement>('audio'));
+  await Promise.all(auds.map(async (aud) => {
+    const src = aud.getAttribute('src') ?? '';
+    let dataUrl: string | null = null;
+    try {
+      if (src.startsWith('asset://')) {
+        const path = decodeURIComponent(src.replace(/^asset:\/\/[^/]*/, ''));
+        const b64  = await invoke<string>('read_file_b64', { path });
+        dataUrl = `data:${audioMime(path)};base64,${b64}`;
+      } else if (src.startsWith('https://') || src.startsWith('http://')) {
+        const [b64, mime] = await invoke<[string, string]>('fetch_url_b64', { url: src });
+        dataUrl = `data:${mime};base64,${b64}`;
+      } else if (src.startsWith('tauri://') || src.startsWith('/')) {
+        const fetchUrl = src.startsWith('/') ? `tauri://localhost${src}` : src;
+        const res = await fetch(fetchUrl);
+        if (res.ok) dataUrl = await blobToDataUrl(await res.blob());
+      }
+    } catch { /* leave original src */ }
+    if (dataUrl) aud.src = dataUrl;
   }));
 }
 

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -530,6 +530,7 @@ function addMediaSlide(s: PS, slide: Slide, t: Theme, cy: number, ch: number) {
   const bodyH = ch - hh - 0.1;
   const yt    = slide.elements.find((e) => e.type === 'youtube');
   const vid   = slide.elements.find((e) => e.type === 'video');
+  const aud   = slide.elements.find((e) => e.type === 'audio');
   const poll  = slide.elements.find((e) => e.type === 'poll');
 
   // ponytail: PPTX can't embed local video without bundling the file — emit a
@@ -539,6 +540,18 @@ function addMediaSlide(s: PS, slide: Slide, t: Theme, cy: number, ch: number) {
       { text: '▶ ', options: { fontSize: 30, bold: true } },
       { text: vid.label || 'Video', options: { fontSize: 20, breakLine: true } },
       { text: vid.src, options: { fontSize: 11, color: hex(t.colors.accent) } },
+    ], {
+      x: M, y: bodyY, w: W - M * 2, h: bodyH,
+      color: hex(t.colors.text), fontFace: firstFont(t.fonts.body),
+      align: 'center', valign: 'middle', wrap: true,
+    });
+  }
+
+  if (aud && aud.type === 'audio') {
+    s.addText([
+      { text: '♪ ', options: { fontSize: 30, bold: true } },
+      { text: aud.label || 'Audio', options: { fontSize: 20, breakLine: true } },
+      { text: aud.src, options: { fontSize: 11, color: hex(t.colors.accent) } },
     ], {
       x: M, y: bodyY, w: W - M * 2, h: bodyH,
       color: hex(t.colors.text), fontFace: firstFont(t.fonts.body),

--- a/src/engine/layout/autoLayout.ts
+++ b/src/engine/layout/autoLayout.ts
@@ -92,7 +92,7 @@ export function detectLayout(
 
   // ── Highest-priority special types ───────────────────────────────────────
 
-  if (has('youtube') || has('poll') || has('video')) return 'media';
+  if (has('youtube') || has('poll') || has('video') || has('audio')) return 'media';
   if (has('column-break')) return 'two-column';
 
   // ── Code-only ────────────────────────────────────────────────────────────

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -75,6 +75,7 @@ interface PreprocessResult {
 
 const YOUTUBE_RE      = /^!youtube\[([^\]]*)\]\(([^)]*)\)$/;
 const VIDEO_RE        = /^!video\[([^\]]*)\]\(([^)]*)\)$/;
+const AUDIO_RE        = /^!audio\[([^\]]*)\]\(([^)]*)\)$/;
 const POLL_RE         = /^!poll\[([^\]]*)\]\(([^)]*)\)$/;
 const PROGRESS_RE     = /^!progress\[([^\]]*)\]\((\d+(?:\.\d+)?)\)$/;
 const REF_RE          = /^!ref\[([^\]]*)\]$/;
@@ -120,6 +121,14 @@ function preprocess(content: string): PreprocessResult {
     if (vid) {
       const idx = nextIdx++;
       placeholders.set(idx, { type: 'video', label: vid[1], src: vid[2] });
+      cleanLines.push(`<!-- kova-el:${idx} -->`);
+      continue;
+    }
+
+    const aud = t.match(AUDIO_RE);
+    if (aud) {
+      const idx = nextIdx++;
+      placeholders.set(idx, { type: 'audio', label: aud[1], src: aud[2] });
       cleanLines.push(`<!-- kova-el:${idx} -->`);
       continue;
     }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -31,6 +31,7 @@ export type SlideElement =
   | { type: 'table'; headers: string[]; rows: string[][]; align?: ('left' | 'right' | 'center' | null)[] }
   | { type: 'youtube';  label: string; url: string }
   | { type: 'video';    label: string; src: string }
+  | { type: 'audio';    label: string; src: string }
   | { type: 'poll';     label: string; url: string }
   | { type: 'progress'; label: string; value: number }
   | { type: 'column-break' }


### PR DESCRIPTION
## Summary
- Adds `!audio[label](path)` — parsed like `!video`, rendered with `<audio controls>` in the media layout
- Includes `audioMime.ts` for PDF export, PPTX placeholder, and media picker / drag-drop support for `.mp3`, `.wav`, `.ogg`, etc.
- `.ogg` files now emit `!audio` instead of a plain image markdown link

## Test plan
- [x] Insert or type `!audio[Intro](theme.mp3)` — preview shows audio player with controls
- [x] Insert media file picker accepts `.mp3` / `.wav` and emits `!audio[…]`
- [x] Export PDF and PPTX — audio slide shows labelled placeholder (PPTX) or player (PDF)