### PR TITLE
fix(updater): stop macOS self-update failing signature verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,37 @@ jobs:
              latest.json > /tmp/latest.json.new
           mv /tmp/latest.json.new latest.json
 
+      # Cached target/ can carry a stale Kova.app.tar.gz.sig from an earlier run
+      # into latest.json while the re-bundled tarball that uploads no longer
+      # matches it — breaking every macOS self-update. Re-sign the exact bytes
+      # we upload, same as the Windows/Linux re-sign steps above.
+      - name: Re-sign macOS updater tarball and patch latest.json
+        if: matrix.platform == 'macos-latest'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TARBALL=$(find src-tauri/target/universal-apple-darwin/release/bundle/macos -name '*.app.tar.gz' | head -1)
+
+          npm install -g @tauri-apps/cli@^2
+          rm -f "$TARBALL.sig"
+          tauri signer sign "$TARBALL"
+          SIG=$(cat "$TARBALL.sig")
+
+          gh release upload "${{ github.ref_name }}" \
+            "$TARBALL#Kova_universal.app.tar.gz" --clobber
+
+          # All four darwin aliases point at the one universal tarball.
+          jq --arg sig "$SIG" '
+              .platforms["darwin-aarch64"].signature    = $sig |
+              .platforms["darwin-x86_64"].signature     = $sig |
+              .platforms["darwin-aarch64-app"].signature = $sig |
+              .platforms["darwin-x86_64-app"].signature = $sig
+            ' latest.json > /tmp/latest.json.new
+          mv /tmp/latest.json.new latest.json
+
       # Save this platform's latest.json as a workflow artifact so the finalize
       # job can merge all three into one before uploading to the release.
       # Without this, each platform overwrites the shared latest.json in the

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -133,7 +133,8 @@ type UpdateState =
   | { phase: 'available'; version: string }
   | { phase: 'downloading'; version: string; pct: number | null }
   | { phase: 'done'; version: string }
-  | 'error';
+  | 'error'          // check failed — server unreachable
+  | 'install-error'; // downloaded, but verify/install failed
 
 interface Props {
   settings: AppSettings;
@@ -237,7 +238,7 @@ export function SettingsModal({ settings, availableUpdate, allThemes, isDirty, s
       setUpdateState({ phase: 'done', version });
     } catch (err) {
       console.error('[updater] install failed:', err);
-      setUpdateState('error');
+      setUpdateState('install-error');
     }
   }
 
@@ -714,7 +715,7 @@ export function SettingsModal({ settings, availableUpdate, allThemes, isDirty, s
         )}
 
         {selfUpdateSupported && <div style={{ display: 'flex', alignItems: 'center', gap: 10, paddingBottom: 4 }}>
-          {(updateState === 'idle' || updateState === 'up-to-date' || updateState === 'error') && (
+          {(updateState === 'idle' || updateState === 'up-to-date' || updateState === 'error' || updateState === 'install-error') && (
             <button
               type="button"
               onClick={runCheck}
@@ -756,6 +757,10 @@ export function SettingsModal({ settings, availableUpdate, allThemes, isDirty, s
 
           {updateState === 'error' && (
             <span style={{ fontSize: 11, color: '#c0392b' }}>{t('settings.updateCheckError')}</span>
+          )}
+
+          {updateState === 'install-error' && (
+            <span style={{ fontSize: 11, color: '#c0392b' }}>{t('settings.updateInstallError')}</span>
           )}
 
           {typeof updateState === 'object' && updateState.phase === 'available' && (

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -405,6 +405,7 @@ const en = {
     checking: 'Checking…',
     upToDate: 'Up to date (v{{version}})',
     updateCheckError: 'Could not reach update server',
+    updateInstallError: 'Downloaded, but the update could not be verified or installed',
     updateAvailable: '{{version}} available',
     updateNow: 'Update Now',
     downloading: 'Downloading {{version}}{{pct}}',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -421,6 +421,7 @@ const de: DeepPartial<Messages> = {
     checking: 'Wird geprüft…', // Checking…
     upToDate: 'Auf dem neuesten Stand (v{{version}})', // Up to date (v{{version}})
     updateCheckError: 'Update-Server konnte nicht erreicht werden', // Could not reach update server
+    updateInstallError: 'Heruntergeladen, aber das Update konnte nicht verifiziert oder installiert werden', // Downloaded, but the update could not be verified or installed
     updateAvailable: '{{version}} verfügbar', // {{version}} available
     updateNow: 'Jetzt aktualisieren', // Update Now
     downloading: '{{version}} wird heruntergeladen{{pct}}', // Downloading {{version}}{{pct}}


### PR DESCRIPTION
macOS in-app update downloads to 100%, then fails "Could not reach update server". The published `Kova_universal.app.tar.gz` downloads fine (`gzip -t` OK, sha256 stable) but `minisign -V` against the configured pubkey fails. Key IDs match, so the right key signed — the bytes just don't match: the `latest.json` signature is stamped 18:47 (an earlier failed run's build), the tarball was uploaded 18:56 (the success re-run).

Cause: the macOS job restores `src-tauri/target/` from cache, so a prior run's `Kova.app.tar.gz.sig` survives in the bundle dir and reaches `latest.json` while the re-bundled tarball that uploads no longer matches it. Windows and Linux already re-sign their final bytes; macOS didn't.

Fix:
- CI: re-sign the exact macOS tarball we upload (same name, `--clobber`) and overwrite the four `darwin-*` signatures — sig and bytes can't diverge. Mirrors the Linux re-sign.
- UI: post-download failures now read "Downloaded, but the update could not be verified or installed" (en + de) instead of the false "Could not reach update server".

Caveats:
- Fixes the next release; live v0.7.0 stays broken until someone re-signs the published tarball with the updater key and patches the live `latest.json`.
- `tauri signer sign` not runnable here (no key); the call matches the proven Linux step.

`tsc` clean, YAML valid.