### PR TITLE
feat(ui): add duplicate slide to thumbnail menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Kova turns plain Markdown into polished slides — with live preview, multiple l
 
 [![Latest release](https://img.shields.io/github/v/release/KovaMD/Kova?label=release&color=orange)](https://github.com/KovaMD/Kova/releases/latest)
 [![Service status](https://status.kova.md/api/badge/1/status?style=flat&label=services)](https://status.kova.md/status/infra)
+[![Matrix](https://img.shields.io/matrix/kova-md%3Amatrix.org?server_fqdn=matrix.org&label=matrix&color=blue)](https://matrix.to/#/#kova-md:matrix.org)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Kova turns plain Markdown into polished slides — with live preview, multiple l
 
 [![Latest release](https://img.shields.io/github/v/release/KovaMD/Kova?label=release&color=orange)](https://github.com/KovaMD/Kova/releases/latest)
 [![Service status](https://status.kova.md/api/badge/1/status?style=flat&label=services)](https://status.kova.md/status/infra)
-[![Matrix](https://img.shields.io/matrix/kova-md%3Amatrix.org?server_fqdn=matrix.org&label=matrix&color=blue)](https://matrix.to/#/#kova-md:matrix.org)
 
 ## Features
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1412,6 +1412,23 @@ export default function App() {
     setTimeout(() => editorRef.current?.scrollToSlide(index + 1), 50);
   }, []);
 
+  const handleDeleteSlide = useCallback((index: number) => {
+    setContent((prev) => {
+      const fmMatch = prev.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/);
+      const fmBlock = fmMatch ? fmMatch[0] : '';
+      const body = prev.slice(fmBlock.length);
+      const segments = body.split(/^---$/m);
+      if (index < 0 || index >= segments.length || segments.length <= 1) return prev;
+      const next = [...segments];
+      next.splice(index, 1);
+      return fmBlock + next.map((s) => s.trim()).join('\n\n---\n\n') + '\n';
+    });
+    setIsDirty(true);
+    const newIndex = Math.max(0, Math.min(index, slides.length - 2));
+    setCurrentSlideIndex(newIndex);
+    setTimeout(() => editorRef.current?.scrollToSlide(newIndex), 50);
+  }, [slides.length]);
+
   const handleToggleHidden = useCallback((index: number) => {
     setContent((prev) => {
       const fmMatch = prev.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/);
@@ -1865,6 +1882,7 @@ export default function App() {
               onReorder={handleSlideReorder}
               onDuplicate={handleDuplicateSlide}
               onToggleHidden={handleToggleHidden}
+              onDelete={handleDeleteSlide}
               theme={activeTheme}
               docTitle={frontmatter.title}
               docDate={frontmatter.date as string | undefined}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1396,6 +1396,22 @@ export default function App() {
     setTimeout(() => editorRef.current?.scrollToSlide(toIndex), 50);
   }, []);
 
+  const handleDuplicateSlide = useCallback((index: number) => {
+    setContent((prev) => {
+      const fmMatch = prev.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/);
+      const fmBlock = fmMatch ? fmMatch[0] : '';
+      const body = prev.slice(fmBlock.length);
+      const segments = body.split(/^---$/m);
+      if (index < 0 || index >= segments.length) return prev;
+      const next = [...segments];
+      next.splice(index + 1, 0, segments[index]);
+      return fmBlock + next.map((s) => s.trim()).join('\n\n---\n\n') + '\n';
+    });
+    setIsDirty(true);
+    setCurrentSlideIndex(index + 1);
+    setTimeout(() => editorRef.current?.scrollToSlide(index + 1), 50);
+  }, []);
+
   const handleToggleHidden = useCallback((index: number) => {
     setContent((prev) => {
       const fmMatch = prev.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/);
@@ -1847,6 +1863,7 @@ export default function App() {
               currentIndex={safeSlideIndex}
               onSelect={handleThumbnailSelect}
               onReorder={handleSlideReorder}
+              onDuplicate={handleDuplicateSlide}
               onToggleHidden={handleToggleHidden}
               theme={activeTheme}
               docTitle={frontmatter.title}

--- a/src/components/layout/ThumbnailPanel.tsx
+++ b/src/components/layout/ThumbnailPanel.tsx
@@ -11,6 +11,7 @@ interface Props {
   onReorder?: (fromIndex: number, toIndex: number) => void;
   onDuplicate?: (index: number) => void;
   onToggleHidden?: (index: number) => void;
+  onDelete?: (index: number) => void;
   theme?: Theme;
   docTitle?: string;
   docDate?: string;
@@ -20,7 +21,7 @@ interface Props {
 const SLIDE_W = 960;
 const THUMB_W = 140;
 
-export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onDuplicate, onToggleHidden, theme = DEFAULT_THEME, docTitle, docDate, aspectRatio = { w: 16, h: 9 } }: Props) {
+export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onDuplicate, onToggleHidden, onDelete, theme = DEFAULT_THEME, docTitle, docDate, aspectRatio = { w: 16, h: 9 } }: Props) {
   const slideH = Math.round(SLIDE_W * aspectRatio.h / aspectRatio.w);
 
   // Observe the outer panel div (no overflow) so a scrollbar appearing in the
@@ -268,6 +269,12 @@ export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onDu
             disabled={!onToggleHidden}
             onClick={() => { onToggleHidden?.(menu.index); setMenu(null); }}
           />
+          <div role="separator" style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+          <MenuItem
+            label="Delete slide"
+            disabled={!onDelete || slides.length <= 1}
+            onClick={() => { onDelete?.(menu.index); setMenu(null); }}
+          />
         </div>
       )}
     </div>
@@ -286,7 +293,7 @@ function MenuItem({ label, disabled, onClick }: { label: string; disabled?: bool
         background: 'transparent', color: 'var(--text)', cursor: disabled ? 'default' : 'pointer',
         opacity: disabled ? 0.4 : 1,
       }}
-      onMouseEnter={(e) => { if (!disabled) e.currentTarget.style.background = 'var(--accent)'; }}
+      onMouseEnter={(e) => { if (!disabled) e.currentTarget.style.background = 'var(--bg-hover)'; }}
       onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
     >
       {label}

--- a/src/components/layout/ThumbnailPanel.tsx
+++ b/src/components/layout/ThumbnailPanel.tsx
@@ -9,6 +9,7 @@ interface Props {
   currentIndex: number;
   onSelect: (index: number) => void;
   onReorder?: (fromIndex: number, toIndex: number) => void;
+  onDuplicate?: (index: number) => void;
   onToggleHidden?: (index: number) => void;
   theme?: Theme;
   docTitle?: string;
@@ -19,7 +20,7 @@ interface Props {
 const SLIDE_W = 960;
 const THUMB_W = 140;
 
-export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onToggleHidden, theme = DEFAULT_THEME, docTitle, docDate, aspectRatio = { w: 16, h: 9 } }: Props) {
+export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onDuplicate, onToggleHidden, theme = DEFAULT_THEME, docTitle, docDate, aspectRatio = { w: 16, h: 9 } }: Props) {
   const slideH = Math.round(SLIDE_W * aspectRatio.h / aspectRatio.w);
 
   // Observe the outer panel div (no overflow) so a scrollbar appearing in the
@@ -256,6 +257,11 @@ export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onTo
             label="Move down"
             disabled={!onReorder || menu.index === slides.length - 1}
             onClick={() => { onReorder?.(menu.index, menu.index + 1); setMenu(null); }}
+          />
+          <MenuItem
+            label="Duplicate slide"
+            disabled={!onDuplicate}
+            onClick={() => { onDuplicate?.(menu.index); setMenu(null); }}
           />
           <MenuItem
             label={slides[menu.index]?.hidden ? 'Show slide' : 'Hide slide'}


### PR DESCRIPTION
## Summary
- Adds **Duplicate slide** to the thumbnail right-click menu (between Move down and Hide slide)
- Inserts an exact copy of the slide's markdown segment after the source slide
- Selects and scrolls to the new slide after duplication

## Test plan
- [x] Right-click a slide thumbnail → Duplicate slide — copy appears below with identical content
- [x] Hidden marker, speaker notes, and custom elements are preserved in the copy
- [x] Undo restores the previous deck