### PR TITLE
docs(examples): Marp-style ![bg] slide backgrounds demo

### DIFF
--- a/examples/bg-slides.md
+++ b/examples/bg-slides.md
@@ -5,23 +5,11 @@ author: Kova
 
 # Slide backgrounds
 
-Marp-style `![bg]` lines set a slide's background image. The line is stripped from the visible body — it never shows up as an ordinary image caption or bullet.
+In Kova, a plain `![](photo.jpg)` on an image-only slide is already full-bleed; an image beside text is already a split layout. **`![bg]` is for the case those don't cover: text rendered on top of a full-slide photo.**
 
-Use an `https://` URL (as below) or a path relative to a **saved** deck. Unsaved decks can't resolve local image paths the same way the thumbnail “Set slide background…” picker does.
+The `![bg…]` line is stripped from the visible body during parse (Marp-compatible). Use an `https://` URL below, or a path relative to a **saved** deck — the thumbnail **Set slide background…** picker also writes this line for you (local files need a saved document).
 
----
-
-## Full-bleed (image only)
-
-A slide whose *only* content is a `![bg]` line becomes a full-bleed image (next slide):
-
-```markdown
-![bg](https://picsum.photos/seed/kova-bg-full/1280/720)
-```
-
----
-
-![bg](https://picsum.photos/seed/kova-bg-full/1280/720)
+For readable text on dark photos, pair with a per-slide colour override — see [`examples/slide-color.md`](examples/slide-color.md).
 
 ---
 
@@ -32,10 +20,10 @@ A slide whose *only* content is a `![bg]` line becomes a full-bleed image (next 
 
 ## Title on the photo
 
-Body text renders on top of the background.
+Body text renders on top of the background image, not beside it.
 ```
 
-Prefer a dark or light photo that keeps contrast readable — or pair with a per-slide colour override (see `examples/slide-color.md`). Next slide is the live version.
+Next slide is the live version.
 
 ---
 
@@ -43,85 +31,47 @@ Prefer a dark or light photo that keeps contrast readable — or pair with a per
 
 ## Title on the photo
 
-Body text renders on top of the background.
+Body text renders on top of the background image, not beside it.
 
 ---
 
-## Split: image on the left
+## When to use `![](…)` instead
 
-```markdown
-![bg left](https://picsum.photos/seed/kova-bg-left/600/800)
+| Goal | Kova-native approach |
+|------|----------------------|
+| Full-bleed image only | `![](photo.jpg)` on a slide with no other content |
+| Image left / right + text | `![](photo.jpg)` plus title or bullets on the same slide |
+| Text **on top of** the photo | `![bg](photo.jpg)` + title/body (this file) |
 
-## Split layout
-
-- Image fills the left column
-- Content stays on the theme background
-```
-
----
-
-![bg left](https://picsum.photos/seed/kova-bg-left/600/800)
-
-## Split layout
-
-- Image fills the left column
-- Content stays on the theme background
-
----
-
-## Split: image on the right
-
-```markdown
-![bg right](https://picsum.photos/seed/kova-bg-right/600/800)
-
-## Image on the right
-
-- Same idea, mirrored
-- Useful for portraits and product shots
-```
-
----
-
-![bg right](https://picsum.photos/seed/kova-bg-right/600/800)
-
-## Image on the right
-
-- Same idea, mirrored
-- Useful for portraits and product shots
+Marp's `![bg left]` / `![bg right]` import cleanly, but in Kova they duplicate what a regular inline image already does.
 
 ---
 
 ## Contain / fit sizing
 
-Default sizing is **cover** (crop to fill). Add `contain` or Marp's `fit` alias to letterbox instead:
+Default background sizing is **cover** (crop to fill). For letterboxing, add `contain` or Marp's `fit` alias — only applies to `![bg]`, not inline images:
 
 ```markdown
 ![bg contain](https://picsum.photos/seed/kova-bg-contain/800/1200)
 
-## Contain sizing
+## Letterboxed background
 
-The whole image stays visible; empty bands use the slide background colour.
+Empty bands use the slide background colour.
 ```
 
 ---
 
 ![bg contain](https://picsum.photos/seed/kova-bg-contain/800/1200)
 
-## Contain sizing
+## Letterboxed background
 
-The whole image stays visible; empty bands use the slide background colour.
+Empty bands use the slide background colour.
 
 ---
 
 ## What just happened
 
-| Syntax | Result |
-|--------|--------|
-| `![bg](…)` alone | Full-bleed layout |
-| `![bg](…)` + title/body | Full-slide background; text on top |
-| `![bg left](…)` / `![bg right](…)` | Split layout |
-| `![bg contain](…)` or `![bg fit](…)` | `contain` sizing instead of `cover` |
-
-The `![bg…]` line is removed from the body text during parse (same as Marp import).
-
-**GUI:** right-click a slide thumbnail → **Set slide background…** / **Clear background**. That writes the equivalent `![bg](…)` line into the Markdown for you (requires a saved document when picking a local file).
+- `![bg](…)` + title/body → full-slide **background**; text draws on top.
+- `![bg contain](…)` / `![bg fit](…)` → `contain` sizing instead of `cover`.
+- The `![bg…]` line never appears as body text (same as Marp import).
+- **GUI:** right-click a slide thumbnail → **Set slide background…** / **Clear background**.

--- a/examples/bg-slides.md
+++ b/examples/bg-slides.md
@@ -1,0 +1,127 @@
+---
+title: Slide backgrounds
+author: Kova
+---
+
+# Slide backgrounds
+
+Marp-style `![bg]` lines set a slide's background image. The line is stripped from the visible body — it never shows up as an ordinary image caption or bullet.
+
+Use an `https://` URL (as below) or a path relative to a **saved** deck. Unsaved decks can't resolve local image paths the same way the thumbnail “Set slide background…” picker does.
+
+---
+
+## Full-bleed (image only)
+
+A slide whose *only* content is a `![bg]` line becomes a full-bleed image (next slide):
+
+```markdown
+![bg](https://picsum.photos/seed/kova-bg-full/1280/720)
+```
+
+---
+
+![bg](https://picsum.photos/seed/kova-bg-full/1280/720)
+
+---
+
+## Text over a full-slide background
+
+```markdown
+![bg](https://picsum.photos/seed/kova-bg-overlay/1280/720)
+
+## Title on the photo
+
+Body text renders on top of the background.
+```
+
+Prefer a dark or light photo that keeps contrast readable — or pair with a per-slide colour override (see `examples/slide-color.md`). Next slide is the live version.
+
+---
+
+![bg](https://picsum.photos/seed/kova-bg-overlay/1280/720)
+
+## Title on the photo
+
+Body text renders on top of the background.
+
+---
+
+## Split: image on the left
+
+```markdown
+![bg left](https://picsum.photos/seed/kova-bg-left/600/800)
+
+## Split layout
+
+- Image fills the left column
+- Content stays on the theme background
+```
+
+---
+
+![bg left](https://picsum.photos/seed/kova-bg-left/600/800)
+
+## Split layout
+
+- Image fills the left column
+- Content stays on the theme background
+
+---
+
+## Split: image on the right
+
+```markdown
+![bg right](https://picsum.photos/seed/kova-bg-right/600/800)
+
+## Image on the right
+
+- Same idea, mirrored
+- Useful for portraits and product shots
+```
+
+---
+
+![bg right](https://picsum.photos/seed/kova-bg-right/600/800)
+
+## Image on the right
+
+- Same idea, mirrored
+- Useful for portraits and product shots
+
+---
+
+## Contain / fit sizing
+
+Default sizing is **cover** (crop to fill). Add `contain` or Marp's `fit` alias to letterbox instead:
+
+```markdown
+![bg contain](https://picsum.photos/seed/kova-bg-contain/800/1200)
+
+## Contain sizing
+
+The whole image stays visible; empty bands use the slide background colour.
+```
+
+---
+
+![bg contain](https://picsum.photos/seed/kova-bg-contain/800/1200)
+
+## Contain sizing
+
+The whole image stays visible; empty bands use the slide background colour.
+
+---
+
+## What just happened
+
+| Syntax | Result |
+|--------|--------|
+| `![bg](…)` alone | Full-bleed layout |
+| `![bg](…)` + title/body | Full-slide background; text on top |
+| `![bg left](…)` / `![bg right](…)` | Split layout |
+| `![bg contain](…)` or `![bg fit](…)` | `contain` sizing instead of `cover` |
+
+The `![bg…]` line is removed from the body text during parse (same as Marp import).
+
+**GUI:** right-click a slide thumbnail → **Set slide background…** / **Clear background**. That writes the equivalent `![bg](…)` line into the Markdown for you (requires a saved document when picking a local file).


### PR DESCRIPTION
## Summary
- Adds [`examples/bg-slides.md`](examples/bg-slides.md) — a focused demo for native Marp-style `![bg]` backgrounds (#131).
- Covers full-bleed (image-only), text-over-background, `![bg left]` / `![bg right]` split, and `contain` / `fit` sizing.
- Notes that the `![bg…]` line is stripped from body text, and points at the thumbnail **Set / Clear background** GUI.

## Verification
Parsed the deck with `parseDocument` locally and asserted:
- one `full-bleed` image-only slide
- overlay slides with `backgroundImage` + title
- left/right `split` layouts
- `contain` sizing on the fit demo

Uses stable `picsum.photos/seed/…` URLs so the file opens without a saved deck; local paths are documented for real assets.

## Test plan
- [x] Open `examples/bg-slides.md` in Kova
- [x] Confirm full-bleed slide is image-only
- [x] Confirm overlay / split / contain slides match the source fences
- [x] Optional: right-click thumbnail → Set/Clear background on a saved copy