### PR TITLE
feat(presentation): add optional presenter countdown timer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1597,6 +1597,7 @@ export default function App() {
           aspectRatio={aspectRatio}
           laserColor={settings.laserColor}
           showTimer={settings.presenterShowTimer}
+          countdownMinutes={settings.presenterCountdownMinutes}
           onNavigate={setPresentIndex}
           onExit={handlePresentExit}
         />
@@ -1611,6 +1612,7 @@ export default function App() {
           aspectRatio={aspectRatio}
           showNextSlide={settings.presenterShowNextSlide}
           showTimer={settings.presenterShowTimer}
+          countdownMinutes={settings.presenterCountdownMinutes}
           notesFontSize={settings.presenterNotesFontSize}
           laserColor={settings.laserColor}
           onNavigate={setPresentIndex}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { useState, useMemo, useEffect, useRef } from 'react';
-import type { AppSettings, PresentationMode, NotesFontSize, LaserColor, StartupBehavior } from '../store/settings';
-import { EDITOR_FONT_OPTIONS, LASER_COLOR_OPTIONS } from '../store/settings';
+import type { AppSettings, PresentationMode, NotesFontSize, PresenterCountdownMinutes, LaserColor, StartupBehavior } from '../store/settings';
+import { EDITOR_FONT_OPTIONS, LASER_COLOR_OPTIONS, PRESENTER_COUNTDOWN_OPTIONS } from '../store/settings';
 import type { Theme } from '../engine/theme';
 import { isFontAvailable } from '../engine/fontDetect';
 import { fetchUpdate, canSelfUpdate, restartApp } from '../engine/updater';
@@ -650,6 +650,25 @@ export function SettingsModal({ settings, availableUpdate, allThemes, isDirty, s
             </div>
           }
         />
+
+        <div style={{ padding: '6px 0 10px' }}>
+          <div style={{ fontSize: 13, color: 'var(--text-primary)', marginBottom: 4 }}>Countdown timer</div>
+          <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 8, lineHeight: 1.5 }}>
+            When set, the presentation HUD counts down instead of elapsed time. Turns red in the final minute.
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            {PRESENTER_COUNTDOWN_OPTIONS.map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => set('presenterCountdownMinutes', value as PresenterCountdownMinutes)}
+                style={groupBtnStyle(settings.presenterCountdownMinutes === value)}
+              >
+                {value === 0 ? 'Off' : `${value} min`}
+              </button>
+            ))}
+          </div>
+        </div>
 
         {settings.presentationMode === 'dual' && (
           <>

--- a/src/components/presentation/PresentationOverlay.css
+++ b/src/components/presentation/PresentationOverlay.css
@@ -114,6 +114,10 @@
   text-align: center;
 }
 
+.pres-hud__timer--warning {
+  color: #ff4444;
+}
+
 .pres-hud__btn {
   background: none;
   border: 1px solid #333;

--- a/src/components/presentation/PresentationOverlay.tsx
+++ b/src/components/presentation/PresentationOverlay.tsx
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useRef, useState } from 'react';
 import type { Slide, AspectRatio } from '../../engine/types';
 import type { Theme } from '../../engine/theme';
 import { SlideRenderer } from '../preview/SlideRenderer';
-import { SLIDE_W, formatTime, ScaledSlideBox, LaserDot } from './presentationShared';
+import { SLIDE_W, timerDisplay, ScaledSlideBox, LaserDot } from './presentationShared';
 import './PresentationOverlay.css';
 
 interface Props {
@@ -14,6 +14,7 @@ interface Props {
   aspectRatio?: AspectRatio;
   laserColor?: string;
   showTimer?: boolean;
+  countdownMinutes?: number;
   onNavigate: (index: number) => void;
   onExit: () => void;
 }
@@ -22,7 +23,7 @@ const HUD_H   = 40;   // px — HUD bar height
 const NOTE_H  = 160;  // px — speaker notes panel height
 
 export function PresentationOverlay({
-  slides, currentIndex, theme, docTitle, docDate, aspectRatio = { w: 16, h: 9 }, laserColor = '#ff2020', showTimer = false, onNavigate, onExit,
+  slides, currentIndex, theme, docTitle, docDate, aspectRatio = { w: 16, h: 9 }, laserColor = '#ff2020', showTimer = false, countdownMinutes = 0, onNavigate, onExit,
 }: Props) {
   const slide = slides[currentIndex];
 
@@ -291,9 +292,17 @@ export function PresentationOverlay({
           title="Next (→ / Space)"
         >›</button>
 
-        {showTimer && (
-          <span className="pres-hud__timer" title="Elapsed time">{formatTime(elapsed)}</span>
-        )}
+        {showTimer && (() => {
+          const timer = timerDisplay(elapsed, countdownMinutes);
+          return (
+            <span
+              className={`pres-hud__timer${timer.warning ? ' pres-hud__timer--warning' : ''}`}
+              title={countdownMinutes > 0 ? 'Time remaining' : 'Elapsed time'}
+            >
+              {timer.text}
+            </span>
+          );
+        })()}
 
         {hasNotes && (
           <button

--- a/src/components/presentation/PresenterOverlay.css
+++ b/src/components/presentation/PresenterOverlay.css
@@ -209,6 +209,10 @@
   text-align: center;
 }
 
+.pres-presenter__timer--warning {
+  color: #ff4444;
+}
+
 .pres-presenter__btn {
   background: none;
   border: 1px solid #2a2a2a;

--- a/src/components/presentation/PresenterOverlay.tsx
+++ b/src/components/presentation/PresenterOverlay.tsx
@@ -4,7 +4,7 @@ import type { Slide, AspectRatio } from '../../engine/types';
 import type { Theme } from '../../engine/theme';
 import type { NotesFontSize } from '../../store/settings';
 import { SlideRenderer } from '../preview/SlideRenderer';
-import { SLIDE_W, formatTime, ScaledSlideBox, LaserDot } from './presentationShared';
+import { SLIDE_W, timerDisplay, ScaledSlideBox, LaserDot } from './presentationShared';
 import './PresenterOverlay.css';
 
 interface Props {
@@ -16,6 +16,7 @@ interface Props {
   aspectRatio: AspectRatio;
   showNextSlide: boolean;
   showTimer: boolean;
+  countdownMinutes?: number;
   notesFontSize: NotesFontSize;
   laserColor?: string;
   onNavigate: (index: number) => void;
@@ -30,7 +31,7 @@ const STORAGE_KEY     = 'kova:presenter-right-w';
 
 export function PresenterOverlay({
   slides, currentIndex, theme, docTitle, docDate, aspectRatio,
-  showNextSlide, showTimer, notesFontSize, laserColor = '#ff2020', onNavigate, onExit,
+  showNextSlide, showTimer, countdownMinutes = 0, notesFontSize, laserColor = '#ff2020', onNavigate, onExit,
 }: Props) {
   const slide     = slides[currentIndex];
   const nextSlide = slides[currentIndex + 1] ?? null;
@@ -357,14 +358,20 @@ export function PresenterOverlay({
           >›</button>
         </div>
 
-        {showTimer && (
-          <>
-            <div className="pres-presenter__hud-divider" />
-            <span className="pres-presenter__timer" title="Elapsed time">
-              {formatTime(elapsed)}
-            </span>
-          </>
-        )}
+        {showTimer && (() => {
+          const timer = timerDisplay(elapsed, countdownMinutes);
+          return (
+            <>
+              <div className="pres-presenter__hud-divider" />
+              <span
+                className={`pres-presenter__timer${timer.warning ? ' pres-presenter__timer--warning' : ''}`}
+                title={countdownMinutes > 0 ? 'Time remaining' : 'Elapsed time'}
+              >
+                {timer.text}
+              </span>
+            </>
+          );
+        })()}
 
         <div className="pres-presenter__hud-divider" />
 

--- a/src/components/presentation/__tests__/presentationShared.test.ts
+++ b/src/components/presentation/__tests__/presentationShared.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatTime } from '../presentationShared';
+import { formatTime, timerDisplay } from '../presentationShared';
 
 describe('formatTime', () => {
   it('pads mm:ss under an hour', () => {
@@ -11,5 +11,17 @@ describe('formatTime', () => {
   it('adds h:mm:ss past an hour', () => {
     expect(formatTime(3600)).toBe('1:00:00');
     expect(formatTime(3661)).toBe('1:01:01');
+  });
+});
+
+describe('timerDisplay', () => {
+  it('shows elapsed time when countdown is off', () => {
+    expect(timerDisplay(125, 0)).toEqual({ text: '02:05', warning: false });
+  });
+
+  it('counts down and warns in the final minute', () => {
+    expect(timerDisplay(240, 5)).toEqual({ text: '01:00', warning: true });
+    expect(timerDisplay(300, 5)).toEqual({ text: '00:00', warning: true });
+    expect(timerDisplay(120, 5)).toEqual({ text: '03:00', warning: false });
   });
 });

--- a/src/components/presentation/presentationShared.tsx
+++ b/src/components/presentation/presentationShared.tsx
@@ -12,6 +12,15 @@ export function formatTime(seconds: number): string {
   return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
 }
 
+/** Elapsed clock, or countdown with a warning flag in the final minute. */
+export function timerDisplay(elapsed: number, countdownMinutes: number): { text: string; warning: boolean } {
+  if (countdownMinutes <= 0) {
+    return { text: formatTime(elapsed), warning: false };
+  }
+  const remaining = Math.max(0, countdownMinutes * 60 - elapsed);
+  return { text: formatTime(remaining), warning: remaining <= 60 };
+}
+
 // The 960px virtual slide scaled to fill its measured frame.
 export function ScaledSlideBox({ scale, slideH, children }: { scale: number; slideH: number; children: ReactNode }) {
   return (

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -2,6 +2,8 @@ import { detectOsLanguage } from '../engine/spellcheck/spellChecker';
 
 export type PresentationMode  = 'auto' | 'single' | 'dual' | 'mirror';
 export type NotesFontSize     = 'sm' | 'md' | 'lg';
+export type PresenterCountdownMinutes = 0 | 5 | 10 | 15;
+export const PRESENTER_COUNTDOWN_OPTIONS = [0, 5, 10, 15] as const satisfies readonly PresenterCountdownMinutes[];
 export type StartupBehavior   = 'blank' | 'reopenLast';
 
 export const LASER_COLOR_OPTIONS = [
@@ -43,6 +45,7 @@ export interface AppSettings {
   presentationMode: PresentationMode;
   presenterShowNextSlide: boolean;
   presenterShowTimer: boolean;
+  presenterCountdownMinutes: PresenterCountdownMinutes;
   presenterNotesFontSize: NotesFontSize;
   laserColor: LaserColor;
   // Editor
@@ -73,6 +76,7 @@ function buildDefaults(): AppSettings {
     presentationMode: 'auto',
     presenterShowNextSlide: true,
     presenterShowTimer: true,
+    presenterCountdownMinutes: 0,
     presenterNotesFontSize: 'md',
     laserColor: '#ff2020',
     showFrontmatter: false,


### PR DESCRIPTION
## Summary
- Adds **Settings → Presentation → Countdown timer** with Off / 5 / 10 / 15 min options
- When enabled, the presentation HUD shows time remaining instead of elapsed time
- Timer turns red in the final minute (presenter view + single-screen HUD)

## Test plan
- [x] Set countdown to 5 min, start presentation — HUD counts down from 05:00
- [x] At ≤ 1:00 remaining, timer text turns red
- [x] Off restores elapsed-time behaviour
- [x] Works in dual presenter view and single-screen presentation