### PR TITLE
feat(ui): copy slide markdown from thumbnail menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1421,6 +1421,15 @@ export default function App() {
     warnTimerRef.current = setTimeout(() => setWarnMessage(null), 6000);
   }, []);
 
+  const handleCopySlideMarkdown = useCallback((index: number) => {
+    const slide = slides[index];
+    if (!slide) return;
+    void navigator.clipboard.writeText(slide.raw.trim()).catch((err) => {
+      console.error('Copy slide markdown failed:', err);
+      handleWarn('Could not copy to clipboard');
+    });
+  }, [slides, handleWarn]);
+
   const handleSettingsChange = useCallback((s: AppSettings) => {
     setSettings(s);
     saveSettings(s);
@@ -1847,6 +1856,7 @@ export default function App() {
               currentIndex={safeSlideIndex}
               onSelect={handleThumbnailSelect}
               onReorder={handleSlideReorder}
+              onCopyMarkdown={handleCopySlideMarkdown}
               onToggleHidden={handleToggleHidden}
               theme={activeTheme}
               docTitle={frontmatter.title}

--- a/src/components/layout/ThumbnailPanel.tsx
+++ b/src/components/layout/ThumbnailPanel.tsx
@@ -9,6 +9,7 @@ interface Props {
   currentIndex: number;
   onSelect: (index: number) => void;
   onReorder?: (fromIndex: number, toIndex: number) => void;
+  onCopyMarkdown?: (index: number) => void;
   onToggleHidden?: (index: number) => void;
   theme?: Theme;
   docTitle?: string;
@@ -19,7 +20,7 @@ interface Props {
 const SLIDE_W = 960;
 const THUMB_W = 140;
 
-export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onToggleHidden, theme = DEFAULT_THEME, docTitle, docDate, aspectRatio = { w: 16, h: 9 } }: Props) {
+export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onCopyMarkdown, onToggleHidden, theme = DEFAULT_THEME, docTitle, docDate, aspectRatio = { w: 16, h: 9 } }: Props) {
   const slideH = Math.round(SLIDE_W * aspectRatio.h / aspectRatio.w);
 
   // Observe the outer panel div (no overflow) so a scrollbar appearing in the
@@ -256,6 +257,11 @@ export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onTo
             label="Move down"
             disabled={!onReorder || menu.index === slides.length - 1}
             onClick={() => { onReorder?.(menu.index, menu.index + 1); setMenu(null); }}
+          />
+          <MenuItem
+            label="Copy slide markdown"
+            disabled={!onCopyMarkdown}
+            onClick={() => { onCopyMarkdown?.(menu.index); setMenu(null); }}
           />
           <MenuItem
             label={slides[menu.index]?.hidden ? 'Show slide' : 'Hide slide'}


### PR DESCRIPTION
## Summary
- Adds **Copy slide markdown** to the thumbnail right-click menu
- Copies the slide's raw markdown segment (title, body, hidden marker, etc.) to the clipboard

## Test plan
- [x] Right-click a slide → Copy slide markdown — paste elsewhere and confirm full slide content
- [x] Hidden slides copy including `<!-- hidden -->` when present
- [x] Speaker notes (`???` block) are included in the copied segment