### PR TITLE
feat(editor): Find dialog with slide number jump

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1490,7 +1490,9 @@ export default function App() {
 
   const runFind = useCallback((dir: 1 | -1 = 1) => {
     if (findMode === 'slide') {
-      const n = parseInt(findQuery.trim(), 10);
+      const trimmed = findQuery.trim();
+      if (!/^\d+$/.test(trimmed)) return;
+      const n = Number(trimmed);
       if (!Number.isFinite(n) || n < 1 || n > slides.length) return;
       const idx = n - 1;
       setCurrentSlideIndex(idx);
@@ -2127,7 +2129,10 @@ export default function App() {
                   type="radio"
                   name="find-mode"
                   checked={findMode === 'slide'}
-                  onChange={() => setFindMode('slide')}
+                  onChange={() => {
+                    setFindMode('slide');
+                    setFindQuery((q) => q.replace(/\D+/g, ''));
+                  }}
                 />
                 {t('editor.findModeSlide')}
               </label>
@@ -2140,7 +2145,10 @@ export default function App() {
                 placeholder={findMode === 'slide'
                   ? t('editor.findPlaceholderSlide', { total: slides.length })
                   : t('editor.findPlaceholderText')}
-                onChange={(e) => setFindQuery(e.target.value)}
+                onChange={(e) => {
+                  const next = e.target.value;
+                  setFindQuery(findMode === 'slide' ? next.replace(/\D+/g, '') : next);
+                }}
                 onKeyDown={(e) => {
                   if (e.key === 'Escape') { e.preventDefault(); setFindOpen(false); editorRef.current?.focus(); }
                   if (e.key === 'Enter') { e.preventDefault(); runFind(e.shiftKey ? -1 : 1); }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1881,6 +1881,10 @@ export default function App() {
               <button className="btn-group-menu-item btn-group-menu-item--shortcut" onClick={() => { setEditMenuOpen(false); editorRef.current?.selectAll(); }}>
                 {t('app.menuSelectAll')} <span>{formatCombo('ctrl+a')}</span>
               </button>
+              <div className="btn-group-menu-separator" />
+              <button className="btn-group-menu-item btn-group-menu-item--shortcut" onClick={() => { setEditMenuOpen(false); openFindDialog(); }}>
+                {t('editor.findDialogTitle')} <span>{formatCombo('ctrl+f')}</span>
+              </button>
             </div>
           )}
         </div>}
@@ -2075,6 +2079,14 @@ export default function App() {
             role="dialog"
             aria-label={t('editor.findDialogTitle')}
             onMouseDown={(e) => e.stopPropagation()}
+            tabIndex={-1}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setFindOpen(false);
+                editorRef.current?.focus();
+              }
+            }}
             style={{
               position: 'fixed',
               left: '50%',
@@ -2094,10 +2106,10 @@ export default function App() {
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
               <div style={{ fontWeight: 600 }}>{t('editor.findDialogTitle')}</div>
               <button
+                className="btn"
                 onClick={() => { setFindOpen(false); editorRef.current?.focus(); }}
-                style={{ border: 'none', background: 'transparent', color: 'var(--text-dim)', cursor: 'pointer', fontSize: 16, lineHeight: 1 }}
                 aria-label={t('common.close')}
-              >×</button>
+              >{t('common.close')}</button>
             </div>
 
             <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 8 }}>
@@ -2146,22 +2158,22 @@ export default function App() {
               {findMode === 'text' ? (
                 <>
                   <button
+                    className="btn"
                     onClick={() => runFind(-1)}
-                    style={{ padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--bg-panel)', color: 'var(--text-primary)', cursor: 'pointer' }}
                   >
                     {t('editor.findPrevious')}
                   </button>
                   <button
+                    className="btn btn--primary"
                     onClick={() => runFind(1)}
-                    style={{ padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--bg-panel)', color: 'var(--text-primary)', cursor: 'pointer' }}
                   >
                     {t('editor.findNext')}
                   </button>
                 </>
               ) : (
                 <button
+                  className="btn btn--primary"
                   onClick={() => runFind(1)}
-                  style={{ padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--bg-panel)', color: 'var(--text-primary)', cursor: 'pointer' }}
                 >
                   {t('common.ok')}
                 </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,6 +143,10 @@ export default function App() {
   const [keybindings, setKeybindings]     = useState<Keybindings>({ path: '', combos: {} });
   const [warnMessage, setWarnMessage]     = useState<string | null>(null);
   const warnTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [findOpen, setFindOpen] = useState(false);
+  const [findMode, setFindMode] = useState<'text' | 'slide'>('text');
+  const [findQuery, setFindQuery] = useState('');
+  const findInputRef = useRef<HTMLInputElement>(null);
   const [showExternalChangeDialog, setShowExternalChangeDialog] = useState(false);
   const [pdfOptionsOpen, setPdfOptionsOpen] = useState(false);
   const [pdfPerPage, setPdfPerPage]         = useState(1);
@@ -1479,6 +1483,25 @@ export default function App() {
     warnTimerRef.current = setTimeout(() => setWarnMessage(null), 6000);
   }, []);
 
+  const openFindDialog = useCallback(() => {
+    setFindOpen(true);
+    setTimeout(() => findInputRef.current?.select(), 0);
+  }, []);
+
+  const runFind = useCallback((dir: 1 | -1 = 1) => {
+    if (findMode === 'slide') {
+      const n = parseInt(findQuery.trim(), 10);
+      if (!Number.isFinite(n) || n < 1 || n > slides.length) return;
+      const idx = n - 1;
+      setCurrentSlideIndex(idx);
+      setTimeout(() => editorRef.current?.scrollToSlide(idx), 50);
+      setFindOpen(false);
+      editorRef.current?.focus();
+      return;
+    }
+    editorRef.current?.findNext(findQuery, dir);
+  }, [findMode, findQuery, slides.length]);
+
   const handleSettingsChange = useCallback((s: AppSettings) => {
     setSettings(s);
     saveSettings(s);
@@ -1997,6 +2020,7 @@ export default function App() {
               onCursorSlide={setCurrentSlideIndex}
               onWarn={handleWarn}
               onSaveAs={handleSaveAs}
+              onRequestFind={openFindDialog}
               focusMode={focusMode}
               filePath={filePath}
               uiTheme={resolvedUiTheme}
@@ -2041,6 +2065,111 @@ export default function App() {
         onVersionClick={availableUpdate ? () => { setShowSettings(true); setSettingsScrollToUpdates(true); } : undefined}
         locale={settings.locale}
       />
+
+      {findOpen && (
+        <div
+          style={{ position: 'fixed', inset: 0, zIndex: 10000 }}
+          onMouseDown={(e) => { e.preventDefault(); setFindOpen(false); editorRef.current?.focus(); }}
+        >
+          <div
+            role="dialog"
+            aria-label={t('editor.findDialogTitle')}
+            onMouseDown={(e) => e.stopPropagation()}
+            style={{
+              position: 'fixed',
+              left: '50%',
+              top: 18,
+              transform: 'translateX(-50%)',
+              width: 420,
+              maxWidth: 'calc(100vw - 32px)',
+              padding: 10,
+              borderRadius: 10,
+              background: 'var(--bg-elevated)',
+              border: '1px solid var(--border-alt)',
+              boxShadow: '0 10px 40px rgba(0,0,0,0.55)',
+              color: 'var(--text-primary)',
+              fontSize: 13,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+              <div style={{ fontWeight: 600 }}>{t('editor.findDialogTitle')}</div>
+              <button
+                onClick={() => { setFindOpen(false); editorRef.current?.focus(); }}
+                style={{ border: 'none', background: 'transparent', color: 'var(--text-dim)', cursor: 'pointer', fontSize: 16, lineHeight: 1 }}
+                aria-label={t('common.close')}
+              >×</button>
+            </div>
+
+            <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 8 }}>
+              <label style={{ display: 'flex', gap: 6, alignItems: 'center', cursor: 'pointer' }}>
+                <input
+                  type="radio"
+                  name="find-mode"
+                  checked={findMode === 'text'}
+                  onChange={() => setFindMode('text')}
+                />
+                {t('editor.findModeText')}
+              </label>
+              <label style={{ display: 'flex', gap: 6, alignItems: 'center', cursor: 'pointer' }}>
+                <input
+                  type="radio"
+                  name="find-mode"
+                  checked={findMode === 'slide'}
+                  onChange={() => setFindMode('slide')}
+                />
+                {t('editor.findModeSlide')}
+              </label>
+            </div>
+
+            <div style={{ display: 'flex', gap: 8 }}>
+              <input
+                ref={findInputRef}
+                value={findQuery}
+                placeholder={findMode === 'slide'
+                  ? t('editor.findPlaceholderSlide', { total: slides.length })
+                  : t('editor.findPlaceholderText')}
+                onChange={(e) => setFindQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') { e.preventDefault(); setFindOpen(false); editorRef.current?.focus(); }
+                  if (e.key === 'Enter') { e.preventDefault(); runFind(e.shiftKey ? -1 : 1); }
+                }}
+                style={{
+                  flex: 1,
+                  padding: '8px 10px',
+                  borderRadius: 8,
+                  border: '1px solid var(--border)',
+                  background: 'var(--bg-panel)',
+                  color: 'var(--text-primary)',
+                  outline: 'none',
+                }}
+              />
+              {findMode === 'text' ? (
+                <>
+                  <button
+                    onClick={() => runFind(-1)}
+                    style={{ padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--bg-panel)', color: 'var(--text-primary)', cursor: 'pointer' }}
+                  >
+                    {t('editor.findPrevious')}
+                  </button>
+                  <button
+                    onClick={() => runFind(1)}
+                    style={{ padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--bg-panel)', color: 'var(--text-primary)', cursor: 'pointer' }}
+                  >
+                    {t('editor.findNext')}
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={() => runFind(1)}
+                  style={{ padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--bg-panel)', color: 'var(--text-primary)', cursor: 'pointer' }}
+                >
+                  {t('common.ok')}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {showSettings && (
         <SettingsModal

--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -531,6 +531,30 @@ export interface EditorHandle {
   focus: () => void;
 }
 
+export function findNextRange(doc: string, query: string, start: number, dir: 1 | -1 = 1): { from: number; to: number } | null {
+  const q = query.trim();
+  if (!q) return null;
+
+  const hay = doc.toLowerCase();
+  const needle = q.toLowerCase();
+
+  const boundedStart = Math.max(0, Math.min(start, hay.length));
+  let idx: number;
+  if (dir === 1) {
+    idx = hay.indexOf(needle, boundedStart);
+  } else {
+    idx = boundedStart === 0 ? -1 : hay.lastIndexOf(needle, Math.min(hay.length - 1, boundedStart - 1));
+  }
+
+  // Wrap.
+  if (idx === -1) {
+    idx = dir === 1 ? hay.indexOf(needle, 0) : hay.lastIndexOf(needle);
+  }
+  if (idx === -1) return null;
+
+  return { from: idx, to: idx + needle.length };
+}
+
 interface ContextMenuState { x: number; y: number; hasSelection: boolean; clickPos: number | null }
 interface ConfirmState { title: string; message: string; okLabel: string; resolve: (ok: boolean) => void }
 
@@ -660,27 +684,15 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
     findNext(query: string, dir: 1 | -1 = 1) {
       const view = viewRef.current;
       if (!view) return;
-      const q = query.trim();
-      if (!q) return;
 
       const doc = view.state.doc.toString();
       const sel = view.state.selection.main;
       const start = dir === 1 ? sel.to : sel.from;
 
-      const hay = doc.toLowerCase();
-      const needle = q.toLowerCase();
+      const range = findNextRange(doc, query, start, dir);
+      if (!range) return;
 
-      let idx = dir === 1
-        ? hay.indexOf(needle, start)
-        : hay.lastIndexOf(needle, Math.max(0, start - 1));
-
-      if (idx === -1) {
-        idx = dir === 1 ? hay.indexOf(needle, 0) : hay.lastIndexOf(needle);
-      }
-      if (idx === -1) return;
-
-      const from = idx;
-      const to = idx + needle.length;
+      const { from, to } = range;
       view.dispatch({
         selection: EditorSelection.range(from, to),
         effects: EditorView.scrollIntoView(from, { y: 'center', yMargin: 12 }),

--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -33,6 +33,7 @@ interface Props {
   onCursorSlide?: (index: number) => void;
   onWarn?: (msg: string) => void;
   onSaveAs?: () => Promise<string | null>;
+  onRequestFind?: () => void;
   focusMode?: boolean;
   filePath?: string | null;
   uiTheme?: 'dark' | 'light';
@@ -523,6 +524,7 @@ export type FormatCmd =
 export interface EditorHandle {
   runFormat: (cmd: FormatCmd) => void;
   scrollToSlide: (index: number) => void;
+  findNext: (query: string, dir?: 1 | -1) => void;
   undo: () => void;
   redo: () => void;
   selectAll: () => void;
@@ -533,7 +535,7 @@ interface ContextMenuState { x: number; y: number; hasSelection: boolean; clickP
 interface ConfirmState { title: string; message: string; okLabel: string; resolve: (ok: boolean) => void }
 
 export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
-  { content, onChange, onCursorSlide, onWarn, onSaveAs, focusMode = false, filePath, uiTheme = 'dark', editorFontFamily = DEFAULT_FONT_FAMILY, wordWrap = true, spellCheckEnabled = false, spellCheckLanguage = 'en_US' }: Props,
+  { content, onChange, onCursorSlide, onWarn, onSaveAs, onRequestFind, focusMode = false, filePath, uiTheme = 'dark', editorFontFamily = DEFAULT_FONT_FAMILY, wordWrap = true, spellCheckEnabled = false, spellCheckLanguage = 'en_US' }: Props,
   ref,
 ) {
   const t = useT();
@@ -544,6 +546,7 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
   const onCursorSlideRef = useRef(onCursorSlide);
   const onWarnRef = useRef(onWarn);
   const onSaveAsRef = useRef(onSaveAs);
+  const onRequestFindRef = useRef(onRequestFind);
   const filePathRef = useRef(filePath);
   const uiThemeRef = useRef(uiTheme);
   const spellCheckEnabledRef = useRef(spellCheckEnabled);
@@ -560,6 +563,7 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
   useEffect(() => { onCursorSlideRef.current = onCursorSlide; }, [onCursorSlide]);
   useEffect(() => { onWarnRef.current = onWarn; }, [onWarn]);
   useEffect(() => { onSaveAsRef.current = onSaveAs; }, [onSaveAs]);
+  useEffect(() => { onRequestFindRef.current = onRequestFind; }, [onRequestFind]);
   useEffect(() => { filePathRef.current = filePath; }, [filePath]);
   useEffect(() => { uiThemeRef.current = uiTheme; }, [uiTheme]);
   useEffect(() => { spellCheckEnabledRef.current = spellCheckEnabled; }, [spellCheckEnabled]);
@@ -652,6 +656,37 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
       });
       view.focus();
     },
+
+    findNext(query: string, dir: 1 | -1 = 1) {
+      const view = viewRef.current;
+      if (!view) return;
+      const q = query.trim();
+      if (!q) return;
+
+      const doc = view.state.doc.toString();
+      const sel = view.state.selection.main;
+      const start = dir === 1 ? sel.to : sel.from;
+
+      const hay = doc.toLowerCase();
+      const needle = q.toLowerCase();
+
+      let idx = dir === 1
+        ? hay.indexOf(needle, start)
+        : hay.lastIndexOf(needle, Math.max(0, start - 1));
+
+      if (idx === -1) {
+        idx = dir === 1 ? hay.indexOf(needle, 0) : hay.lastIndexOf(needle);
+      }
+      if (idx === -1) return;
+
+      const from = idx;
+      const to = idx + needle.length;
+      view.dispatch({
+        selection: EditorSelection.range(from, to),
+        effects: EditorView.scrollIntoView(from, { y: 'center', yMargin: 12 }),
+      });
+      view.focus();
+    },
   }), []);
 
   // Create editor once
@@ -685,6 +720,14 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
         markdown({ codeLanguages: languages }),
         Prec.high(keymap.of([
           indentWithTab,
+          {
+            key: 'Mod-f',
+            run: () => {
+              onRequestFindRef.current?.();
+              return true;
+            },
+            preventDefault: true,
+          },
           { key: 'Mod-b',       run: makeWrapCommand('**',  '**',   'bold text') },
           { key: 'Mod-i',       run: makeWrapCommand('*',   '*',    'italic text') },
           { key: 'Mod-u',       run: makeWrapCommand('<u>', '</u>', 'underlined text') },

--- a/src/components/layout/__tests__/findNextRange.test.ts
+++ b/src/components/layout/__tests__/findNextRange.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+
+import { findNextRange } from '../EditorPanel';
+
+describe('findNextRange', () => {
+  it('wraps around when searching forward past the last match', () => {
+    const doc = 'hello world\nhello again\n';
+    // start after the last "hello"
+    const start = doc.length;
+    const r = findNextRange(doc, 'hello', start, 1);
+    expect(r).toEqual({ from: 0, to: 5 });
+  });
+
+  it('wraps around when searching backward before the first match', () => {
+    const doc = 'hello world\nhello again\n';
+    const r = findNextRange(doc, 'hello', 0, -1);
+    // should wrap to the last "hello"
+    expect(r).toEqual({ from: 12, to: 17 });
+  });
+
+  it('returns null for empty query', () => {
+    expect(findNextRange('abc', '   ', 0, 1)).toBeNull();
+  });
+});
+

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -137,6 +137,13 @@ const en = {
   },
   editor: {
     contextMenuAriaLabel: 'Context menu',
+    findDialogTitle: 'Find',
+    findModeText: 'Text',
+    findModeSlide: 'Slide #',
+    findPlaceholderText: 'Find in document…',
+    findPlaceholderSlide: 'Go to slide (1–{{total}})…',
+    findNext: 'Next',
+    findPrevious: 'Previous',
     newPresentationHint: '{{mod}}+N — new presentation',
     openFileHint: '{{mod}}+O — open file',
     tocHint: 'Right-click → Insert → Table of Contents',


### PR DESCRIPTION
Closes #132.

## Summary
- Adds `Ctrl/Cmd+F` in editor to open a small Find dialog.
- Dialog supports **Text** search (next/previous) and **Slide #** jump (1-based), reusing existing `scrollToSlide` behavior.

## Test plan
- Press `Ctrl/Cmd+F` → dialog opens
- **Text** mode: enter a word → Enter (next), Shift+Enter (previous)
- **Slide #** mode: enter a number → Enter/OK jumps to that slide and focuses editor
- `npm test`