### PR TITLE
feat(export): export speaker notes as Markdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { normalizePath } from './engine/resolvePath';
 import { exportToPptx } from './engine/export/exportPptx';
 import { exportToPdf, printPresentation } from './engine/export/exportPdf';
 import { exportPdfNative, buildPrintDocument, type PdfExportOpts } from './engine/export/exportPdfNative';
+import { buildSpeakerNotesMarkdown } from './engine/export/speakerNotesExport';
 import { SlideRenderer } from './components/preview/SlideRenderer';
 import { BUILT_IN_THEMES, DEFAULT_THEME, parseThemeYaml, sanitiseThemeOverrides, type ThemeParseResult } from './engine/theme';
 import { registerBundledFonts, registerCachedFont } from './engine/bundledFonts';
@@ -1303,6 +1304,30 @@ export default function App() {
     });
   }, [visibleSlides, filePath, aspectRatio]);
 
+  const handleExportSpeakerNotes = useCallback(async () => {
+    if (visibleSlides.length === 0) return;
+    const notesSlides = visibleSlides.filter((s) => s.speakerNotes.trim());
+    if (notesSlides.length === 0) {
+      setWarnMessage('No speaker notes in this deck');
+      return;
+    }
+    const defaultPath = filePath
+      ? filePath.replace(/\.(md|markdown)$/i, '-notes.md')
+      : 'speaker-notes.md';
+    const target = await save({
+      filters: [{ name: 'Markdown', extensions: ['md'] }],
+      defaultPath,
+    });
+    if (!target) return;
+    const savePath = target.toLowerCase().endsWith('.md') ? target : `${target}.md`;
+    try {
+      await invoke('write_file', { path: savePath, content: buildSpeakerNotesMarkdown(notesSlides) });
+    } catch (err) {
+      console.error('Speaker notes export failed:', err);
+      window.alert(`Speaker notes export failed:\n${String(err)}`);
+    }
+  }, [visibleSlides, filePath]);
+
   const handlePrint = useCallback(async () => {
     if (visibleSlides.length === 0) return;
     const visSlides = [...visibleSlides];
@@ -1474,6 +1499,7 @@ export default function App() {
     export: handleExport,
     exportPdf: () => { setPdfPerPage(1); setPdfNotesOn(false); setPdfOptionsOpen(true); },
     exportHtml: handleExportHtml,
+    exportSpeakerNotes: () => { void handleExportSpeakerNotes(); },
     print: handlePrint,
     present: () => { void handlePresentEnter(); },
     toggleInspector: () => setShowInspector((v) => !v),
@@ -1492,6 +1518,7 @@ export default function App() {
     export: () => menuHandlersRef.current.export(),
     exportPdf: () => menuHandlersRef.current.exportPdf(),
     exportHtml: () => menuHandlersRef.current.exportHtml(),
+    exportSpeakerNotes: () => menuHandlersRef.current.exportSpeakerNotes(),
     print: () => menuHandlersRef.current.print(),
     present: () => menuHandlersRef.current.present(),
     toggleInspector: () => menuHandlersRef.current.toggleInspector(),
@@ -1690,6 +1717,13 @@ export default function App() {
                     </button>
                     <button className="btn-group-menu-item" disabled={slides.length === 0 || pdfExportContext !== null} onClick={() => { setFileMenuOpen(false); handleExportHtml(); }}>
                       {pdfExportContext ? 'Exporting…' : 'HTML (.html)'}
+                    </button>
+                    <button
+                      className="btn-group-menu-item"
+                      disabled={slides.length === 0 || !visibleSlides.some((s) => s.speakerNotes.trim())}
+                      onClick={() => { setFileMenuOpen(false); void handleExportSpeakerNotes(); }}
+                    >
+                      Speaker notes (.md)
                     </button>
                   </div>
                 )}

--- a/src/engine/export/__tests__/speakerNotesExport.test.ts
+++ b/src/engine/export/__tests__/speakerNotesExport.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { buildSpeakerNotesMarkdown } from '../speakerNotesExport';
+import type { Slide } from '../../types';
+
+const base = (over: Partial<Slide>): Slide => ({
+  index: 0,
+  raw: '',
+  title: '',
+  titleLevel: 0,
+  elements: [],
+  speakerNotes: '',
+  references: [],
+  layout: 'blank',
+  hidden: false,
+  ...over,
+});
+
+describe('buildSpeakerNotesMarkdown', () => {
+  it('formats titled slides with notes separated by ---', () => {
+    const md = buildSpeakerNotesMarkdown([
+      base({ title: 'Intro', speakerNotes: 'Welcome everyone.' }),
+      base({ title: 'Agenda', speakerNotes: 'Three topics today.' }),
+    ]);
+    expect(md).toBe(
+      '# Intro\n\nWelcome everyone.\n\n---\n\n# Agenda\n\nThree topics today.\n',
+    );
+  });
+
+  it('falls back to Slide N when a slide has no title', () => {
+    const md = buildSpeakerNotesMarkdown([
+      base({ speakerNotes: 'No heading on this one.' }),
+    ]);
+    expect(md).toBe('# Slide 1\n\nNo heading on this one.\n');
+  });
+});

--- a/src/engine/export/speakerNotesExport.ts
+++ b/src/engine/export/speakerNotesExport.ts
@@ -1,0 +1,9 @@
+import type { Slide } from '../types';
+
+/** One `# title` + notes block per slide, separated by `---`. */
+export function buildSpeakerNotesMarkdown(slides: Slide[]): string {
+  return slides.map((s, i) => {
+    const title = s.title || `Slide ${i + 1}`;
+    return `# ${title}\n\n${s.speakerNotes.trim()}`;
+  }).join('\n\n---\n\n') + '\n';
+}

--- a/src/macMenu.ts
+++ b/src/macMenu.ts
@@ -22,6 +22,7 @@ export interface MacMenuHandlers {
   export: () => void;
   exportPdf: () => void;
   exportHtml: () => void;
+  exportSpeakerNotes: () => void;
   print: () => void;
   present: () => void;
   toggleInspector: () => void;
@@ -83,6 +84,7 @@ export async function buildMacMenu(h: MacMenuHandlers, recents: string[]): Promi
               { text: 'PowerPoint (.pptx)', action: () => h.export() },
               { text: 'PDF (.pdf)', action: () => h.exportPdf() },
               { text: 'HTML (.html)', action: () => h.exportHtml() },
+              { text: 'Speaker notes (.md)', action: () => h.exportSpeakerNotes() },
             ],
           }),
           { text: 'Print…', accelerator: 'CmdOrCtrl+P', action: () => h.print() },


### PR DESCRIPTION
## Summary
- Adds **File → Export → Speaker notes (.md)** on Windows/Linux and macOS
- Exports visible slides that have speaker notes as `# title` + notes blocks separated by `---`
- Default save path: `{deck}-notes.md`; menu item disabled when the deck has no notes

## Test plan
- [x] Add `???` notes to several slides → Export → Speaker notes — `.md` file contains titled sections
- [x] Hidden slides are excluded (matches PDF/presentation export)
- [x] Slides without notes are omitted from the export
- [x] Menu item disabled when no speaker notes exist