### PR TITLE
feat(editor): add Insert → Bibliography slide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { loadKeybindings, matchShortcut, getCombo, formatCombo, isMac } from './
 import type { Keybindings } from './engine/keybindings';
 
 import { parseDocument } from './engine/parser/markdownToSlides';
+import { collectDeckReferences, buildBibliographySlideMarkdown } from './engine/bibliography';
 import { extractFrontmatter, patchFrontmatter } from './engine/parser/frontmatter';
 import { fetchUpdate } from './engine/updater';
 import { normalizePath } from './engine/resolvePath';
@@ -1421,6 +1422,26 @@ export default function App() {
     warnTimerRef.current = setTimeout(() => setWarnMessage(null), 6000);
   }, []);
 
+  const handleInsertBibliography = useCallback(() => {
+    const refs = collectDeckReferences(slides);
+    if (refs.length === 0) {
+      handleWarn('No references found — add !ref[…] citations to your slides first.');
+      return;
+    }
+    const slideBody = buildBibliographySlideMarkdown(refs);
+    const newIndex = slides.length;
+    setContent((prev) => {
+      const fmMatch = prev.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/);
+      const fmBlock = fmMatch ? fmMatch[0] : '';
+      const body = prev.slice(fmBlock.length).trimEnd();
+      const sep = body.length > 0 ? '\n\n---\n\n' : '';
+      return fmBlock + body + sep + slideBody + '\n';
+    });
+    setIsDirty(true);
+    setCurrentSlideIndex(newIndex);
+    setTimeout(() => editorRef.current?.scrollToSlide(newIndex), 50);
+  }, [slides, handleWarn]);
+
   const handleSettingsChange = useCallback((s: AppSettings) => {
     setSettings(s);
     saveSettings(s);
@@ -1865,6 +1886,7 @@ export default function App() {
               onCursorSlide={setCurrentSlideIndex}
               onWarn={handleWarn}
               onSaveAs={handleSaveAs}
+              onInsertBibliography={handleInsertBibliography}
               focusMode={focusMode}
               filePath={filePath}
               uiTheme={resolvedUiTheme}

--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -32,6 +32,7 @@ interface Props {
   onCursorSlide?: (index: number) => void;
   onWarn?: (msg: string) => void;
   onSaveAs?: () => Promise<string | null>;
+  onInsertBibliography?: () => void;
   focusMode?: boolean;
   filePath?: string | null;
   uiTheme?: 'dark' | 'light';
@@ -528,7 +529,7 @@ interface ContextMenuState { x: number; y: number; hasSelection: boolean; clickP
 interface ConfirmState { title: string; message: string; okLabel: string; resolve: (ok: boolean) => void }
 
 export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
-  { content, onChange, onCursorSlide, onWarn, onSaveAs, focusMode = false, filePath, uiTheme = 'dark', editorFontFamily = DEFAULT_FONT_FAMILY, wordWrap = true, spellCheckEnabled = false, spellCheckLanguage = 'en_US' }: Props,
+  { content, onChange, onCursorSlide, onWarn, onSaveAs, onInsertBibliography, focusMode = false, filePath, uiTheme = 'dark', editorFontFamily = DEFAULT_FONT_FAMILY, wordWrap = true, spellCheckEnabled = false, spellCheckLanguage = 'en_US' }: Props,
   ref,
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -538,6 +539,7 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
   const onCursorSlideRef = useRef(onCursorSlide);
   const onWarnRef = useRef(onWarn);
   const onSaveAsRef = useRef(onSaveAs);
+  const onInsertBibliographyRef = useRef(onInsertBibliography);
   const filePathRef = useRef(filePath);
   const uiThemeRef = useRef(uiTheme);
   const spellCheckEnabledRef = useRef(spellCheckEnabled);
@@ -554,6 +556,7 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
   useEffect(() => { onCursorSlideRef.current = onCursorSlide; }, [onCursorSlide]);
   useEffect(() => { onWarnRef.current = onWarn; }, [onWarn]);
   useEffect(() => { onSaveAsRef.current = onSaveAs; }, [onSaveAs]);
+  useEffect(() => { onInsertBibliographyRef.current = onInsertBibliography; }, [onInsertBibliography]);
   useEffect(() => { filePathRef.current = filePath; }, [filePath]);
   useEffect(() => { uiThemeRef.current = uiTheme; }, [uiTheme]);
   useEffect(() => { spellCheckEnabledRef.current = spellCheckEnabled; }, [spellCheckEnabled]);
@@ -1251,6 +1254,11 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
           { type: 'item', label: 'Math/LaTeX Block', action: () => doInsert('$$\nE = mc^2\n$$', 3) },
           { type: 'item', label: 'Speaker Notes',   action: () => doInsert('\n\n???\n\n', 7) },
           { type: 'item', label: 'Reference',       action: () => doInsert('!ref[]', 5) },
+          {
+            type: 'item',
+            label: 'Bibliography slide',
+            action: () => onInsertBibliographyRef.current?.(),
+          },
           {
             type: 'item',
             label: 'Table of Contents',

--- a/src/engine/__tests__/bibliography.test.ts
+++ b/src/engine/__tests__/bibliography.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { collectDeckReferences, buildBibliographySlideMarkdown } from '../bibliography';
+import type { Slide } from '../../types';
+
+const slide = (over: Partial<Slide> & Pick<Slide, 'references'>): Slide => ({
+  index: 0,
+  raw: '',
+  title: '',
+  titleLevel: 0,
+  elements: [],
+  speakerNotes: '',
+  layout: 'blank',
+  hidden: false,
+  ...over,
+});
+
+describe('bibliography', () => {
+  it('collects references in deck order and dedupes', () => {
+    const refs = collectDeckReferences([
+      slide({ references: ['First', 'Second'] }),
+      slide({ references: ['Second', 'Third'] }),
+    ]);
+    expect(refs).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('ignores empty reference strings', () => {
+    const refs = collectDeckReferences([
+      slide({ references: ['  ', 'Real citation'] }),
+    ]);
+    expect(refs).toEqual(['Real citation']);
+  });
+
+  it('builds a References slide with bullet list', () => {
+    expect(buildBibliographySlideMarkdown(['Alpha', 'Beta'])).toBe(
+      '## References\n\n- Alpha\n- Beta',
+    );
+  });
+});

--- a/src/engine/bibliography.ts
+++ b/src/engine/bibliography.ts
@@ -1,0 +1,22 @@
+import type { Slide } from './types';
+
+/** Collect unique `!ref[…]` citations across the deck, preserving first-seen order. */
+export function collectDeckReferences(slides: Slide[]): string[] {
+  const seen = new Set<string>();
+  const refs: string[] = [];
+  for (const slide of slides) {
+    for (const ref of slide.references) {
+      const key = ref.trim();
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      refs.push(ref);
+    }
+  }
+  return refs;
+}
+
+/** Markdown for a bibliography slide appended to the deck. */
+export function buildBibliographySlideMarkdown(refs: string[]): string {
+  const lines = refs.map((r) => `- ${r.trim()}`);
+  return `## References\n\n${lines.join('\n')}`;
+}


### PR DESCRIPTION
## Summary
- Adds **Insert → Bibliography slide** to the editor context menu
- Scans all slides for `!ref[…]` citations, dedupes while preserving order, and appends a `## References` slide with a bullet list
- Warns when the deck has no references yet

## Test plan
- [x] Add `!ref[Citation A]` and `!ref[Citation B]` on different slides → Insert → Bibliography slide
- [x] New slide appears at end with both citations; duplicates are omitted
- [x] Empty deck / no refs shows a warning banner