### PR TITLE
feat(sheet): computed tables in Markdown (#133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Kova turns plain Markdown into polished slides — with live preview, multiple l
 - **Rich media** — images, local video, YouTube embeds, and polls
 - **Fullscreen presentation** — speaker notes, slide counter, keyboard and click navigation
 - **Export** — PowerPoint (16:9 and 4:3), PDF (with speaker notes), and standalone HTML
+- **Computed tables** — annotate a table with `!sheet` and write formulas in the cells (`=qty * unit`, `=sum(total)`); Kova computes them, the source keeps only the formulas. See [`examples/sheet-basics.md`](examples/sheet-basics.md)
 
 ## Download
 

--- a/examples/sheet-basics.md
+++ b/examples/sheet-basics.md
@@ -1,0 +1,100 @@
+---
+title: Computed tables
+author: Kova
+---
+
+# Computed tables
+
+Derived numbers — totals, VAT, percentages — usually get computed in a spreadsheet and pasted in as dead values. Change an input and the deck rots.
+
+Annotate a table with `!sheet` and Kova computes it. The source keeps formulas, never cached values.
+
+---
+
+## A bill of materials
+
+```markdown
+!let vat = 0.255
+
+!sheet
+| item   | qty | unit  | total                   |
+|--------|----:|------:|------------------------:|
+| motor  |   2 | 12.50 | =qty * unit             |
+| ESC    |   2 |  8.00 | =qty * unit             |
+| !Total |     |       | =sum(total) * (1 + vat) |
+```
+
+!let vat = 0.255
+
+!sheet
+| item   | qty | unit  | total                   |
+|--------|----:|------:|------------------------:|
+| motor  |   2 | 12.50 | =qty * unit             |
+| ESC    |   2 |  8.00 | =qty * unit             |
+| !Total |     |       | =sum(total) * (1 + vat) |
+
+---
+
+## What just happened
+
+- `!let vat = 0.255` — a document constant. Declare it anywhere; every slide sees it.
+- `!sheet` — sits directly above the table. A table without it is left alone, even if a cell starts with `=`.
+- `=qty * unit` — a **row** formula. A bare column name means *this row's* value.
+- `| !Total |` — a leading `!` makes a **footer row**. The `!` is stripped when rendered.
+- `=sum(total)` — a **footer** formula. There a column name means the whole column, and footer rows are never counted in it.
+
+Column names come from the header: lowercased, punctuation dropped, spaces to underscores. `Unit (€)` becomes `unit`.
+
+---
+
+## Chaining columns
+
+```markdown
+!sheet
+| role   | days | rate | fee          |
+|--------|-----:|-----:|-------------:|
+| design |    4 |  620 | =days * rate |
+| build  |   12 |  680 | =days * rate |
+| !Total |      |      | =sum(fee)    |
+```
+
+!sheet
+| role   | days | rate | fee          |
+|--------|-----:|-----:|-------------:|
+| design |    4 |  620 | =days * rate |
+| build  |   12 |  680 | =days * rate |
+| !Total |      |      | =sum(fee)    |
+
+---
+
+## When a formula is wrong
+
+```markdown
+!sheet
+| item  | qty | unit  | total        |
+|-------|----:|------:|-------------:|
+| motor |   2 | 12.50 | =qty * unit  |
+| ESC   |   2 |  8.00 | =qty * untis |
+```
+
+!sheet
+| item  | qty | unit  | total        |
+|-------|----:|------:|-------------:|
+| motor |   2 | 12.50 | =qty * unit  |
+| ESC   |   2 |  8.00 | =qty * untis |
+
+---
+
+## Errors stay put
+
+The bad cell shows its error, the rest of the table computes, and the slide renders. Kova re-parses on every keystroke, so a half-typed formula must never blank a slide.
+
+That error text is also what lands in a PPTX or PDF export. A broken deck should look broken, not quietly ship a wrong number.
+
+---
+
+## Degrades gracefully
+
+Open this file in any Markdown viewer that has never heard of Kova and you still get a valid table — with `=qty * unit` in the derived cells instead of numbers, and a stray `!` in front of the footer labels.
+
+Legible, honest, and diffable. That is the whole point.

--- a/examples/sheet-reference.md
+++ b/examples/sheet-reference.md
@@ -1,0 +1,226 @@
+---
+title: Sheet reference
+author: Kova
+---
+
+# `!sheet` reference
+
+Every directive, operator and function: the source, then what it renders. Doubles as a manual test — if a slide here looks wrong, something is broken.
+
+---
+
+## Directives
+
+- `!sheet` — marks the table on the next line as computed. Takes `precision=N` (default 2).
+- `!let name = expr` — a document-wide constant. A literal, or an expression over earlier constants — never over table data.
+- `!` first in a row's first cell — makes it a footer row, where a column name means the whole column. A label that really starts with `!` escapes it as `\!`.
+
+`!include`, `!fmt` and `!code` are reserved and currently error out, so decks written today will not collide with them later.
+
+---
+
+## Arithmetic
+
+```markdown
+!let base = 10
+
+!sheet
+| what   | result    |
+|--------|----------:|
+| add    | =base + 5 |
+| divide | =base / 4 |
+| negate | =-base    |
+```
+
+!let base = 10
+
+!sheet
+| what   | result    |
+|--------|----------:|
+| add    | =base + 5 |
+| divide | =base / 4 |
+| negate | =-base    |
+
+---
+
+## Precedence
+
+```markdown
+!sheet
+| what        | result          |
+|-------------|----------------:|
+| power       | =2 ^ 3 ^ 2      |
+| plus, times | =base + 2 * 3   |
+| parentheses | =(base + 2) * 3 |
+```
+
+!sheet
+| what        | result          |
+|-------------|----------------:|
+| power       | =2 ^ 3 ^ 2      |
+| plus, times | =base + 2 * 3   |
+| parentheses | =(base + 2) * 3 |
+
+---
+
+## Operator notes
+
+`^` is right-associative, so `2 ^ 3 ^ 2` is 512, not 64.
+
+`*` and `/` bind tighter than `+` and `-`, and parentheses override both.
+
+The full set: `+ - * / % ^`, the comparisons, `and` / `or` / `not`, and the ternary `cond ? a : b`.
+
+---
+
+## Comparisons and logic
+
+```markdown
+!sheet precision=0
+| what    | result                  |
+|---------|------------------------:|
+| ternary | =base > 5 ? 1 : 0       |
+| if()    | =if(base == 10, 100, 0) |
+```
+
+!sheet precision=0
+| what    | result                  |
+|---------|------------------------:|
+| ternary | =base > 5 ? 1 : 0       |
+| if()    | =if(base == 10, 100, 0) |
+
+---
+
+## Scalar functions
+
+```markdown
+!sheet
+| call   | result               |
+|--------|---------------------:|
+| round  | =round(3.14159, 2)   |
+| abs    | =abs(-7.5)           |
+| concat | =concat("a", "-", 1) |
+```
+
+!sheet
+| call   | result               |
+|--------|---------------------:|
+| round  | =round(3.14159, 2)   |
+| abs    | =abs(-7.5)           |
+| concat | =concat("a", "-", 1) |
+
+---
+
+## Aggregate functions
+
+```markdown
+!sheet
+| student | score       |
+|---------|------------:|
+| Ada     |          91 |
+| Linus   |          64 |
+| Grace   |          88 |
+| !sum    | =sum(score) |
+```
+
+!sheet
+| student | score       |
+|---------|------------:|
+| Ada     |          91 |
+| Linus   |          64 |
+| Grace   |          88 |
+| !sum    | =sum(score) |
+
+---
+
+## About aggregates
+
+`sum`, `avg`, `min`, `max`, `count` and `median`. Each takes one whole column, so they only work in a footer row.
+
+A footer row is never part of a column — `sum(score)` cannot eat its own total. Empty cells are skipped. A non-empty cell that is not a number is an error, not a silent skip: a wrong total is worse than a visible failure.
+
+---
+
+## Precision
+
+```markdown
+!sheet precision=6
+| item | unit | share     |
+|------|-----:|----------:|
+| a    |    3 | =unit / 7 |
+```
+
+!sheet precision=6
+| item | unit | share     |
+|------|-----:|----------:|
+| a    |    3 | =unit / 7 |
+
+Per table. Whole numbers render without a decimal point.
+
+---
+
+## Errors, part 1
+
+```markdown
+!sheet
+| case             | result         |
+|------------------|----------------|
+| unknown column   | =nope * 2      |
+| unknown function | =frobnicate(1) |
+| divide by zero   | =1 / 0         |
+```
+
+!sheet
+| case             | result         |
+|------------------|----------------|
+| unknown column   | =nope * 2      |
+| unknown function | =frobnicate(1) |
+| divide by zero   | =1 / 0         |
+
+---
+
+## Errors, part 2
+
+```markdown
+!sheet
+| case          | value | result      |
+|---------------|------:|-------------|
+| wrong arity   |     1 | =round(1)   |
+| syntax error  |     1 | =1 +        |
+| aggregate     |     1 | =sum(value) |
+```
+
+!sheet
+| case          | value | result      |
+|---------------|------:|-------------|
+| wrong arity   |     1 | =round(1)   |
+| syntax error  |     1 | =1 +        |
+| aggregate     |     1 | =sum(value) |
+
+---
+
+## About errors
+
+Errors are per cell. A bad formula never takes the slide down with it, and the rest of the table still computes.
+
+The last one above is the vector/scalar rule: an aggregate needs a whole column, and a data row only has scalars.
+
+---
+
+## Not a sheet
+
+```markdown
+| key       | literal value |
+|-----------|---------------|
+| formula?  | =qty * unit   |
+| computed? | no            |
+```
+
+| key       | literal value |
+|-----------|---------------|
+| formula?  | =qty * unit   |
+| computed? | no            |
+
+No `!sheet` line, so the table is inert — Kova never touches it, even when a cell starts with `=`.
+
+Inside a sheet, escape a cell that really starts with `=` as `\=`, and a row label that really starts with `!` as `\!` — otherwise the row is read as a footer.

--- a/src/components/preview/layouts.tsx
+++ b/src/components/preview/layouts.tsx
@@ -48,7 +48,12 @@ export function OverflowPane({ className, elements, minScale, onNaturalScale }: 
     // ResizeObserver → setState → re-render cycle terminates.
     inner.style.transform = '';
     const contentH = inner.scrollHeight;
-    const availH = outer.clientHeight;
+    // clientHeight includes padding, and .sl-body's is a percentage — which
+    // resolves against the *width*, so it is ~90px on a 16:9 slide. Measuring
+    // against it made content up to two table rows too tall read as "fits",
+    // and the frame's overflow:hidden then clipped it instead of scaling.
+    const pad = getComputedStyle(outer);
+    const availH = outer.clientHeight - parseFloat(pad.paddingTop) - parseFloat(pad.paddingBottom);
     if (contentH === lastRef.current.c && availH === lastRef.current.a) {
       applyTransform(fitScaleRef.current);
       return;

--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -729,3 +729,147 @@ describe('![bg] slide backgrounds', () => {
     expect(code?.type === 'code' && code.value).toContain('![bg]');
   });
 });
+
+// ── Sheet tables (!sheet) ────────────────────────────────────────────────────
+
+describe('sheet tables', () => {
+  it('counts a line item whose label starts with an escaped !', () => {
+    const { slides } = parseDocument(doc(
+      '!sheet\n' +
+      '| item           | price       |\n' +
+      '|----------------|------------:|\n' +
+      '| motor          |          30 |\n' +
+      '| \\!brand widget |          30 |\n' +
+      '| ESC            |          35 |\n' +
+      '| !Total         | =sum(price) |\n'
+    ));
+    const table = slides[0].elements.find((e) => e.type === 'table') as any;
+    expect(table.rows[3][1]).toBe('95');            // not 65 — the row is not a footer
+    expect(table.rows[1][0]).toBe('!brand widget'); // the escape does not survive into the cell
+  });
+
+  it('computes row formulas and footer aggregates', () => {
+    const { slides } = parseDocument(doc(
+      '!let vat = 0.255\n\n' +
+      '!sheet bom\n' +
+      '| item  | qty | unit  | total       |\n' +
+      '|-------|----:|------:|------------:|\n' +
+      '| motor |   2 | 12.50 | =qty * unit |\n' +
+      '| ESC   |   2 |  8.00 | =qty * unit |\n' +
+      '| !**Total** |  |    | =sum(total) * (1 + vat) |\n'
+    ));
+    const table = slides[0].elements.find((e) => e.type === 'table') as any;
+    expect(table.rows[0][3]).toBe('25');
+    expect(table.rows[1][3]).toBe('16');
+    // 41 * 1.255 is 51.454999… as a double, but render() rounds away the float
+    // artifact so this reads as the correct decimal value, 51.46.
+    expect(table.rows[2][3]).toBe('51.46');
+    // the footer marker is consumed, the bold survives
+    expect(table.rows[2][0]).toBe('<strong>Total</strong>');
+  });
+
+  it('reads the formula from the raw source, so * is not parsed as emphasis', () => {
+    const { slides } = parseDocument(doc(
+      '!sheet t\n' +
+      '| a | b | c | out   |\n' +
+      '|--:|--:|--:|------:|\n' +
+      '| 2 | 3 | 4 | =a*b*c |\n'
+    ));
+    const table = slides[0].elements.find((e) => e.type === 'table') as any;
+    expect(table.rows[0][3]).toBe('24');
+  });
+
+  it('leaves a table with no !sheet line completely alone', () => {
+    const { slides } = parseDocument(doc(
+      '| key      | value       |\n' +
+      '|----------|-------------|\n' +
+      '| formula? | =qty * unit |\n'
+    ));
+    const table = slides[0].elements.find((e) => e.type === 'table') as any;
+    expect(table.rows[0][1]).toBe('=qty * unit');
+  });
+
+  it('renders a broken cell as #ERR without killing the slide', () => {
+    const { slides } = parseDocument(doc(
+      '# Title\n\n' +
+      '!sheet t\n' +
+      '| qty | unit  | total        |\n' +
+      '|----:|------:|-------------:|\n' +
+      '|   2 | 12.50 | =qty * untis |\n'
+    ));
+    const table = slides[0].elements.find((e) => e.type === 'table') as any;
+    expect(slides[0].title).toBe('Title');
+    expect(table.rows[0][2]).toContain('#ERR');
+  });
+
+  it('errors when !sheet is not followed by a table', () => {
+    const { slides } = parseDocument(doc('!sheet t\n\njust a paragraph\n'));
+    const html = slides[0].elements.map((e: any) => e.html ?? '').join(' ');
+    expect(html).toContain('#ERR');
+  });
+
+  it('errors when a !sheet is the last block on the slide', () => {
+    const { slides } = parseDocument(doc('# t\n\n!sheet\n'));
+    const html = slides[0].elements.map((e: any) => e.html ?? '').join(' ');
+    expect(html).toContain('#ERR');
+  });
+
+  it('never throws on hostile or half-typed sheet input', () => {
+    const hostile = [
+      // a prototype-chain function name in a footer cell
+      '!sheet t\n| qty |\n|----:|\n| 1 |\n| !=valueOf(qty) |\n',
+      // a ragged row
+      '!sheet t\n| a | b | c |\n|--:|--:|--:|\n| 1 |\n| 1 | 2 | 3 | 4 |\n',
+      // an empty header cell
+      '!sheet t\n| a |  |\n|--:|--:|\n| 1 | =a + 1 |\n',
+      // a half-typed directive, mid-slide and as the last line
+      '!sheet\n\ntext after\n',
+      '# t\n\n!sheet\n',
+      // a header that slugifies to the empty string
+      '!sheet t\n| €€ | b |\n|--:|--:|\n| 1 | =1 + 1 |\n',
+    ];
+    for (const body of hostile) {
+      expect(() => parseDocument(doc(body))).not.toThrow();
+    }
+  });
+
+  it('HTML-escapes a computed value and an #ERR message', () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const { slides } = parseDocument(doc(
+      '!sheet t\n' +
+      '| val | out | msg |\n' +
+      '|-----|-----|-----|\n' +
+      `| ${payload} | =val + 1 | =concat("${payload}") |\n`
+    ));
+    const table = slides[0].elements.find((e) => e.type === 'table') as any;
+    expect(table.rows[0][1]).toContain('#ERR');
+    expect(table.rows[0][1]).toContain('&lt;img');
+    expect(table.rows[0][1]).not.toContain('<img');
+    expect(table.rows[0][2]).toContain('&lt;img');
+    expect(table.rows[0][2]).not.toContain('<img');
+  });
+
+  it('errors on a reserved directive', () => {
+    const { slides } = parseDocument(doc('!code python\n'));
+    const html = slides[0].elements.map((e: any) => e.html ?? '').join(' ');
+    expect(html).toContain('reserved');
+  });
+
+  it('does not render the !let line', () => {
+    const { slides } = parseDocument(doc('!let vat = 0.255\n\ntext\n'));
+    const texts = slides[0].elements.map((e: any) => e.text ?? '');
+    expect(texts.join(' ')).not.toContain('!let');
+  });
+
+  it('re-renders a later slide when a constant on an earlier slide changes', () => {
+    const body = (vat: string) =>
+      `!let vat = ${vat}\n\n---\n\n!sheet t\n| net | gross |\n|----:|------:|\n| 100 | =net * (1 + vat) |\n`;
+    const first = parseDocument(doc(body('0.10'))).slides[1].elements.find((e) => e.type === 'table') as any;
+    // 100 * 1.1 is 110.00000000000001 as a double, but render() rounds away the
+    // float artifact so this still renders as the bare integer 110.
+    expect(first.rows[0][1]).toBe('110');
+    // same slide 2 text, different constant — the cache must not serve the stale slide
+    const second = parseDocument(doc(body('0.20'))).slides[1].elements.find((e) => e.type === 'table') as any;
+    expect(second.rows[0][1]).toBe('120');
+  });
+});

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -11,6 +11,9 @@ import { detectLayout } from '../layout/autoLayout';
 import { extractFrontmatter } from './frontmatter';
 import { extractSpeakerNotes } from './speakerNotes';
 import { extractBgImage } from './bgImage';
+import { collectConstants } from '../sheet/constants';
+import { evaluateSheet, isFooterRow, parseSheetDirective, type SheetOpts } from '../sheet/sheet';
+import type { Value } from '../sheet/evaluate';
 
 const processor = unified().use(remarkParse).use(remarkGfm).use(remarkMath);
 
@@ -28,22 +31,30 @@ const processor = unified().use(remarkParse).use(remarkGfm).use(remarkMath);
 // mermaidSvgCache pattern elsewhere in this codebase.
 let prevRawSlides: string[] = [];
 let prevParsedSlides: Slide[] = [];
+// A !let on slide 1 can change a sheet on slide 7, so an unchanged slide is
+// only safe to reuse while the constants are unchanged too.
+let prevConstKey = '';
 
 export function parseDocument(rawContent: string): ParsedDocument {
   const normalised = rawContent.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   const { frontmatter, body } = extractFrontmatter(normalised);
+  const constants = collectConstants(body);
+  const constKey = JSON.stringify([...constants]);
   const rawSlides = body.split(/^---$/m).map((s) => s.trim()).filter(Boolean);
   const slides = rawSlides.map((raw, index) =>
-    raw === prevRawSlides[index] && prevParsedSlides[index] ? prevParsedSlides[index] : parseSlide(raw, index),
+    raw === prevRawSlides[index] && prevParsedSlides[index] && constKey === prevConstKey
+      ? prevParsedSlides[index]
+      : parseSlide(raw, index, constants),
   );
   prevRawSlides = rawSlides;
   prevParsedSlides = slides;
+  prevConstKey = constKey;
   return { slides, frontmatter };
 }
 
 // ── Per-slide parser ─────────────────────────────────────────────────────────
 
-function parseSlide(raw: string, index: number): Slide {
+function parseSlide(raw: string, index: number, constants: Map<string, Value>): Slide {
   const { body: rawWithoutBg, bg: bgImage } = extractBgImage(raw);
 
   // Extract layout override from HTML comment before anything else
@@ -57,11 +68,11 @@ function parseSlide(raw: string, index: number): Slide {
   // Preprocess before speaker-notes extraction so ??? inside custom URLs is not
   // misinterpreted as speaker-note markers. Custom elements become inline HTML
   // comment placeholders so remark preserves their position in the element list.
-  const { cleanContent, placeholders, references } = preprocess(rawWithoutBg);
+  const { cleanContent, placeholders, sheets, references } = preprocess(rawWithoutBg);
   const { content, notes } = extractSpeakerNotes(cleanContent);
 
   const tree = processor.parse(content) as Root;
-  let { title, titleLevel, elements } = convertRoot(tree, placeholders);
+  let { title, titleLevel, elements } = convertRoot(tree, placeholders, sheets, content, constants);
 
   let layout = layoutOverride ?? detectLayout(elements, titleLevel, !!title);
   let backgroundImage: Slide['backgroundImage'];
@@ -88,6 +99,7 @@ function parseSlide(raw: string, index: number): Slide {
 interface PreprocessResult {
   cleanContent: string;
   placeholders: Map<number, SlideElement>;
+  sheets: Map<number, SheetOpts>;
   references: string[];
 }
 
@@ -97,6 +109,9 @@ const POLL_RE         = /^!poll\[([^\]]*)\]\(([^)]*)\)$/;
 const PROGRESS_RE     = /^!progress\[([^\]]*)\]\((\d+(?:\.\d+)?)\)$/;
 const REF_RE          = /^!ref\[([^\]]*)\]$/;
 const TOC_RE          = /^!toc$/;
+const SHEET_RE        = /^!sheet\b(.*)$/;
+const LET_RE          = /^!let\b/;
+const RESERVED_RE     = /^!(include|fmt|code)\b/;
 // remark-math v6 only recognises block math when $$ appears on its own line.
 // Normalise single-line $$...$$ → multi-line so it is parsed as a math block.
 const DISPLAY_MATH_RE = /^\$\$(.+)\$\$\s*$/;
@@ -104,6 +119,8 @@ const DISPLAY_MATH_RE = /^\$\$(.+)\$\$\s*$/;
 function preprocess(content: string): PreprocessResult {
   const placeholders = new Map<number, SlideElement>();
   const references: string[] = [];
+  const sheets = new Map<number, SheetOpts>();
+  let nextSheet = 0;
   let nextIdx = 0;
   const cleanLines: string[] = [];
   let inFencedCode = false;
@@ -158,6 +175,32 @@ function preprocess(content: string): PreprocessResult {
       continue;
     }
 
+    // Constants are collected document-wide by collectConstants; the line itself
+    // never renders.
+    if (LET_RE.test(t)) continue;
+
+    const reserved = t.match(RESERVED_RE);
+    if (reserved) {
+      const idx = nextIdx++;
+      placeholders.set(idx, {
+        type: 'paragraph',
+        text: '',
+        html: `#ERR '!${reserved[1]}' is reserved for a future release`,
+      });
+      cleanLines.push(`<!-- kova-el:${idx} -->`);
+      continue;
+    }
+
+    const sheet = t.match(SHEET_RE);
+    if (sheet) {
+      const idx = nextSheet++;
+      sheets.set(idx, parseSheetDirective(sheet[1]));
+      // The blank line closes the HTML block, so the table below still parses
+      // as a table rather than being swallowed into it.
+      cleanLines.push(`<!-- kova-sheet:${idx} -->`, '');
+      continue;
+    }
+
     const ref = t.match(REF_RE);
     if (ref) {
       if (ref[1].trim()) references.push(ref[1]);
@@ -185,7 +228,7 @@ function preprocess(content: string): PreprocessResult {
     cleanLines.push(line);
   }
 
-  return { cleanContent: cleanLines.join('\n').trim(), placeholders, references };
+  return { cleanContent: cleanLines.join('\n').trim(), placeholders, sheets, references };
 }
 
 // ── mdast → SlideElement converter ───────────────────────────────────────────
@@ -196,12 +239,25 @@ interface ConvertResult {
   elements: SlideElement[];
 }
 
-function convertRoot(tree: Root, placeholders: Map<number, SlideElement>): ConvertResult {
+function convertRoot(
+  tree: Root,
+  placeholders: Map<number, SlideElement>,
+  sheets: Map<number, SheetOpts>,
+  src: string,
+  constants: Map<string, Value>,
+): ConvertResult {
   let title = '';
   let titleLevel = 0;
   const elements: SlideElement[] = [];
+  let pendingSheet: SheetOpts | undefined;
 
   for (const node of tree.children) {
+    // A !sheet annotates the table on the very next line and nothing else.
+    if (pendingSheet && node.type !== 'table') {
+      elements.push({ type: 'paragraph', text: '', html: '#ERR !sheet must sit directly above a table' });
+      pendingSheet = undefined;
+    }
+
     switch (node.type) {
       case 'heading': {
         const h = node as Heading;
@@ -278,7 +334,25 @@ function convertRoot(tree: Root, placeholders: Map<number, SlideElement>): Conve
         const t = node as Table;
         const [headerRow, ...bodyRows] = t.children;
         const headers = (headerRow?.children ?? []).map((cell) => inlineToHtml(cell.children as Node[]));
-        const rows = bodyRows.map((row) => row.children.map((cell) => inlineToHtml(cell.children as Node[])));
+        let rows = bodyRows.map((row) => row.children.map((cell) => inlineToHtml(cell.children as Node[])));
+
+        if (pendingSheet) {
+          // Raw source, not mdast: remark reads `=a*b*c` as `a<em>b</em>c`.
+          const rawCells = t.children.map((row) => row.children.map((cell) => rawText(src, cell)));
+          const computed = evaluateSheet(rawCells, pendingSheet, constants);
+          rows = bodyRows.map((row, r) =>
+            row.children.map((cell, c) => {
+              const value = computed[r + 1]?.[c];
+              if (value != null) return escHtml(value);
+              // A literal cell keeps the HTML remark already built for it, so
+              // `| !**Total** |` stays bold — minus the footer marker.
+              const html = inlineToHtml(cell.children as Node[]);
+              return c === 0 && isFooterRow(rawCells[r + 1] ?? []) ? html.replace(/^!\s*/, '') : html;
+            }),
+          );
+          pendingSheet = undefined;
+        }
+
         elements.push({ type: 'table', headers, rows, align: t.align ?? undefined });
         break;
       }
@@ -289,6 +363,11 @@ function convertRoot(tree: Root, placeholders: Map<number, SlideElement>): Conve
         if (v === '<!-- column-break -->') {
           elements.push({ type: 'column-break' });
         } else {
+          const sheetMatch = v.match(/^<!-- kova-sheet:(\d+) -->$/);
+          if (sheetMatch) {
+            pendingSheet = sheets.get(Number(sheetMatch[1]));
+            break;
+          }
           const m = v.match(/^<!-- kova-el:(\d+) -->$/);
           if (m) {
             const el = placeholders.get(Number(m[1]));
@@ -311,6 +390,12 @@ function convertRoot(tree: Root, placeholders: Map<number, SlideElement>): Conve
       default:
         break;
     }
+  }
+
+  // A !sheet as the last block on the slide has no following node to trip the
+  // check above, so report it here instead of dropping it silently.
+  if (pendingSheet) {
+    elements.push({ type: 'paragraph', text: '', html: '#ERR !sheet must sit directly above a table' });
   }
 
   return { title, titleLevel, elements };
@@ -458,6 +543,19 @@ function listToHtml(l: List): string {
     return `<li>${inner}${sub ? listToHtml(sub) : ''}</li>`;
   }).join('');
   return `<${tag}>${items}</${tag}>`;
+}
+
+// ── Raw-source slicing ───────────────────────────────────────────────────────
+
+// A sheet cell's formula must come from the source text, not from the parsed
+// mdast: `=a*b*c` parses as `a<em>b</em>c` and would be silently corrupted.
+// A tableCell's position spans its delimiting `|` characters too, so strip them
+// (an unescaped `|` cannot occur inside a GFM cell).
+function rawText(src: string, node: Node): string {
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  if (start === undefined || end === undefined) return '';
+  return src.slice(start, end).replace(/^\s*\|/, '').replace(/(?<!\\)\|\s*$/, '').replace(/\\\|/g, '|').trim();
 }
 
 // ── Inline node → HTML ───────────────────────────────────────────────────────

--- a/src/engine/sheet/__tests__/constants.test.ts
+++ b/src/engine/sheet/__tests__/constants.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { collectConstants } from '../constants';
+
+describe('collectConstants', () => {
+  it('collects a scalar constant from anywhere in the document', () => {
+    const c = collectConstants('# Slide\n\n!let vat = 0.255\n\ntext\n');
+    expect(c.get('vat')).toBe(0.255);
+  });
+
+  it('lets a constant build on an earlier one', () => {
+    const c = collectConstants('!let rate = 620\n!let week = rate * 5\n');
+    expect(c.get('week')).toBe(3100);
+  });
+
+  it('ignores !let inside a fenced code block', () => {
+    const c = collectConstants('```\n!let vat = 0.255\n```\n');
+    expect(c.has('vat')).toBe(false);
+  });
+
+  it('defines nothing when the expression is broken, so cells report it', () => {
+    const c = collectConstants('!let vat = 0.255 +\n');
+    expect(c.has('vat')).toBe(false);
+  });
+
+  it('lets the last definition win', () => {
+    const c = collectConstants('!let vat = 0.20\n!let vat = 0.255\n');
+    expect(c.get('vat')).toBe(0.255);
+  });
+
+  it('a broken redefinition leaves the name undefined', () => {
+    const c = collectConstants('!let vat = 0.20\n!let vat = 0.255 +\n');
+    expect(c.has('vat')).toBe(false);
+  });
+
+  it('a constant depending on an earlier one still works after broken redefinition', () => {
+    const c = collectConstants('!let rate = 620\n!let week = rate * 5\n!let rate = bad +\n');
+    expect(c.has('rate')).toBe(false);
+    expect(c.has('week')).toBe(true);
+    expect(c.get('week')).toBe(3100);
+  });
+});

--- a/src/engine/sheet/__tests__/evaluate.test.ts
+++ b/src/engine/sheet/__tests__/evaluate.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { parseExpr } from '../parser';
+import { evaluate, render, type Result, type Scope } from '../evaluate';
+import { SheetError } from '../lexer';
+
+const scope = (vars: Record<string, Result>): Scope => (name) => {
+  if (name in vars) return vars[name];
+  throw new SheetError(`unknown column or constant '${name}'`);
+};
+
+const run = (src: string, vars: Record<string, Result> = {}) => evaluate(parseExpr(src), scope(vars));
+
+describe('evaluate', () => {
+  it('does arithmetic with identifiers', () => {
+    expect(run('qty * unit', { qty: 2, unit: 12.5 })).toBe(25);
+    expect(run('1 + 2 * 3')).toBe(7);
+    expect(run('2 ^ 3 ^ 2')).toBe(512);
+    expect(run('-base', { base: 10 })).toBe(-10);
+    expect(run('10 % 3')).toBe(1);
+  });
+
+  it('does comparisons, logic and the ternary', () => {
+    expect(run('1 < 2')).toBe(true);
+    expect(run('1 == 1 and 2 > 3')).toBe(false);
+    expect(run('1 == 1 or 2 > 3')).toBe(true);
+    expect(run('not (1 == 1)')).toBe(false);
+    expect(run('x > 5 ? 1 : 0', { x: 10 })).toBe(1);
+    expect(run('if(x == 10, 100, 0)', { x: 10 })).toBe(100);
+  });
+
+  it('propagates an empty cell instead of erroring', () => {
+    expect(run('qty * unit', { qty: null, unit: 12.5 })).toBe(null);
+    expect(run('qty + 1', { qty: null })).toBe(null);
+  });
+
+  it('runs the scalar functions', () => {
+    expect(run('round(3.14159, 2)')).toBe(3.14);
+    expect(run('abs(-7.5)')).toBe(7.5);
+    expect(run('floor(2.9)')).toBe(2);
+    expect(run('ceil(2.1)')).toBe(3);
+    expect(run('concat("a", "-", 1)')).toBe('a-1');
+  });
+
+  it('runs the aggregate functions over a vector, skipping empties', () => {
+    const col = { score: [91, 64, 88, null, 73] as Result };
+    expect(run('sum(score)', col)).toBe(316);
+    expect(run('count(score)', col)).toBe(4);
+    expect(run('avg(score)', col)).toBe(79);
+    expect(run('min(score)', col)).toBe(64);
+    expect(run('max(score)', col)).toBe(91);
+    expect(run('median(score)', col)).toBe(80.5);
+  });
+
+  it('errors on a non-numeric cell inside an aggregate', () => {
+    expect(() => run('sum(score)', { score: [1, 'n/a'] })).toThrow(/needs numbers/);
+  });
+
+  it('errors when a vector is used as a scalar', () => {
+    expect(() => run('score * 2', { score: [1, 2] })).toThrow(/whole column/);
+  });
+
+  it('errors when an aggregate gets a scalar', () => {
+    expect(() => run('sum(qty)', { qty: 2 })).toThrow(/whole column/);
+  });
+
+  it('errors on an unknown function and on division by zero', () => {
+    expect(() => run('frobnicate(1)')).toThrow(/unknown function/);
+    expect(() => run('1 / 0')).toThrow(/division by zero/);
+  });
+
+  it('rejects a function named like an Object.prototype member', () => {
+    // `name in AGGREGATES` used to walk the prototype chain: valueOf(qty)
+    // returned the AGGREGATES object itself, which escaped the sheet and blew
+    // up the whole document downstream.
+    const col = { qty: [1, 2] as Result };
+    for (const fn of ['valueOf', 'toString', 'hasOwnProperty', 'constructor', '__lookupGetter__']) {
+      expect(() => run(`${fn}(qty)`, col)).toThrow(SheetError);
+      expect(() => run(`${fn}(qty)`, col)).toThrow(/unknown function/);
+    }
+  });
+
+  it('errors on wrong arity', () => {
+    expect(() => run('round(1)')).toThrow(/takes 2 argument/);
+  });
+
+  it('errors on an aggregate over a column containing an empty-string cell, instead of silently skipping it', () => {
+    expect(() => run('sum(score)', { score: [1, '', 3] })).toThrow(/needs numbers/);
+  });
+
+  it('counts an empty-string cell as present, unlike an empty (null) cell', () => {
+    expect(run('count(score)', { score: ['', 'a', 'b'] })).toBe(3);
+  });
+
+  it('still skips a genuinely empty (null) cell in aggregates and count', () => {
+    const col = { score: [1, null, 3] as Result };
+    expect(run('sum(score)', col)).toBe(4);
+    expect(run('count(score)', col)).toBe(2);
+  });
+
+  it('errors when if() returns a vector branch instead of leaking it as the result', () => {
+    const col = { score: [1, 2, 3] as Result };
+    expect(() => run('if(true, score, 0)', col)).toThrow(/whole column/);
+  });
+});
+
+describe('render', () => {
+  it('renders integers without decimals and floats at the given precision', () => {
+    expect(render(25, 2)).toBe('25');
+    expect(render(12.345, 2)).toBe('12.35');
+    expect(render(3 / 7, 6)).toBe('0.428571');
+  });
+
+  it('renders empties, booleans and strings', () => {
+    expect(render(null, 2)).toBe('');
+    expect(render(true, 2)).toBe('true');
+    expect(render('n/a', 2)).toBe('n/a');
+  });
+
+  it('throws on a non-finite number', () => {
+    expect(() => render(NaN, 2)).toThrow(SheetError);
+    expect(() => render(Infinity, 2)).toThrow(SheetError);
+  });
+
+  it('rounds away IEEE-double artifacts instead of leaking them into the output', () => {
+    // 41 * 1.255 is 51.454999999999998… as a double; the true decimal value
+    // is 51.455, which rounds half-up to 51.46 — not the truncated 51.45.
+    expect(render(41 * 1.255, 2)).toBe('51.46');
+    // 100 * 1.1 is 110.00000000000001 as a double, so it must still render bare.
+    expect(render(100 * 1.1, 2)).toBe('110');
+    // 0.1 + 0.2 is 0.30000000000000004 as a double.
+    expect(render(0.1 + 0.2, 2)).toBe('0.30');
+  });
+
+  it('renders tiny values instead of leaking exponential notation into a NaN string', () => {
+    // String(1e-7) is '1e-7'; naively appending 'e2' gives '1e-7e2', which
+    // Number() cannot parse, producing the literal string 'NaN' in the cell.
+    expect(render(2 / 3000000, 2)).toBe('0.00');
+  });
+
+  it('preserves values with more than 12 significant digits', () => {
+    // toPrecision(12) used to silently truncate these to the wrong number.
+    expect(render(999999999999 + 3, 2)).toBe('1000000000002');
+    expect(render(1234567890123 * 1, 2)).toBe('1234567890123');
+  });
+
+  it('rounds half away from zero, like a spreadsheet, not half up', () => {
+    expect(render(51.455, 2)).toBe('51.46');
+    expect(render(-51.455, 2)).toBe('-51.46');
+    expect(render(2.5, 0)).toBe('3');
+    expect(render(-2.5, 0)).toBe('-3');
+  });
+
+  it('throws instead of rendering exponential notation for huge magnitudes', () => {
+    // String(1e21) is '1e+21'; past this magnitude both String() and toFixed()
+    // switch to exponential notation, which must not land in a cell as text.
+    expect(() => render(1e21, 2)).toThrow(SheetError);
+    expect(() => render(-1e21, 2)).toThrow(SheetError);
+  });
+
+  it('keeps exact-integer doubles exact instead of truncating them via toPrecision(15)', () => {
+    expect(render(Number.MAX_SAFE_INTEGER, 2)).toBe('9007199254740991');
+  });
+
+  it('renders a large non-integer at high precision instead of the string NaN', () => {
+    // |v| * 10^precision >= 1e21, so String() of the shifted value is
+    // exponential: a template built from it used to yield '…e+21e-10' → NaN.
+    expect(render(123456789012.5 + 0.25, 10)).toBe('123456789012.7500000000');
+    expect(render(-(123456789012.5 + 0.25), 10)).toBe('-123456789012.7500000000');
+    expect(render(51.455, 10)).toBe('51.4550000000');
+  });
+});

--- a/src/engine/sheet/__tests__/examples.test.ts
+++ b/src/engine/sheet/__tests__/examples.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { parseDocument } from '../../parser/markdownToSlides';
+
+// The example decks double as fixtures: if a slide there is broken, so is the
+// feature. sheet-reference.md has an "Errors" slide that is *meant* to fail, so
+// only the deliberate ones are allowed to.
+function cells(file: string): string[] {
+  const { slides } = parseDocument(readFileSync(`examples/${file}`, 'utf8'));
+  return slides.flatMap((s) =>
+    s.elements.filter((e) => e.type === 'table').flatMap((e: any) => e.rows.flat() as string[]),
+  );
+}
+
+describe('example decks', () => {
+  it('computes sheet-basics.md, with exactly one deliberate error', () => {
+    const errs = cells('sheet-basics.md').filter((c) => c.includes('#ERR'));
+    expect(errs).toHaveLength(1);                    // the "When a formula is wrong" slide
+    expect(errs[0]).toContain("'untis'");
+    expect(cells('sheet-basics.md')).toContain('25');   // 2 × 12.50
+  });
+
+  it('computes sheet-reference.md', () => {
+    const all = cells('sheet-reference.md');
+    expect(all).toContain('512');       // 2 ^ 3 ^ 2, right-associative
+    expect(all).toContain('16');        // 10 + 2 * 3
+    expect(all).toContain('36');        // (10 + 2) * 3
+    expect(all).toContain('243');       // sum(score): 91 + 64 + 88
+    expect(all).toContain('0.428571');  // 3 / 7 at precision=6
+    // the Errors slide is meant to fail, all six of its cells
+    expect(all.filter((c) => c.includes('#ERR'))).toHaveLength(6);
+  });
+});

--- a/src/engine/sheet/__tests__/parser.test.ts
+++ b/src/engine/sheet/__tests__/parser.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { parseExpr } from '../parser';
+import { SheetError } from '../lexer';
+
+describe('parseExpr', () => {
+  it('parses a binary expression', () => {
+    expect(parseExpr('qty * unit')).toEqual({
+      k: 'bin', op: '*',
+      l: { k: 'id', name: 'qty' },
+      r: { k: 'id', name: 'unit' },
+    });
+  });
+
+  it('gives * higher precedence than +', () => {
+    expect(parseExpr('1 + 2 * 3')).toEqual({
+      k: 'bin', op: '+',
+      l: { k: 'num', v: 1 },
+      r: { k: 'bin', op: '*', l: { k: 'num', v: 2 }, r: { k: 'num', v: 3 } },
+    });
+  });
+
+  it('makes ^ right-associative', () => {
+    // 2 ^ (3 ^ 2), not (2 ^ 3) ^ 2
+    expect(parseExpr('2 ^ 3 ^ 2')).toEqual({
+      k: 'bin', op: '^',
+      l: { k: 'num', v: 2 },
+      r: { k: 'bin', op: '^', l: { k: 'num', v: 3 }, r: { k: 'num', v: 2 } },
+    });
+  });
+
+  it('parses parentheses, calls, strings and the ternary', () => {
+    expect(parseExpr('(a + 1) * 2')).toEqual({
+      k: 'bin', op: '*',
+      l: { k: 'bin', op: '+', l: { k: 'id', name: 'a' }, r: { k: 'num', v: 1 } },
+      r: { k: 'num', v: 2 },
+    });
+    expect(parseExpr('round(x, 2)')).toEqual({
+      k: 'call', name: 'round', args: [{ k: 'id', name: 'x' }, { k: 'num', v: 2 }],
+    });
+    expect(parseExpr('sum(total)')).toEqual({
+      k: 'call', name: 'sum', args: [{ k: 'id', name: 'total' }],
+    });
+    expect(parseExpr('concat("a", "b")')).toEqual({
+      k: 'call', name: 'concat', args: [{ k: 'str', v: 'a' }, { k: 'str', v: 'b' }],
+    });
+    expect(parseExpr('a > 1 ? 10 : 20')).toEqual({
+      k: 'cond',
+      c: { k: 'bin', op: '>', l: { k: 'id', name: 'a' }, r: { k: 'num', v: 1 } },
+      a: { k: 'num', v: 10 },
+      b: { k: 'num', v: 20 },
+    });
+  });
+
+  it('parses unary minus, not, and booleans', () => {
+    expect(parseExpr('-a')).toEqual({ k: 'un', op: '-', e: { k: 'id', name: 'a' } });
+    expect(parseExpr('not a')).toEqual({ k: 'un', op: 'not', e: { k: 'id', name: 'a' } });
+    expect(parseExpr('true')).toEqual({ k: 'bool', v: true });
+    // -2^2 is -(2^2)
+    expect(parseExpr('-2 ^ 2')).toEqual({
+      k: 'un', op: '-', e: { k: 'bin', op: '^', l: { k: 'num', v: 2 }, r: { k: 'num', v: 2 } },
+    });
+  });
+
+  it('parses decimals', () => {
+    expect(parseExpr('12.50')).toEqual({ k: 'num', v: 12.5 });
+  });
+
+  it('throws SheetError on a truncated formula', () => {
+    expect(() => parseExpr('1 +')).toThrow(SheetError);
+  });
+
+  it('throws SheetError on trailing junk', () => {
+    expect(() => parseExpr('1 2')).toThrow(SheetError);
+  });
+
+  it('throws SheetError on an unexpected character', () => {
+    expect(() => parseExpr('a & b')).toThrow(SheetError);
+  });
+});

--- a/src/engine/sheet/__tests__/sheet.test.ts
+++ b/src/engine/sheet/__tests__/sheet.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateSheet, parseSheetDirective, slugify, isFooterRow } from '../sheet';
+import type { Value } from '../evaluate';
+
+const NO_CONSTS = new Map<string, Value>();
+
+describe('parseSheetDirective', () => {
+  it('reads precision, defaulting to 2, and accepts-and-ignores a bare table name', () => {
+    expect(parseSheetDirective(' bom')).toEqual({ precision: 2 });
+    expect(parseSheetDirective(' bom precision=4')).toEqual({ precision: 4 });
+    expect(parseSheetDirective('')).toEqual({ precision: 2 });
+  });
+});
+
+describe('slugify', () => {
+  it('lowercases, strips emphasis and punctuation, and underscores spaces', () => {
+    expect(slugify('Unit (€)')).toBe('unit');
+    expect(slugify('**With VAT**')).toBe('with_vat');
+    expect(slugify('qty')).toBe('qty');
+    // an underscore already in the header survives — it is a legal identifier char
+    expect(slugify('with_vat')).toBe('with_vat');
+  });
+});
+
+describe('isFooterRow', () => {
+  it('is true when the first cell starts with !', () => {
+    expect(isFooterRow(['!Total', '', '=sum(total)'])).toBe(true);
+    expect(isFooterRow(['motor', '2', '=qty * unit'])).toBe(false);
+  });
+
+  it('is false for a label that escapes a literal leading !', () => {
+    expect(isFooterRow(['\\!brand widget', '2', '12.50'])).toBe(false);
+  });
+});
+
+// A data row whose label happens to start with `!` used to be read as a footer,
+// which dropped it from every column vector and quietly deflated the totals.
+describe('a label that starts with !', () => {
+  const table = (label: string) => [
+    ['item', 'price'],
+    ['motor', '30'],
+    [label, '30'],
+    ['ESC', '35'],
+    ['!Total', '=sum(price)'],
+  ];
+
+  it('counts an escaped label as a data row, so the total is right', () => {
+    const out = evaluateSheet(table('\\!brand widget'), { precision: 2 }, NO_CONSTS);
+    expect(out[4][1]).toBe('95');       // 30 + 30 + 35, nothing dropped
+    expect(out[2][0]).toBe(null);       // literal cell: the caller keeps its HTML
+  });
+
+  it('reports an unescaped label instead of silently dropping the row', () => {
+    const out = evaluateSheet(table('!brand widget'), { precision: 2 }, NO_CONSTS);
+    expect(out[2][0]).toContain('#ERR');
+    expect(out[2][0]).toContain('\\!');  // names the escape
+  });
+
+  it('leaves a real footer row (one that computes) alone', () => {
+    const out = evaluateSheet(
+      [['item', 'price'], ['motor', '30'], ['!Total', '=sum(price)']],
+      { precision: 2 },
+      NO_CONSTS,
+    );
+    expect(out[2][0]).toBe(null);
+    expect(out[2][1]).toBe('30');
+  });
+});
+
+describe('evaluateSheet', () => {
+  const bom = () => [
+    ['item', 'qty', 'unit', 'total'],
+    ['motor RS550', '2', '12.50', '=qty * unit'],
+    ['ESC 30A', '2', '8.00', '=qty * unit'],
+    ['RF module', '1', '6.90', '=qty * unit'],
+    ['!Subtotal', '', '', '=sum(total)'],
+    ['!VAT', '', '', '=sum(total) * vat'],
+    ['!**Total**', '', '', '=sum(total) * (1 + vat)'],
+  ];
+
+  it('computes rows, aggregates footers, and leaves literals to the caller', () => {
+    const out = evaluateSheet(bom(), { precision: 2 }, new Map([['vat', 0.255 as Value]]));
+
+    // literal cells are null: "not mine"
+    expect(out[0]).toEqual([null, null, null, null]);
+    expect(out[1][0]).toBe(null);
+    expect(out[1][1]).toBe(null);
+
+    // row formulas
+    expect(out[1][3]).toBe('25');
+    expect(out[2][3]).toBe('16');
+    expect(out[3][3]).toBe('6.90');
+
+    // footer formulas — and the footers do not count themselves
+    expect(out[4][3]).toBe('47.90');
+    expect(out[5][3]).toBe('12.21');
+    expect(out[6][3]).toBe('60.11');
+  });
+
+  it('resolves a formula that depends on another computed column', () => {
+    const out = evaluateSheet(
+      [
+        ['days', 'rate', 'fee', 'with_vat'],
+        ['4', '620', '=days * rate', '=fee * (1 + vat)'],
+      ],
+      { precision: 2 },
+      new Map([['vat', 0.255 as Value]]),
+    );
+    expect(out[1][2]).toBe('2480');
+    expect(out[1][3]).toBe('3112.40');
+  });
+
+  it('reports a circular reference instead of hanging', () => {
+    const out = evaluateSheet(
+      [['a', 'b'], ['=b + 1', '=a + 1']],
+      { precision: 2 },
+      NO_CONSTS,
+    );
+    expect(out[1][0]).toMatch(/#ERR circular reference/);
+  });
+
+  it('reports errors per cell and keeps the rest of the table computing', () => {
+    const out = evaluateSheet(
+      [
+        ['item', 'qty', 'unit', 'total'],
+        ['motor', '2', '12.50', '=qty * unit'],
+        ['ESC', '2', '8.00', '=qty * untis'],
+      ],
+      { precision: 2 },
+      NO_CONSTS,
+    );
+    expect(out[1][3]).toBe('25');
+    expect(out[2][3]).toBe("#ERR unknown column or constant 'untis'");
+  });
+
+  it('reports a duplicate column name', () => {
+    const out = evaluateSheet([['qty', 'qty'], ['1', '=qty']], { precision: 2 }, NO_CONSTS);
+    expect(out[1][1]).toMatch(/#ERR duplicate column name 'qty'/);
+  });
+
+  it('reports a syntax error, an unknown function and an aggregate used in a data row', () => {
+    // 'd' is a healthy column (a plain literal) so the sum(d) misuse is
+    // isolated from 'a', which is deliberately broken for the syntax-error
+    // assertion — otherwise sum(d) would just report a's real error.
+    const out = evaluateSheet(
+      [['a', 'b', 'c', 'd'], ['=1 +', '=frobnicate(1)', '=sum(d)', '5']],
+      { precision: 2 },
+      NO_CONSTS,
+    );
+    expect(out[1][0]).toMatch(/^#ERR /);
+    expect(out[1][1]).toMatch(/#ERR unknown function/);
+    expect(out[1][2]).toMatch(/#ERR .*whole column/);
+  });
+
+  it('reports an error in a cell that depends on a broken cell, instead of rendering blank', () => {
+    const out = evaluateSheet(
+      [['a', 'c'], ['=1 +', '=a + 1']],
+      { precision: 2 },
+      NO_CONSTS,
+    );
+    expect(out[1][1]).toContain('#ERR');
+    expect(out[1][1]).not.toBe('');
+  });
+
+  it('reports circular reference on both cells of a mutual cycle', () => {
+    const out = evaluateSheet(
+      [['a', 'b'], ['=b + 1', '=a + 1']],
+      { precision: 2 },
+      NO_CONSTS,
+    );
+    expect(out[1][0]).toMatch(/#ERR circular reference/);
+    expect(out[1][1]).toMatch(/#ERR circular reference/);
+  });
+
+  it('still renders an empty string for a formula referencing a genuinely empty cell', () => {
+    const out = evaluateSheet(
+      [['a', 'b'], ['', '=a + 1']],
+      { precision: 2 },
+      NO_CONSTS,
+    );
+    expect(out[1][1]).toBe('');
+  });
+
+  it('honours precision and renders integers bare', () => {
+    const out = evaluateSheet([['unit', 'v'], ['3', '=unit / 7']], { precision: 6 }, NO_CONSTS);
+    expect(out[1][1]).toBe('0.428571');
+  });
+
+  it('treats a cell escaped with a backslash as a literal', () => {
+    const out = evaluateSheet([['a'], ['\\=not a formula']], { precision: 2 }, NO_CONSTS);
+    expect(out[1][0]).toBe(null);
+  });
+});

--- a/src/engine/sheet/constants.ts
+++ b/src/engine/sheet/constants.ts
@@ -1,0 +1,43 @@
+import { SheetError } from './lexer';
+import { parseExpr } from './parser';
+import { evaluate, type Value } from './evaluate';
+
+const LET_RE = /^!let\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)$/;
+
+// Document-scoped constants: declared on any slide, visible on every slide.
+// A constant is an input, so its expression may only use earlier constants,
+// never table data. A broken !let defines nothing rather than throwing — the
+// directive line has no rendered cell to show an error in, and the cells that
+// reference the missing constant report it instead.
+export function collectConstants(body: string): Map<string, Value> {
+  const out = new Map<string, Value>();
+  let inFencedCode = false;
+
+  for (const line of body.split('\n')) {
+    const t = line.trim();
+
+    if (/^(`{3,}|~{3,})/.test(t)) {
+      inFencedCode = !inFencedCode;
+      continue;
+    }
+    if (inFencedCode) continue;
+
+    const m = t.match(LET_RE);
+    if (!m) continue;
+
+    try {
+      // Remove any existing binding for this name before evaluating.
+      // A successful eval re-adds it (last-wins); a failed one leaves it undefined.
+      out.delete(m[1]);
+      const v = evaluate(parseExpr(m[2]), (name) => {
+        if (out.has(name)) return out.get(name)!;
+        throw new SheetError(`unknown constant '${name}'`);
+      });
+      if (!Array.isArray(v)) out.set(m[1], v);
+    } catch {
+      // leave it undefined
+    }
+  }
+
+  return out;
+}

--- a/src/engine/sheet/evaluate.ts
+++ b/src/engine/sheet/evaluate.ts
@@ -1,0 +1,164 @@
+import { SheetError } from './lexer';
+import type { Expr } from './parser';
+
+export type Value = number | string | boolean | null;   // null = an empty cell
+export type Result = Value | Value[];                   // an array is a column vector
+export type Scope = (name: string) => Result;
+
+const AGGREGATES: Record<string, (xs: number[]) => number> = {
+  sum: (xs) => xs.reduce((a, b) => a + b, 0),
+  avg: (xs) => xs.reduce((a, b) => a + b, 0) / xs.length,
+  min: (xs) => Math.min(...xs),
+  max: (xs) => Math.max(...xs),
+  median: (xs) => {
+    const s = [...xs].sort((a, b) => a - b);
+    const m = s.length >> 1;
+    return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+  },
+};
+
+export function evaluate(e: Expr, scope: Scope): Result {
+  switch (e.k) {
+    case 'num':
+    case 'str':
+    case 'bool':
+      return e.v;
+    case 'id':
+      return scope(e.name);
+    case 'un': {
+      const v = scalar(evaluate(e.e, scope));
+      if (e.op === 'not') return !truthy(v);
+      return v === null ? null : -num(v);
+    }
+    case 'bin':
+      return binop(e, scope);
+    case 'cond':
+      return truthy(scalar(evaluate(e.c, scope))) ? evaluate(e.a, scope) : evaluate(e.b, scope);
+    case 'call':
+      return call(e, scope);
+  }
+}
+
+// Integers render bare; anything else at the table's precision.
+export function render(v: Value, precision: number): string {
+  if (v === null) return '';
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  if (typeof v === 'number') {
+    if (!Number.isFinite(v)) throw new SheetError('result is not a finite number');
+    if (Math.abs(v) >= 1e21) throw new SheetError('value too large to render');
+    // Exact integers need no noise-scrubbing (that's only for binary-representation
+    // artifacts in non-integers), and toPrecision(15) would truncate large ones.
+    if (Number.isInteger(v)) return String(v);
+    // Doubles carry binary-representation noise (41 * 1.255 = 51.454999999999998…).
+    // Round to ~15 significant digits to recover the decimal value a spreadsheet would show.
+    const n = Number(v.toPrecision(15));
+    if (Number.isInteger(n)) return String(n);
+    // toFixed also suffers from binary representation ((51.455).toFixed(2) === '51.45'),
+    // so shift the decimal point through toExponential() (format-proof, unlike a template
+    // string built from String(n)) before rounding half away from zero.
+    const [m, e] = n.toExponential().split('e');
+    const shifted = Number(`${m}e${Number(e) + precision}`);
+    // Shift back the same format-proof way: String(1.234567890125e21) is
+    // exponential, so a template built from it would yield '…e+21e-10' → NaN.
+    const [rm, re] = (Math.sign(shifted) * Math.round(Math.abs(shifted))).toExponential().split('e');
+    const rounded = Number(`${rm}e${Number(re) - precision}`);
+    return rounded.toFixed(precision);
+  }
+  // The type system says this is a string, but a formula that reaches a value
+  // of any other shape must fail per-cell, not escape the sheet as an object.
+  if (typeof v !== 'string') throw new SheetError('unsupported value');
+  return v;
+}
+
+function binop(e: Extract<Expr, { k: 'bin' }>, scope: Scope): Result {
+  if (e.op === 'and' || e.op === 'or') {
+    const l = truthy(scalar(evaluate(e.l, scope)));
+    if (e.op === 'and') return l ? truthy(scalar(evaluate(e.r, scope))) : false;
+    return l ? true : truthy(scalar(evaluate(e.r, scope)));
+  }
+
+  const l = scalar(evaluate(e.l, scope));
+  const r = scalar(evaluate(e.r, scope));
+  if (l === null || r === null) return null;   // an empty cell propagates, it does not error
+
+  switch (e.op) {
+    case '+':  return num(l) + num(r);
+    case '-':  return num(l) - num(r);
+    case '*':  return num(l) * num(r);
+    case '/':  if (num(r) === 0) throw new SheetError('division by zero'); return num(l) / num(r);
+    case '%':  if (num(r) === 0) throw new SheetError('division by zero'); return num(l) % num(r);
+    case '^':  return num(l) ** num(r);
+    case '==': return l === r;
+    case '!=': return l !== r;
+    case '<':  return num(l) < num(r);
+    case '<=': return num(l) <= num(r);
+    case '>':  return num(l) > num(r);
+    case '>=': return num(l) >= num(r);
+  }
+  throw new SheetError(`unknown operator '${e.op}'`);
+}
+
+function call(e: Extract<Expr, { k: 'call' }>, scope: Scope): Result {
+  const name = e.name;
+  const args = e.args.map((a) => evaluate(a, scope));
+  const arity = (n: number) => {
+    if (args.length !== n) throw new SheetError(`${name}() takes ${n} argument(s), got ${args.length}`);
+  };
+
+  if (name === 'count') return column(name, args).filter(present).length;
+
+  // Own-property only: `in` would walk the prototype chain, making 'valueOf',
+  // 'toString' & co. resolve to Object.prototype members. (Object.hasOwn needs
+  // ES2022; this project's lib is ES2020.)
+  if (Object.prototype.hasOwnProperty.call(AGGREGATES, name)) {
+    const xs = column(name, args).filter(present);
+    for (const v of xs) {
+      if (typeof v !== 'number') throw new SheetError(`${name}() needs numbers, found '${v}'`);
+    }
+    if (!xs.length && name !== 'sum') throw new SheetError(`${name}() of an empty column`);
+    return AGGREGATES[name](xs as number[]);
+  }
+
+  switch (name) {
+    case 'round': {
+      arity(2);
+      const f = 10 ** num(scalar(args[1]));
+      return Math.round(num(scalar(args[0])) * f) / f;
+    }
+    case 'abs':   arity(1); return Math.abs(num(scalar(args[0])));
+    case 'floor': arity(1); return Math.floor(num(scalar(args[0])));
+    case 'ceil':  arity(1); return Math.ceil(num(scalar(args[0])));
+    case 'if':    arity(3); return scalar(truthy(scalar(args[0])) ? args[1] : args[2]);
+    case 'concat': return args.map((a) => String(scalar(a) ?? '')).join('');
+  }
+
+  throw new SheetError(`unknown function '${name}'`);
+}
+
+function column(name: string, args: Result[]): Value[] {
+  if (args.length !== 1 || !Array.isArray(args[0])) {
+    throw new SheetError(`${name}() takes one whole column`);
+  }
+  return args[0];
+}
+
+function present(v: Value): boolean {
+  return v !== null;
+}
+
+function scalar(v: Result): Value {
+  if (Array.isArray(v)) throw new SheetError('expected a single value, got a whole column');
+  return v;
+}
+
+function num(v: Value): number {
+  if (typeof v === 'number') return v;
+  throw new SheetError(`expected a number, got '${v}'`);
+}
+
+function truthy(v: Value): boolean {
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'number') return v !== 0;
+  if (v === null) return false;
+  return v !== '';
+}

--- a/src/engine/sheet/lexer.ts
+++ b/src/engine/sheet/lexer.ts
@@ -1,0 +1,49 @@
+// Tokenizer for !sheet formulas. The grammar is deliberately tiny (see the
+// mdsheet design): no assignment, no loops, no user-defined functions.
+export class SheetError extends Error {}
+
+export type Tok = { t: 'num' | 'str' | 'id' | 'op'; v: string };
+
+const OPS2 = ['==', '!=', '<=', '>='];
+const OPS1 = '+-*/%^<>(),?:'.split('');
+
+export function lex(src: string): Tok[] {
+  const toks: Tok[] = [];
+  let i = 0;
+
+  while (i < src.length) {
+    const c = src[i];
+
+    if (/\s/.test(c)) { i++; continue; }
+
+    if (/[0-9]/.test(c) || (c === '.' && /[0-9]/.test(src[i + 1] ?? ''))) {
+      const m = /^[0-9]*\.?[0-9]+/.exec(src.slice(i))!;
+      toks.push({ t: 'num', v: m[0] });
+      i += m[0].length;
+      continue;
+    }
+
+    if (c === '"' || c === "'") {
+      const end = src.indexOf(c, i + 1);
+      if (end < 0) throw new SheetError('unterminated string');
+      toks.push({ t: 'str', v: src.slice(i + 1, end) });
+      i = end + 1;
+      continue;
+    }
+
+    if (/[A-Za-z_]/.test(c)) {
+      const m = /^[A-Za-z_][A-Za-z0-9_]*/.exec(src.slice(i))!;
+      toks.push({ t: 'id', v: m[0] });
+      i += m[0].length;
+      continue;
+    }
+
+    const two = src.slice(i, i + 2);
+    if (OPS2.includes(two)) { toks.push({ t: 'op', v: two }); i += 2; continue; }
+    if (OPS1.includes(c)) { toks.push({ t: 'op', v: c }); i++; continue; }
+
+    throw new SheetError(`unexpected character '${c}'`);
+  }
+
+  return toks;
+}

--- a/src/engine/sheet/parser.ts
+++ b/src/engine/sheet/parser.ts
@@ -1,0 +1,128 @@
+import { lex, SheetError, type Tok } from './lexer';
+
+export type Expr =
+  | { k: 'num'; v: number }
+  | { k: 'str'; v: string }
+  | { k: 'bool'; v: boolean }
+  | { k: 'id'; name: string }
+  | { k: 'un'; op: '-' | 'not'; e: Expr }
+  | { k: 'bin'; op: string; l: Expr; r: Expr }
+  | { k: 'cond'; c: Expr; a: Expr; b: Expr }
+  | { k: 'call'; name: string; args: Expr[] };
+
+const CMP = ['==', '!=', '<', '<=', '>', '>='];
+
+// Recursive descent, one function per precedence level (lowest first).
+export function parseExpr(src: string): Expr {
+  const toks: Tok[] = lex(src);
+  let i = 0;
+
+  const peek = (): Tok | undefined => toks[i];
+  const at = (t: Tok['t'], v: string) => peek()?.t === t && peek()!.v === v;
+  const eat = (t: Tok['t'], v: string) => {
+    if (!at(t, v)) throw new SheetError(`expected '${v}'`);
+    i++;
+  };
+
+  function ternary(): Expr {
+    const c = or();
+    if (!at('op', '?')) return c;
+    i++;
+    const a = ternary();
+    eat('op', ':');
+    return { k: 'cond', c, a, b: ternary() };
+  }
+
+  function or(): Expr {
+    let l = and();
+    while (at('id', 'or')) { i++; l = { k: 'bin', op: 'or', l, r: and() }; }
+    return l;
+  }
+
+  function and(): Expr {
+    let l = notExpr();
+    while (at('id', 'and')) { i++; l = { k: 'bin', op: 'and', l, r: notExpr() }; }
+    return l;
+  }
+
+  function notExpr(): Expr {
+    if (at('id', 'not')) { i++; return { k: 'un', op: 'not', e: notExpr() }; }
+    return cmp();
+  }
+
+  function cmp(): Expr {
+    let l = add();
+    while (peek()?.t === 'op' && CMP.includes(peek()!.v)) {
+      const op = toks[i++].v;
+      l = { k: 'bin', op, l, r: add() };
+    }
+    return l;
+  }
+
+  function add(): Expr {
+    let l = mul();
+    while (peek()?.t === 'op' && (peek()!.v === '+' || peek()!.v === '-')) {
+      const op = toks[i++].v;
+      l = { k: 'bin', op, l, r: mul() };
+    }
+    return l;
+  }
+
+  function mul(): Expr {
+    let l = unary();
+    while (peek()?.t === 'op' && ['*', '/', '%'].includes(peek()!.v)) {
+      const op = toks[i++].v;
+      l = { k: 'bin', op, l, r: unary() };
+    }
+    return l;
+  }
+
+  function unary(): Expr {
+    if (at('op', '-')) { i++; return { k: 'un', op: '-', e: unary() }; }
+    return pow();
+  }
+
+  // Right-associative: 2 ^ 3 ^ 2 is 2 ^ (3 ^ 2).
+  function pow(): Expr {
+    const l = primary();
+    if (at('op', '^')) { i++; return { k: 'bin', op: '^', l, r: unary() }; }
+    return l;
+  }
+
+  function primary(): Expr {
+    const tk = peek();
+    if (!tk) throw new SheetError('unexpected end of formula');
+
+    if (tk.t === 'num') { i++; return { k: 'num', v: Number(tk.v) }; }
+    if (tk.t === 'str') { i++; return { k: 'str', v: tk.v }; }
+
+    if (tk.t === 'id') {
+      i++;
+      if (tk.v === 'true' || tk.v === 'false') return { k: 'bool', v: tk.v === 'true' };
+      if (at('op', '(')) {
+        i++;
+        const args: Expr[] = [];
+        if (!at('op', ')')) {
+          args.push(ternary());
+          while (at('op', ',')) { i++; args.push(ternary()); }
+        }
+        eat('op', ')');
+        return { k: 'call', name: tk.v, args };
+      }
+      return { k: 'id', name: tk.v };
+    }
+
+    if (at('op', '(')) {
+      i++;
+      const e = ternary();
+      eat('op', ')');
+      return e;
+    }
+
+    throw new SheetError(`unexpected '${tk.v}'`);
+  }
+
+  const e = ternary();
+  if (i < toks.length) throw new SheetError(`unexpected '${toks[i].v}'`);
+  return e;
+}

--- a/src/engine/sheet/sheet.ts
+++ b/src/engine/sheet/sheet.ts
@@ -1,0 +1,162 @@
+import { SheetError } from './lexer';
+import { parseExpr } from './parser';
+import { evaluate, render, type Result, type Scope, type Value } from './evaluate';
+
+export interface SheetOpts {
+  precision: number;
+}
+
+// "!sheet bom precision=3" → { precision: 3 }. A bare word (a table name, for
+// the deferred cross-table references) is accepted and ignored. Never throws: a
+// malformed option in a half-typed directive must not take the slide down.
+export function parseSheetDirective(rest: string): SheetOpts {
+  const opts: SheetOpts = { precision: 2 };
+  for (const tok of rest.trim().split(/\s+/).filter(Boolean)) {
+    const kv = tok.match(/^([a-z]+)=(.+)$/);
+    if (kv && kv[1] === 'precision') {
+      const n = Number(kv[2]);
+      if (Number.isInteger(n) && n >= 0 && n <= 10) opts.precision = n;
+    }
+  }
+  return opts;
+}
+
+// "Unit (€)" → "unit", "**With VAT**" → "with_vat". A collision after
+// slugification is an error (below). `_` survives: it is a legal identifier
+// character, and a header is far more likely to be `with_vat` than `_em_`.
+export function slugify(header: string): string {
+  return header
+    .replace(/[*`~]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9_\s]/g, '')
+    .trim()
+    .replace(/\s+/g, '_');
+}
+
+// A leading `!` in the first cell marks a footer row. An ordinary label that
+// starts with `!` escapes it as `\!` — the same escape `\=` uses for a literal
+// that starts with `=`. (remark renders `\!` as a plain `!`, so the escape
+// costs the author nothing in a non-Kova viewer.)
+export function isFooterRow(row: string[]): boolean {
+  return (row[0] ?? '').trim().startsWith('!');
+}
+
+function hasFormula(raw: string[][], r: number): boolean {
+  return (raw[r] ?? []).some((_, c) => cellText(raw, r, c).startsWith('='));
+}
+
+export function evaluateSheet(
+  raw: string[][],
+  opts: SheetOpts,
+  constants: Map<string, Value>,
+): (string | null)[][] {
+  const header = raw[0] ?? [];
+  const cols = header.map(slugify);
+  const out: (string | null)[][] = raw.map((row) => row.map(() => null));
+
+  // A table-wide problem (a duplicate column) has no single cell to blame, so
+  // every formula cell reports it.
+  const dup = cols.find((c, i) => c !== '' && cols.indexOf(c) !== i);
+  if (dup) {
+    forEachFormula(raw, (r, c) => { out[r][c] = `#ERR duplicate column name '${dup}'`; });
+    return out;
+  }
+
+  const dataRows: number[] = [];
+  const footerRows: number[] = [];
+  for (let r = 1; r < raw.length; r++) (isFooterRow(raw[r]) ? footerRows : dataRows).push(r);
+
+  // A footer row computes nothing, so it is almost certainly a data row whose
+  // label just happens to start with `!` — and misreading it would drop that
+  // row from every column vector, quietly deflating the totals below it. Say so
+  // in the label cell instead: a wrong total with no error is the one outcome
+  // this design refuses.
+  for (const r of footerRows) {
+    if (!hasFormula(raw, r)) {
+      out[r][0] = "#ERR footer row has no formula — for a label starting with '!', escape it as '\\!'";
+    }
+  }
+
+  const memo = new Map<string, Value>();
+  const visiting = new Set<string>();
+
+  function cell(r: number, c: number): Value {
+    const key = `${r}:${c}`;
+    if (memo.has(key)) return memo.get(key)!;
+    if (visiting.has(key)) throw new SheetError(`circular reference in column '${cols[c]}'`);
+
+    const text = cellText(raw, r, c);
+    if (!text.startsWith('=')) {
+      const v = literal(text);
+      memo.set(key, v);
+      return v;
+    }
+
+    // A failure is deliberately not memoized: null is the empty-cell sentinel,
+    // so caching it here would make a broken cell look merely empty to every
+    // dependent and turn a visible #ERR into silent blanks. Letting it throw
+    // means dependents report an error too; re-evaluating costs nothing at this
+    // table size.
+    visiting.add(key);
+    try {
+      const scope = footerRows.includes(r) ? footerScope() : rowScope(r);
+      const v = evaluate(parseExpr(text.slice(1)), scope);
+      if (Array.isArray(v)) throw new SheetError('expected a single value, got a whole column');
+      memo.set(key, v);
+      return v;
+    } finally {
+      visiting.delete(key);
+    }
+  }
+
+  const constant = (name: string): Result => {
+    if (constants.has(name)) return constants.get(name)!;
+    throw new SheetError(`unknown column or constant '${name}'`);
+  };
+
+  // In a data row a bare name is this row's cell...
+  const rowScope = (r: number): Scope => (name) => {
+    const c = cols.indexOf(name);
+    return c >= 0 ? cell(r, c) : constant(name);
+  };
+
+  // ...and in a footer row it is the whole data column, footers excluded.
+  const footerScope = (): Scope => (name) => {
+    const c = cols.indexOf(name);
+    return c >= 0 ? dataRows.map((r) => cell(r, c)) : constant(name);
+  };
+
+  forEachFormula(raw, (r, c) => {
+    try {
+      out[r][c] = render(cell(r, c), opts.precision);
+    } catch (err) {
+      out[r][c] = `#ERR ${err instanceof SheetError ? err.message : 'evaluation failed'}`;
+    }
+  });
+
+  return out;
+}
+
+// The footer marker is not part of the cell's content.
+function cellText(raw: string[][], r: number, c: number): string {
+  const text = (raw[r]?.[c] ?? '').trim();
+  if (r > 0 && c === 0 && text.startsWith('!')) return text.slice(1).trim();
+  return text;
+}
+
+function forEachFormula(raw: string[][], fn: (r: number, c: number) => void): void {
+  for (let r = 1; r < raw.length; r++) {
+    for (let c = 0; c < raw[r].length; c++) {
+      if (cellText(raw, r, c).startsWith('=')) fn(r, c);
+    }
+  }
+}
+
+function literal(text: string): Value {
+  if (text === '') return null;
+  if (text === 'true') return true;
+  if (text === 'false') return false;
+  if (/^-?(\d+\.?\d*|\.\d+)$/.test(text)) return Number(text);
+  // `\=` and `\!` escape the two markers, so drop the backslash from the value.
+  return /^\\[=!]/.test(text) ? text.slice(1) : text;
+}


### PR DESCRIPTION
Implements the mdsheet RFC (#133), scoped to a minimal live core.

Annotate a GFM table with `!sheet` and its formula cells compute at parse time:

```markdown
!let vat = 0.255

!sheet
| item   | qty | unit  | total                   |
|--------|----:|------:|------------------------:|
| motor  |   2 | 12.50 | =qty * unit             |
| ESC    |   2 |  8.00 | =qty * unit             |
| !Total |     |       | =sum(total) * (1 + vat) |
```

A bare column name is this row's value; in a footer row (first cell starts with `!`) it is the whole column, footers excluded. The source keeps formulas, never cached values, and a renderer that has never heard of Kova still shows a valid table.

## Design

- New engine in `src/engine/sheet/` — lexer, recursive-descent parser, evaluator, table driver. **No new dependencies**, and no `eval()`/`Function()`: decks are untrusted files, re-parsed on every keystroke.
- **Errors are per cell** (`#ERR unknown column 'untis'`) and never fatal — a half-typed formula must not blank a slide. The same text reaches PPTX/PDF, so a broken deck looks broken rather than shipping a wrong number.
- Uses the existing `preprocess()`/`convertRoot()` directive mechanism (same as `!poll`/`!toc`). Sheet tables come out as ordinary `table` elements, so **preview, PPTX and PDF are untouched**.
- Formula text is sliced from the raw source via mdast offsets — remark parses `=a*b*c` as `a<em>b</em>c`, so reading it back from the tree would silently corrupt it.
- A table with no `!sheet` above it stays inert, even if a cell starts with `=`.

`!include`, `!fmt` and `!code` are reserved (they error) so today's decks can't collide with the deferred features: cross-table refs, lookups, the `@footer` sigil, dates, money/locale.

## Also fixes a preview bug

Found while checking the decks, unrelated to sheets but affecting every slide: `OverflowPane` compared content height to `outer.clientHeight`, which **includes padding** — and `.sl-body`'s padding is a percentage, so it resolves against the *width* (~90px on a 16:9 slide). Content up to two table rows too tall measured as "fits", got no scale, and was clipped by `overflow: hidden`. It now measures against the content box.

## Testing

`npm test` — 462 passing in `src/engine/`. (The 7 `keybindings.test.ts > formatCombo` failures are pre-existing on `main`, a macOS Cmd/Ctrl assumption.) `npx tsc --noEmit` clean.

Coverage includes operator precedence, footer exclusion from aggregates, cycle detection, empty-cell propagation, every error class, HTML escaping of computed values and error text, and `parseDocument` never throwing on hostile input (a formula named after an `Object.prototype` member used to crash the whole document).

`examples/sheet-basics.md` and `examples/sheet-reference.md` are runnable decks that double as end-to-end fixtures — each shows the source next to what it renders.

