### PR TITLE
fix(parser): preserve lists and inline formatting in blockquotes (#116)

### DIFF
--- a/src/components/preview/SlideRenderer.css
+++ b/src/components/preview/SlideRenderer.css
@@ -162,6 +162,10 @@
   color: color-mix(in srgb, var(--sl-text) 75%, transparent);
   font-style: italic;
 }
+.sl-blockquote p { margin: 0 0 0.3em; }
+.sl-blockquote ul, .sl-blockquote ol { margin: 0.2em 0; padding-left: 1.4em; }
+.sl-blockquote ul { list-style: disc; }
+.sl-blockquote ol { list-style: decimal; }
 .sl-blockquote cite {
   display: block;
   margin-top: 0.3em;

--- a/src/components/preview/SlideRenderer.tsx
+++ b/src/components/preview/SlideRenderer.tsx
@@ -706,7 +706,9 @@ function ElementNode({ el }: { el: SlideElement }) {
     case 'blockquote':
       return (
         <blockquote className="sl-blockquote">
-          <p>{el.text}</p>
+          {el.html
+            ? <div dangerouslySetInnerHTML={{ __html: el.html }} />
+            : <p>{el.text}</p>}
           {el.attribution && <cite>— {el.attribution}</cite>}
         </blockquote>
       );

--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -168,6 +168,23 @@ describe('element parsing', () => {
     expect(bq?.type === 'blockquote' && bq.attribution).toBe('The Author');
   });
 
+  it('preserves list structure inside a blockquote (#116)', () => {
+    const { slides } = parseDocument(doc('## Slide\n\n> Intro\n> - first\n> - second\n'));
+    const bq = slides[0].elements.find((e) => e.type === 'blockquote');
+    const html = bq?.type === 'blockquote' ? bq.html ?? '' : '';
+    expect(html).toContain('<p>Intro</p>');
+    expect(html).toContain('<li>first</li>');
+    expect(html).toContain('<li>second</li>');
+    expect(html).not.toContain('firstsecond'); // no run-on flattening
+  });
+
+  it('keeps inline formatting in an attributed blockquote (#116)', () => {
+    const { slides } = parseDocument(doc('## Slide\n\n> A **bold** point\n> — The Author\n'));
+    const bq = slides[0].elements.find((e) => e.type === 'blockquote');
+    expect(bq?.type === 'blockquote' && bq.attribution).toBe('The Author');
+    expect(bq?.type === 'blockquote' && bq.html).toContain('<strong>bold</strong>');
+  });
+
   it('parses GFM table', () => {
     const { slides } = parseDocument(doc('## Slide\n\n| A | B |\n|---|---|\n| 1 | 2 |\n'));
     const table = slides[0].elements.find((e) => e.type === 'table');

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -226,15 +226,13 @@ function convertRoot(tree: Root, placeholders: Map<number, SlideElement>): Conve
 
       case 'blockquote': {
         const bq = node as Blockquote;
-        const text = toString(bq);
-        const lines = text.split('\n').filter(Boolean);
-        const lastLine = lines[lines.length - 1] ?? '';
-        const hasAttrib = lines.length > 1 && /^[—–\-]/.test(lastLine);
-        elements.push({
-          type: 'blockquote',
-          text: hasAttrib ? lines.slice(0, -1).join('\n') : text,
-          attribution: hasAttrib ? lastLine.replace(/^[—–\-]\s*/, '') : undefined,
-        });
+        // Attribution (— Author on the last line) applies to a single-paragraph
+        // quote; the body keeps its inline formatting via `html`. Structured
+        // quotes (lists, multiple blocks) render their markup through `html` too.
+        const attrib = extractAttribution(bq);
+        elements.push(attrib
+          ? { type: 'blockquote', text: attrib.children.map((c) => toString(c)).join(''), attribution: attrib.attribution, html: `<p>${inlineToHtml(attrib.children)}</p>` }
+          : { type: 'blockquote', text: toString(bq), html: blockquoteInnerHtml(bq) });
         break;
       }
 
@@ -328,6 +326,43 @@ function convertListItem(item: MdastListItem): ListItem {
     html,
     children: subList ? subList.children.map(convertListItem) : [],
   };
+}
+
+// Blockquote children → HTML, preserving paragraphs and (nested) lists.
+// Code/tables inside a quote are rare — fall back to their flattened text.
+function blockquoteInnerHtml(bq: Blockquote): string {
+  return bq.children.map((child) => {
+    if (child.type === 'paragraph') return `<p>${inlineToHtml((child as Paragraph).children)}</p>`;
+    if (child.type === 'list') return listToHtml(child as List);
+    return `<p>${escHtml(toString(child))}</p>`;
+  }).join('');
+}
+
+// A single-paragraph quote ending in a "— Author" line: split the attribution
+// off the last text node, keeping the body's inline nodes intact for formatting.
+function extractAttribution(bq: Blockquote): { children: Node[]; attribution: string } | null {
+  if (bq.children.length !== 1 || bq.children[0].type !== 'paragraph') return null;
+  const kids = [...(bq.children[0] as Paragraph).children] as any[];
+  const last = kids[kids.length - 1];
+  if (!last || last.type !== 'text') return null;
+  const nl = (last.value as string).lastIndexOf('\n');
+  if (nl < 0) return null;
+  const tail = (last.value as string).slice(nl + 1);
+  if (!/^\s*[—–\-]/.test(tail)) return null;
+  const children = [...kids.slice(0, -1), { ...last, value: (last.value as string).slice(0, nl) }] as Node[];
+  return { children, attribution: tail.replace(/^\s*[—–\-]\s*/, '') };
+}
+
+function listToHtml(l: List): string {
+  const tag = l.ordered ? 'ol' : 'ul';
+  const items = l.children.map((item) => {
+    const mi = item as MdastListItem;
+    const sub = mi.children.find((c): c is List => c.type === 'list');
+    const inner = (mi.children.filter((c) => c.type === 'paragraph') as Paragraph[])
+      .map((p) => inlineToHtml(p.children)).join(' ');
+    return `<li>${inner}${sub ? listToHtml(sub) : ''}</li>`;
+  }).join('');
+  return `<${tag}>${items}</${tag}>`;
 }
 
 // ── Inline node → HTML ───────────────────────────────────────────────────────

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -27,7 +27,7 @@ export type SlideElement =
   | { type: 'code'; lang: string; value: string }
   | { type: 'mermaid'; value: string }
   | { type: 'math'; value: string; display: boolean }
-  | { type: 'blockquote'; text: string; attribution?: string }
+  | { type: 'blockquote'; text: string; attribution?: string; html?: string }
   | { type: 'table'; headers: string[]; rows: string[][]; align?: ('left' | 'right' | 'center' | null)[] }
   | { type: 'youtube';  label: string; url: string }
   | { type: 'video';    label: string; src: string }


### PR DESCRIPTION
Blockquotes flattened all child content into one run-on string — a quote with a list rendered as `This is the important partfirstsecondthird`, and inline markup (bold/links/code) was lost.

Build the quote body from its child nodes instead:
- paragraphs and nested lists preserved (`blockquoteInnerHtml` / `listToHtml`)
- inline formatting via `inlineToHtml` on every path, including attributed quotes
- attribution (`— Author`) split off the trailing line, body keeps its markup

Not handled (falls back to flattened text): code blocks, tables, block math inside a quote — rare.

Tests: 2 added, 73/73 pass; tsc clean.

Closes #116