### PR TITLE
build(nix): add flake for reproducible Linux build + dev shell

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,25 @@
+name: Nix Build
+
+# Builds the flake so a broken flake.nix / stale hash is caught in review.
+# Runs only when the flake or its inputs (frontend, Tauri shell) change.
+on:
+  push:
+    branches: [main]
+    paths: [flake.nix, flake.lock, src/**, 'src-tauri/**', package-lock.json]
+  pull_request:
+    paths: [flake.nix, flake.lock, src/**, 'src-tauri/**', package-lock.json]
+
+jobs:
+  nix-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Build package + dev shell
+        run: |
+          nix build .#default -L
+          nix develop --command true

--- a/.github/workflows/nix-hash-sync.yml
+++ b/.github/workflows/nix-hash-sync.yml
@@ -1,0 +1,40 @@
+name: Nix Hash Sync
+
+# When a PR changes package-lock.json, recompute npmDepsHash and commit it
+# back so the flake keeps building. Same-repo PRs only — fork PRs get no write
+# token, so those contributors run packaging/nix/update-npm-hash.sh themselves
+# (the Nix Build check prints the expected hash on failure).
+on:
+  pull_request:
+    paths: [package-lock.json]
+
+jobs:
+  sync:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.head_ref }}
+          # PAT push retriggers Nix Build on the fix commit (GITHUB_TOKEN can't).
+          # No loop: the commit touches only flake.nix, this workflow watches
+          # package-lock.json. Without the PAT the hash still lands, but a
+          # maintainer must rerun Nix Build for a required check to clear.
+          token: ${{ secrets.NIX_HASH_SYNC_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Refresh npmDepsHash and commit if changed
+        run: |
+          bash packaging/nix/update-npm-hash.sh
+          if ! git diff --quiet flake.nix; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "build(nix): refresh npmDepsHash for lockfile change"
+            # Retry once against a concurrent push to the PR branch.
+            git push || { git pull --rebase && git push; }
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,9 @@ npm install
 npm run tauri dev      # development — hot-reload
 ```
 
+Nix users can skip the prerequisites — `nix develop` drops you in a shell with
+Rust, Node, and Tauri ready.
+
 Before opening a PR:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ sudo curl -o /etc/yum.repos.d/kova.repo \
 sudo dnf install kova   # openSUSE: zypper install kova
 ```
 
+**Nix (flakes)**
+
+```bash
+nix run github:KovaMD/Kova          # run without installing
+nix profile install github:KovaMD/Kova   # install into your profile
+```
+
+Or add `github:KovaMD/Kova` as a flake input and use `packages.<system>.default`.
+
 ## Building from source
 
 **Prerequisites:** [Node.js](https://nodejs.org/) 18+, [Rust](https://rustup.rs/) (stable), and [Tauri prerequisites](https://tauri.app/start/prerequisites/) for your platform.
@@ -71,6 +80,8 @@ npm install
 npm run tauri dev      # development — hot-reload
 npm run tauri build    # release binary
 ```
+
+Nix users can skip the prerequisites: `nix develop` drops you in a shell with Rust, Node, and Tauri ready.
 
 See the [Contributing guide](https://wiki.kova.md/contributing/) for more details, or [TRANSLATING.md](TRANSLATING.md) if you'd like to add a language.
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+{
+  description = "Kova — markdown presentation authoring tool";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    # Linux-only: webkitgtk_4_1/gtk3 don't build on darwin.
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        # Track the app version from tauri.conf.json so releases need no flake edit.
+        version = (builtins.fromJSON (builtins.readFile ./src-tauri/tauri.conf.json)).version;
+
+        # Dodges EGL_BAD_PARAMETER GL failures (issue #3); shared so package and
+        # dev shell can't drift. Drop when webkitgtk's dmabuf path stops being flaky.
+        dmabufVar = "WEBKIT_DISABLE_DMABUF_RENDERER";
+
+        # Runtime/build libraries the Tauri (webkitgtk) shell links against.
+        # gtk3/webkitgtk propagate cairo/pango/gdk-pixbuf/atk, so no need to list them.
+        libs = with pkgs; [ glib gtk3 webkitgtk_4_1 libsoup_3 openssl ];
+
+        # Frontend assets (dist/) built offline from package-lock.json.
+        # `npm run build` (tsc && vite build) is buildNpmPackage's default script.
+        # npmDepsHash pins the vendored deps — update it when package-lock.json
+        # changes (CI fails and prints the correct hash to paste in). Tried
+        # importNpmLock to drop the hash entirely, but it can't resolve this
+        # lockfile (ENOTCACHED on a transitive dep).
+        frontend = pkgs.buildNpmPackage {
+          pname = "kova-frontend";
+          inherit version;
+          src = ./.;
+          npmDepsHash = "sha256-1IxXr5irSQX1NVqplDSqVpmO1GzcxmyLv1XL4hTZWzI=";
+          installPhase = ''
+            runHook preInstall
+            cp -r dist "$out"
+            runHook postInstall
+          '';
+        };
+      in {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "kova";
+          inherit version;
+          src = ./src-tauri;
+          cargoLock.lockFile = ./src-tauri/Cargo.lock;
+
+          # Tauri embeds frontendDist (../dist) at compile time — supply the
+          # prebuilt assets instead of letting it shell out to npm.
+          preBuild = ''
+            cp -r ${frontend} ../dist
+          '';
+
+          nativeBuildInputs = with pkgs; [ pkg-config wrapGAppsHook3 ];
+          buildInputs = libs;
+
+          postInstall = ''
+            install -Dm644 kova.desktop $out/share/applications/kova.desktop
+            install -Dm644 icons/32x32.png       $out/share/icons/hicolor/32x32/apps/kova.png
+            install -Dm644 icons/64x64.png       $out/share/icons/hicolor/64x64/apps/kova.png
+            install -Dm644 icons/128x128.png     $out/share/icons/hicolor/128x128/apps/kova.png
+            install -Dm644 icons/128x128@2x.png  $out/share/icons/hicolor/256x256/apps/kova.png
+          '';
+
+          preFixup = ''
+            gappsWrapperArgs+=(--set ${dmabufVar} 1)
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Markdown presentation authoring tool";
+            homepage = "https://github.com/KovaMD/Kova";
+            license = licenses.gpl3Plus;
+            platforms = platforms.linux;
+            mainProgram = "kova";
+          };
+        };
+
+        # Contributor shell: rust + node + tauri, no system SDKs to install.
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [ nodejs cargo rustc rust-analyzer cargo-tauri pkg-config ];
+          buildInputs = libs;
+          shellHook = "export ${dmabufVar}=1";
+        };
+      });
+}

--- a/packaging/nix/update-npm-hash.sh
+++ b/packaging/nix/update-npm-hash.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Recompute the flake's npmDepsHash from package-lock.json and write it back.
+# Run after any dependency change. Needs Nix.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+# --inputs-from . pins prefetch-npm-deps to the flake's own nixpkgs.
+hash=$(nix run --inputs-from . nixpkgs#prefetch-npm-deps -- package-lock.json)
+# Fail loud if the line moved — a silent no-op would ship a stale hash.
+grep -q 'npmDepsHash = "' flake.nix || { echo "npmDepsHash line not found in flake.nix" >&2; exit 1; }
+# perl -pi is portable across macOS/Linux (BSD/GNU sed differ on -i).
+perl -pi -e "s|npmDepsHash = \".*\"|npmDepsHash = \"$hash\"|" flake.nix
+echo "npmDepsHash -> $hash"


### PR DESCRIPTION
Addresses the Nix ask in #9.

- `packages.default` — the Tauri app: `buildNpmPackage` builds the frontend `dist` offline, `rustPlatform.buildRustPackage` compiles the shell and wraps it with the webkitgtk/gtk runtime. `version` reads from `tauri.conf.json`, so releases need no flake edit.
- `devShells.default` — rust + node + tauri, no system SDKs.
- CI: `nix-build.yml` builds the flake on relevant PRs. `nix-hash-sync.yml` auto-commits a refreshed `npmDepsHash` on same-repo dep-bump PRs (fork PRs run `packaging/nix/update-npm-hash.sh`).
- README: `nix run` / `nix profile install` / `nix develop`.

`nix run github:KovaMD/Kova` · `nix develop`.

`WEBKIT_DISABLE_DMABUF_RENDERER=1` sidesteps the `EGL_BAD_PARAMETER` crash the AppImage hit (#3); the pinned webkitgtk + Mesa is the actual fix.

Built + headless smoke-tested on x86_64-linux (launches, no GL crash).

Flatpak (#9's other ask): separate follow-up.