### PR TITLE
packaging(flatpak): self-hosted Flatpak manifest + metainfo

### DIFF
--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -161,3 +161,110 @@ jobs:
             repo/rpm/ $USER@$HOST:/opt/kova/rpm-repo/data/
 
           rm /tmp/deploy_key
+
+  # Repacks the release .deb into a signed Flatpak ostree repo (Flathub is out —
+  # its no-LLM policy), served at flatpak.kova.md by the flatpak-repo service in
+  # infra/services. Needs the DNS record for flatpak.kova.md, like deb/rpm.
+  publish-flatpak:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Flatpak tooling + GNOME runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder rsync
+          flatpak remote-add --user --if-not-exists flathub \
+            https://dl.flathub.org/repo/ --gpg-import <(curl -fsSL https://dl.flathub.org/repo/flathub.gpg)
+          flatpak install --user -y --noninteractive flathub org.gnome.Platform//49 org.gnome.Sdk//49
+
+      - name: Resolve release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG=$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName -q '.[0].tagName')
+          fi
+          echo "RELEASE_TAG=$TAG" >> $GITHUB_ENV
+
+      - name: Download release .deb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "$RELEASE_TAG" --pattern "Kova_Linux.deb" \
+            --dir packaging/flatpak --repo ${{ github.repository }}
+          mv packaging/flatpak/Kova_Linux.deb packaging/flatpak/kova.deb
+
+          # Stamp this release into the metainfo so software centers show the
+          # right version — the checked-in value is a placeholder, not per-release.
+          sed -i "s|<release version=\"[^\"]*\" date=\"[^\"]*\"/>|<release version=\"${RELEASE_TAG#v}\" date=\"$(date +%F)\"/>|" \
+            packaging/flatpak/md.kova.app.metainfo.xml
+
+      - name: Import GPG key and preset passphrase for signing
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          GPG_KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/{print $5; exit}')
+          echo "GPG_KEY_ID=$GPG_KEY_ID" >> $GITHUB_ENV
+          # flatpak-builder/ostree invoke gpg themselves (no way to pass
+          # --passphrase per call as the deb/rpm job does), so preset it into the
+          # agent for unattended signing.
+          echo "allow-preset-passphrase" >> ~/.gnupg/gpg-agent.conf
+          gpgconf --reload gpg-agent
+          PRESET=$(find /usr/lib -name gpg-preset-passphrase 2>/dev/null | head -1)
+          # Preset every keygrip (primary + any signing subkey) — whichever gpg
+          # picks to sign is then cached, regardless of the key's shape.
+          gpg --batch --with-keygrip --list-secret-keys "$GPG_KEY_ID" \
+            | awk '/Keygrip/{print $3}' \
+            | while read -r grip; do "$PRESET" --preset --passphrase "$GPG_PASSPHRASE" "$grip"; done
+
+      - name: Deploy signed Flatpak repo to VPS
+        env:
+          SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+          HOST: ${{ secrets.HETZNER_HOST }}
+          USER: ${{ secrets.HETZNER_USER }}
+          KNOWN_HOSTS: ${{ secrets.HETZNER_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          echo "$SSH_KEY" > /tmp/deploy_key
+          chmod 600 /tmp/deploy_key
+          SSH_OPTS="-i /tmp/deploy_key -o StrictHostKeyChecking=yes"
+          REMOTE=/opt/kova/flatpak-repo/data
+
+          # Pull the existing repo so prior versions' objects (and static deltas)
+          # survive the --delete push below. ssh-mkdir first so the first run has
+          # an (empty) source; no `|| true` — a flaky pull must abort here, else
+          # we'd rebuild from nothing and --delete would wipe every past version.
+          mkdir -p repo/flatpak
+          ssh $SSH_OPTS "$USER@$HOST" "mkdir -p $REMOTE"
+          rsync -az -e "ssh $SSH_OPTS" $USER@$HOST:$REMOTE/ repo/flatpak/
+
+          flatpak-builder --user --force-clean --disable-rofiles-fuse \
+            --gpg-sign="$GPG_KEY_ID" --gpg-homedir="$HOME/.gnupg" \
+            --repo=repo/flatpak build packaging/flatpak/md.kova.app.yml
+          flatpak build-update-repo --generate-static-deltas --prune \
+            --gpg-sign="$GPG_KEY_ID" --gpg-homedir="$HOME/.gnupg" repo/flatpak
+
+          # One-click install descriptor + public key.
+          gpg --export "$GPG_KEY_ID" > repo/flatpak/kova.gpg
+          cat > repo/flatpak/kova.flatpakref << EOF
+          [Flatpak Ref]
+          Title=Kova
+          Name=md.kova.app
+          Branch=master
+          Url=https://flatpak.kova.md
+          GPGKey=$(gpg --export "$GPG_KEY_ID" | base64 -w0)
+          IsRuntime=false
+          RuntimeRepo=https://dl.flathub.org/repo/flathub.flatpakref
+          EOF
+
+          rsync -avz --delete -e "ssh $SSH_OPTS" repo/flatpak/ $USER@$HOST:$REMOTE/
+          rm /tmp/deploy_key

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ nix profile install github:KovaMD/Kova   # install into your profile
 
 Or add `github:KovaMD/Kova` as a flake input and use `packages.<system>.default`.
 
+**Flatpak**
+
+Flathub's current policy excludes LLM-assisted apps, so Kova ships from a self-hosted Flatpak repo:
+
+```bash
+flatpak install https://flatpak.kova.md/kova.flatpakref
+flatpak run md.kova.app
+```
+
+Or build it locally from the manifest:
+
+```bash
+flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//49
+curl -fsSL -o packaging/flatpak/kova.deb \
+  https://github.com/KovaMD/Kova/releases/latest/download/Kova_Linux.deb
+flatpak-builder --user --install --force-clean build packaging/flatpak/md.kova.app.yml
+flatpak run md.kova.app
+```
+
 ## Building from source
 
 **Prerequisites:** [Node.js](https://nodejs.org/) 18+, [Rust](https://rustup.rs/) (stable), and [Tauri prerequisites](https://tauri.app/start/prerequisites/) for your platform.

--- a/infra/services/docker-compose.yml
+++ b/infra/services/docker-compose.yml
@@ -29,6 +29,21 @@ services:
     networks:
       - proxy
 
+  flatpak-repo:
+    image: nginx:stable-alpine
+    container_name: flatpak-repo
+    restart: unless-stopped
+    volumes:
+      - ./flatpak-repo/data:/usr/share/nginx/html:ro
+      - ./flatpak-repo/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.flatpak.rule=Host(`flatpak.kova.md`)"
+      - "traefik.http.routers.flatpak.entrypoints=websecure"
+      - "traefik.http.routers.flatpak.tls.certresolver=letsencrypt"
+    networks:
+      - proxy
+
   themes:
     image: nginx:stable-alpine
     container_name: themes

--- a/infra/services/flatpak-repo/nginx.conf
+++ b/infra/services/flatpak-repo/nginx.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    location / {
+        autoindex on;
+        autoindex_exact_size off;
+        autoindex_localtime on;
+    }
+
+    types {
+        application/vnd.flatpak.ref  flatpakref;
+        application/pgp-keys         gpg;
+        text/plain                   asc;
+    }
+
+    # ostree objects are content-addressed → immutable; the summary changes
+    # every publish, so it must not be cached.
+    location /objects/     { add_header Cache-Control "public, max-age=31536000, immutable"; }
+    location /deltas/      { add_header Cache-Control "public, max-age=31536000, immutable"; }
+    location = /summary     { add_header Cache-Control "no-cache, must-revalidate"; }
+    location = /summary.sig { add_header Cache-Control "no-cache, must-revalidate"; }
+}

--- a/packaging/flatpak/md.kova.app.metainfo.xml
+++ b/packaging/flatpak/md.kova.app.metainfo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>md.kova.app</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Kova</name>
+  <summary>Markdown presentation authoring tool</summary>
+  <description>
+    <p>
+      Kova turns plain Markdown into polished slides — with live preview,
+      multiple layouts, theming, math, Mermaid diagrams, and PPTX export.
+    </p>
+  </description>
+  <launchable type="desktop-id">md.kova.app.desktop</launchable>
+  <url type="homepage">https://github.com/KovaMD/Kova</url>
+  <url type="bugtracker">https://github.com/KovaMD/Kova/issues</url>
+  <developer id="md.kova">
+    <name>Kova</name>
+  </developer>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <!-- Placeholder — publish-repos.yml stamps the real version/date per release. -->
+    <release version="0.0.0" date="1970-01-01"/>
+  </releases>
+</component>

--- a/packaging/flatpak/md.kova.app.yml
+++ b/packaging/flatpak/md.kova.app.yml
@@ -1,0 +1,46 @@
+# Flatpak for Kova. Repacks the tested release .deb into the GNOME runtime
+# (which ships webkit2gtk-4.1 + libsoup3) rather than compiling from source —
+# no offline node/cargo source generators to maintain.
+#
+# The .deb is provided as a local file (kova.deb next to this manifest), so
+# there's no pinned url/sha to bump per release — the release CI drops in the
+# freshly built .deb, and for a local build you fetch it first:
+#   curl -fsSL -o packaging/flatpak/kova.deb \
+#     https://github.com/KovaMD/Kova/releases/latest/download/Kova_Linux.deb
+#   flatpak-builder --user --install --force-clean build packaging/flatpak/md.kova.app.yml
+id: md.kova.app
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: kova
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri              # GPU access; with the runtime's Mesa this avoids the #3 EGL crash
+  - --share=ipc
+  - --share=network           # theme library + update checks
+  - --filesystem=home         # open/save .md files under $HOME; for decks elsewhere, flatpak override --filesystem=…
+  - --env=WEBKIT_DISABLE_DMABUF_RENDERER=1   # workaround for the #3 EGL crash; drop when webkitgtk's dmabuf path is fixed
+
+modules:
+  - name: kova
+    buildsystem: simple
+    build-commands:
+      - ar x kova.deb
+      - tar -xf data.tar.*   # dpkg may compress as gz/xz/zst
+      - install -Dm755 usr/bin/kova /app/bin/kova
+      - desktop-file-edit --set-icon=md.kova.app usr/share/applications/Kova.desktop
+      - install -Dm644 usr/share/applications/Kova.desktop /app/share/applications/md.kova.app.desktop
+      # Rename each packaged icon (kova.png) to the app id, keeping its size dir.
+      - |
+        for png in $(find usr/share/icons/hicolor -name kova.png); do
+          size=$(basename "$(dirname "$(dirname "$png")")")
+          install -Dm644 "$png" "/app/share/icons/hicolor/$size/apps/md.kova.app.png"
+        done
+      - install -Dm644 md.kova.app.metainfo.xml /app/share/metainfo/md.kova.app.metainfo.xml
+    sources:
+      - type: file
+        path: kova.deb
+      - type: file
+        path: md.kova.app.metainfo.xml


### PR DESCRIPTION
Addresses the Flatpak ask in #9.

Repacks the tested release `.deb` into the GNOME 49 runtime (webkit2gtk-4.1 + libsoup3) — no in-sandbox source build, so no offline node/cargo generators. The `.deb` is a local source, so nothing to bump per release except the metainfo version. `WEBKIT_DISABLE_DMABUF_RENDERER=1` + the runtime Mesa sidestep the AppImage EGL crash (#3).

**Release publishing** — `publish-repos.yml` gains a `publish-flatpak` job: builds a GPG-signed ostree repo (reuses the existing signing key + Hetzner rsync to `/opt/kova/flatpak-repo/data`), pulls the repo first so old versions/deltas survive, emits a one-click `kova.flatpakref`.

**Serving** — a `flatpak-repo` service in `infra/services` (Traefik + nginx) serves it at `flatpak.kova.md`, mirroring the deb/rpm services.

Manifest, signed build, and GPG-verified install all tested on x86_64; metainfo passes `appstreamcli validate`; signing/preset-passphrase/repo commands validated end-to-end with a throwaway key.

**Yours to set up once:** the `flatpak.kova.md` DNS record (everything else — vhost, cert, rsync path — is in this PR). CI reuses existing secrets.