### PR TITLE
feat(cli): terminal interface for presenting, theming, and validating decks

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,7 +45,9 @@ block2 = "0.6"
 # Native PDF export via ICoreWebView2_7::PrintToPdf. Versions are pinned to what
 # Tauri/wry already pull in transitively so the lockfile doesn't change.
 webview2-com = "0.38"
-windows = { version = "0.61", features = [] }
+# Win32_System_Console: AttachConsole for CLI output — release builds use the
+# GUI subsystem, so --help/--version/errors need the parent terminal's console.
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Console"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18", features = [] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,6 +23,7 @@
     "core:window:allow-primary-monitor",
     "core:window:allow-set-position",
     "core:window:allow-set-size",
+    "core:window:allow-show",
     "updater:default"
   ]
 }

--- a/src-tauri/installer-hooks.nsh
+++ b/src-tauri/installer-hooks.nsh
@@ -6,3 +6,107 @@
 !macro NSIS_HOOK_PREINSTALL
   Delete "$COMMON_DESKTOP\Kova.lnk"
 !macroend
+
+; ---------------------------------------------------------------------------
+; Per-user PATH registration so `kova` works from Command Prompt / PowerShell
+; (docs/plans/kova-cli.md, Phase D). installMode is currentUser, so this only
+; touches HKCU\Environment — no admin rights involved. String helpers are
+; self-contained (no StrFunc.nsh) to avoid colliding with functions the Tauri
+; NSIS template may already declare.
+;
+; Terminals opened before the install won't see the new PATH — Windows only
+; delivers WM_SETTINGCHANGE to new processes.
+
+!include "WinMessages.nsh"
+
+; Push haystack, push needle → pops both, pushes the 0-based index of the
+; first match, or -1 if absent. StrCmp is case-sensitive; the worst case of a
+; case-mismatch is a duplicate PATH entry, which Windows tolerates.
+!macro KOVA_STRIDX_FUNC un
+Function ${un}KovaStrIdx
+  Exch $R0        ; needle
+  Exch
+  Exch $R1        ; haystack
+  Push $R2
+  Push $R3
+  Push $R4
+  StrLen $R2 $R0
+  StrCpy $R3 0
+  loop_${un}:
+    StrCpy $R4 $R1 $R2 $R3
+    StrCmp $R4 $R0 found_${un}
+    StrCmp $R4 "" notfound_${un}
+    IntOp $R3 $R3 + 1
+    Goto loop_${un}
+  found_${un}:
+    Goto done_${un}
+  notfound_${un}:
+    StrCpy $R3 -1
+  done_${un}:
+  StrCpy $R0 $R3
+  Pop $R4
+  Pop $R3
+  Pop $R2
+  Pop $R1
+  Exch $R0
+FunctionEnd
+!macroend
+!insertmacro KOVA_STRIDX_FUNC ""
+!insertmacro KOVA_STRIDX_FUNC "un."
+
+!macro NSIS_HOOK_POSTINSTALL
+  ReadRegStr $0 HKCU "Environment" "Path"
+  Push $0
+  Push "$INSTDIR"
+  Call KovaStrIdx
+  Pop $1
+  IntCmp $1 -1 0 kova_path_done kova_path_done   ; only append when absent
+  StrCmp $0 "" 0 +3
+    WriteRegExpandStr HKCU "Environment" "Path" "$INSTDIR"
+    Goto kova_path_notify
+  WriteRegExpandStr HKCU "Environment" "Path" "$0;$INSTDIR"
+  kova_path_notify:
+    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  kova_path_done:
+!macroend
+
+; Excise $INSTDIR from the per-user PATH: try the ";dir" form first (mid/end
+; of list), then "dir;" (start of list), then the exact-match form (sole
+; entry). Leaves PATH untouched when the entry is absent.
+!macro NSIS_HOOK_POSTUNINSTALL
+  ReadRegStr $0 HKCU "Environment" "Path"
+  StrCmp $0 "" kova_unpath_done
+
+  StrCpy $2 ";$INSTDIR"
+  Push $0
+  Push $2
+  Call un.KovaStrIdx
+  Pop $1
+  IntCmp $1 -1 kova_unpath_try_leading
+    Goto kova_unpath_excise
+
+  kova_unpath_try_leading:
+  StrCpy $2 "$INSTDIR;"
+  Push $0
+  Push $2
+  Call un.KovaStrIdx
+  Pop $1
+  IntCmp $1 -1 kova_unpath_try_exact
+    Goto kova_unpath_excise
+
+  kova_unpath_try_exact:
+  StrCmp $0 "$INSTDIR" 0 kova_unpath_done
+    WriteRegExpandStr HKCU "Environment" "Path" ""
+    Goto kova_unpath_notify
+
+  kova_unpath_excise:
+    StrLen $3 $2
+    StrCpy $4 $0 $1          ; prefix: everything before the match
+    IntOp $5 $1 + $3
+    StrCpy $6 $0 "" $5       ; suffix: everything after the matched needle
+    WriteRegExpandStr HKCU "Environment" "Path" "$4$6"
+
+  kova_unpath_notify:
+    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  kova_unpath_done:
+!macroend

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,0 +1,622 @@
+//! Command-line argument handling for the Kova binary.
+//!
+//! Grammar: at most one action per invocation (`--present`, `--import`,
+//! `--export`, or standalone `--check FILE`) plus modifiers (`--theme`,
+//! `--check`) that combine with an action in any order. `--import` and
+//! `--export` parse fully but are rejected as "not available in this
+//! version" until the export engine work lands, so the grammar is stable
+//! and scripts fail loudly rather than misparsing.
+//!
+//! `parse_cli_args` is pure (no filesystem, no exit) so the grammar is unit
+//! testable; `startup` wraps it with the process-level concerns: printing,
+//! exit codes, path canonicalisation, and the Windows console attach.
+
+use serde::Serialize;
+
+/// Value of `--theme`: a theme name to resolve against the built-in and
+/// installed community themes, or a path to a theme YAML file.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ThemeArg {
+    Named { name: String },
+    Path { path: String },
+}
+
+/// CLI action parsed at startup, buffered in `AppState` and drained once by
+/// the frontend via the `take_pending_cli` command. Paths are canonicalised
+/// absolute paths (existence already verified — `startup` exits 1 otherwise).
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+pub struct PendingCli {
+    pub present: Option<String>,
+    pub theme: Option<ThemeArg>,
+    pub check: bool,
+    pub check_only: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CliArgs {
+    Run(RunArgs),
+    Help,
+    Version,
+    Error(String),
+}
+
+#[derive(Debug, PartialEq, Default)]
+pub struct RunArgs {
+    pub action: Option<Action>,
+    pub theme: Option<ThemeArg>,
+    pub check: bool,
+    /// Plain-file arguments for the editor launch path (existence filtering
+    /// happens in `startup`, keeping the parser filesystem-free).
+    pub open: Vec<String>,
+}
+
+// Import/Export are parsed for grammar stability but rejected until Track 2
+// implements them, so their payload fields are not read yet.
+#[allow(dead_code)]
+#[derive(Debug, PartialEq)]
+pub enum Action {
+    Present(String),
+    Import { format: ImportFormat, input: String, output: String },
+    Export { format: ExportFormat, input: String, output: String },
+    CheckOnly(String),
+}
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq)]
+pub enum ImportFormat {
+    Marp,
+    Pptx,
+    Url,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq)]
+pub enum ExportFormat {
+    Pptx,
+    Pdf,
+}
+
+const IMPORT_USAGE: &str = "--import requires: --import <marp|pptx|url> <input> <output>";
+const EXPORT_USAGE: &str = "--export requires: --export <pptx|pdf> <input> <output>";
+
+const USAGE: &str = "\
+Usage:
+  kova [FILE...]                            open file(s) in the editor
+  kova --present <FILE>                     present FILE directly
+  kova --check <FILE>                       validate FILE and exit
+  kova --import <marp|pptx|url> <IN> <OUT>  convert IN to Kova Markdown
+  kova --export <pptx|pdf> <IN> <OUT>       export IN via Kova's engine
+
+Modifiers (combine with an action, any order):
+  --theme <NAME|PATH>   override the deck theme for this run; a name is
+                        resolved against built-in and installed community
+                        themes, a path must point to a theme YAML file
+  --check               validate syntax before running the action
+
+Other:
+  -h, --help            show this help
+  --version             show version
+
+--import and --export are not available in this version.
+";
+
+pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
+    // --help / --version win regardless of position or other errors.
+    for arg in &args {
+        let (flag, _) = split_eq(arg);
+        match flag {
+            "--help" | "-h" => return CliArgs::Help,
+            "--version" => return CliArgs::Version,
+            _ => {}
+        }
+    }
+
+    let mut action: Option<Action> = None;
+    let mut theme: Option<ThemeArg> = None;
+    let mut check = false;
+    let mut positionals: Vec<String> = Vec::new();
+    let mut unknown: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        if !arg.starts_with('-') {
+            positionals.push(arg.clone());
+            i += 1;
+            continue;
+        }
+        // macOS Finder launches inject a process serial number argument.
+        if arg.starts_with("-psn_") {
+            i += 1;
+            continue;
+        }
+
+        let (flag, inline) = split_eq(arg);
+        match flag {
+            "--present" => {
+                let Some(file) = take_value(inline, &args, &mut i) else {
+                    return CliArgs::Error("--present requires a file argument".into());
+                };
+                if let Err(e) = set_action(&mut action, Action::Present(file)) {
+                    return e;
+                }
+            }
+            "--check" => {
+                if inline.is_some() {
+                    return CliArgs::Error(
+                        "--check does not take a value; pass the file as a separate argument"
+                            .into(),
+                    );
+                }
+                check = true;
+            }
+            "--theme" => {
+                let Some(value) = take_value(inline, &args, &mut i) else {
+                    return CliArgs::Error("--theme requires a value".into());
+                };
+                theme = Some(classify_theme(value));
+            }
+            "--import" => {
+                let Some(format) = take_value(inline, &args, &mut i) else {
+                    return CliArgs::Error(IMPORT_USAGE.into());
+                };
+                let format = match format.as_str() {
+                    "marp" => ImportFormat::Marp,
+                    "pptx" => ImportFormat::Pptx,
+                    "url" => ImportFormat::Url,
+                    other => {
+                        return CliArgs::Error(format!(
+                            "unknown import format '{other}' (expected marp, pptx, or url)"
+                        ))
+                    }
+                };
+                let (Some(input), Some(output)) = (
+                    take_value(None, &args, &mut i),
+                    take_value(None, &args, &mut i),
+                ) else {
+                    return CliArgs::Error(IMPORT_USAGE.into());
+                };
+                if let Err(e) = set_action(&mut action, Action::Import { format, input, output }) {
+                    return e;
+                }
+            }
+            "--export" => {
+                let Some(format) = take_value(inline, &args, &mut i) else {
+                    return CliArgs::Error(EXPORT_USAGE.into());
+                };
+                let format = match format.as_str() {
+                    "pptx" => ExportFormat::Pptx,
+                    "pdf" => ExportFormat::Pdf,
+                    other => {
+                        return CliArgs::Error(format!(
+                            "unknown export format '{other}' (expected pptx or pdf)"
+                        ))
+                    }
+                };
+                let (Some(input), Some(output)) = (
+                    take_value(None, &args, &mut i),
+                    take_value(None, &args, &mut i),
+                ) else {
+                    return CliArgs::Error(EXPORT_USAGE.into());
+                };
+                if let Err(e) = set_action(&mut action, Action::Export { format, input, output }) {
+                    return e;
+                }
+            }
+            other => {
+                if unknown.is_none() {
+                    unknown = Some(other.to_string());
+                }
+            }
+        }
+        i += 1;
+    }
+
+    // Standalone --check: the file arrives as a positional.
+    if check && action.is_none() {
+        match positionals.len() {
+            0 => return CliArgs::Error("--check requires a file or an action to gate".into()),
+            1 => action = Some(Action::CheckOnly(positionals.remove(0))),
+            _ => return CliArgs::Error("--check validates one file at a time".into()),
+        }
+    }
+
+    let cli_intent = action.is_some() || check || theme.is_some();
+    if cli_intent {
+        // Strict mode: CLI invocations fail loudly.
+        if let Some(flag) = unknown {
+            return CliArgs::Error(format!("unknown option '{flag}'"));
+        }
+        if let Some(extra) = positionals.first() {
+            return CliArgs::Error(format!("unexpected argument '{extra}'"));
+        }
+        if action.is_none() {
+            return CliArgs::Error("--theme requires --present, --import, or --export".into());
+        }
+        match action {
+            Some(Action::Import { .. }) => {
+                return CliArgs::Error("--import is not available in this version".into())
+            }
+            Some(Action::Export { .. }) => {
+                return CliArgs::Error("--export is not available in this version".into())
+            }
+            _ => {}
+        }
+        CliArgs::Run(RunArgs { action, theme, check, open: Vec::new() })
+    } else {
+        // Plain editor launch: positionals are files to open. Unknown
+        // dash-arguments stay silently ignored — platform launchers and
+        // desktop files pass flags Kova has never handled.
+        CliArgs::Run(RunArgs { action: None, theme: None, check: false, open: positionals })
+    }
+}
+
+fn split_eq(arg: &str) -> (&str, Option<&str>) {
+    match arg.split_once('=') {
+        Some((flag, value)) => (flag, Some(value)),
+        None => (arg, None),
+    }
+}
+
+/// Value for a flag: the inline `--flag=value` form, or the following
+/// argument when it doesn't look like another flag.
+fn take_value(inline: Option<&str>, args: &[String], i: &mut usize) -> Option<String> {
+    if let Some(v) = inline {
+        return Some(v.to_string());
+    }
+    let next = args.get(*i + 1)?;
+    if next.starts_with('-') {
+        return None;
+    }
+    *i += 1;
+    Some(next.clone())
+}
+
+fn set_action(slot: &mut Option<Action>, action: Action) -> Result<(), CliArgs> {
+    if slot.is_some() {
+        return Err(CliArgs::Error(
+            "only one action allowed (--present, --import, --export, or standalone --check)"
+                .into(),
+        ));
+    }
+    *slot = Some(action);
+    Ok(())
+}
+
+/// A value is a path if it looks like one; anything else is a theme name.
+fn classify_theme(value: String) -> ThemeArg {
+    let lower = value.to_ascii_lowercase();
+    let looks_like_path = value.contains('/')
+        || value.contains('\\')
+        || value.starts_with('~')
+        || lower.ends_with(".yaml")
+        || lower.ends_with(".yml");
+    if looks_like_path {
+        ThemeArg::Path { path: value }
+    } else {
+        ThemeArg::Named { name: value }
+    }
+}
+
+/// What `run()` needs after CLI handling: the buffered CLI action (if any)
+/// and the plain files to open in the editor.
+pub struct Startup {
+    pub pending: Option<PendingCli>,
+    pub open: Vec<String>,
+}
+
+/// Parse argv and resolve everything that must happen before the Tauri
+/// builder runs: `--help`/`--version` print and exit 0, usage errors exit 2,
+/// and action paths that fail to canonicalise exit 1 — fail fast, no window.
+pub fn startup() -> Startup {
+    match parse_cli_args(std::env::args().skip(1).collect()) {
+        CliArgs::Help => {
+            attach_parent_console();
+            print!("{USAGE}");
+            std::process::exit(0);
+        }
+        CliArgs::Version => {
+            attach_parent_console();
+            println!("kova {}", env!("CARGO_PKG_VERSION"));
+            std::process::exit(0);
+        }
+        CliArgs::Error(msg) => {
+            attach_parent_console();
+            eprintln!("kova: {msg}");
+            eprintln!("Try 'kova --help' for usage.");
+            std::process::exit(2);
+        }
+        CliArgs::Run(run) => resolve(run),
+    }
+}
+
+fn resolve(run: RunArgs) -> Startup {
+    let mut pending = PendingCli { check: run.check, ..PendingCli::default() };
+    match run.action {
+        Some(Action::Present(path)) => {
+            pending.present = Some(canonicalise_or_exit(&path, "cannot open"));
+        }
+        Some(Action::CheckOnly(path)) => {
+            pending.check_only = Some(canonicalise_or_exit(&path, "cannot open"));
+        }
+        // Rejected with "not available" during parse.
+        Some(Action::Import { .. }) | Some(Action::Export { .. }) => unreachable!(),
+        None => {}
+    }
+    pending.theme = run.theme.map(|theme| match theme {
+        ThemeArg::Path { path } => {
+            ThemeArg::Path { path: canonicalise_or_exit(&path, "cannot read theme") }
+        }
+        named => named,
+    });
+
+    let cli_active = pending.present.is_some() || pending.check_only.is_some();
+    // Editor launch keeps the pre-CLI behaviour: arguments that don't exist
+    // on disk are silently ignored rather than failing the launch.
+    let open = run
+        .open
+        .into_iter()
+        .filter(|p| std::path::Path::new(p).exists())
+        .collect();
+    Startup { pending: if cli_active { Some(pending) } else { None }, open }
+}
+
+fn canonicalise_or_exit(path: &str, verb: &str) -> String {
+    match std::fs::canonicalize(path) {
+        Ok(p) => p.to_string_lossy().into_owned(),
+        Err(_) => {
+            attach_parent_console();
+            eprintln!("kova: {verb} '{path}': no such file");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Release builds use the Windows GUI subsystem (no console), so terminal
+/// output vanishes unless the process attaches to the parent's console
+/// first. Silently a no-op when there is no parent console (GUI launches)
+/// or on other platforms.
+#[cfg(windows)]
+pub fn attach_parent_console() {
+    use windows::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
+    unsafe {
+        let _ = AttachConsole(ATTACH_PARENT_PROCESS);
+    }
+}
+
+#[cfg(not(windows))]
+pub fn attach_parent_console() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> CliArgs {
+        parse_cli_args(args.iter().map(|s| s.to_string()).collect())
+    }
+
+    fn expect_run(args: &[&str]) -> RunArgs {
+        match parse(args) {
+            CliArgs::Run(run) => run,
+            other => panic!("expected Run, got {other:?}"),
+        }
+    }
+
+    fn expect_error(args: &[&str]) -> String {
+        match parse(args) {
+            CliArgs::Error(msg) => msg,
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    // -- actions ------------------------------------------------------------
+
+    #[test]
+    fn present_with_space_value() {
+        let run = expect_run(&["--present", "talk.md"]);
+        assert_eq!(run.action, Some(Action::Present("talk.md".into())));
+        assert!(run.open.is_empty());
+    }
+
+    #[test]
+    fn present_with_equals_value() {
+        let run = expect_run(&["--present=talk.md"]);
+        assert_eq!(run.action, Some(Action::Present("talk.md".into())));
+    }
+
+    #[test]
+    fn present_missing_value() {
+        assert_eq!(expect_error(&["--present"]), "--present requires a file argument");
+    }
+
+    #[test]
+    fn present_followed_by_flag_is_missing_value() {
+        assert_eq!(
+            expect_error(&["--present", "--check"]),
+            "--present requires a file argument"
+        );
+    }
+
+    #[test]
+    fn check_standalone_takes_positional_file() {
+        let run = expect_run(&["--check", "talk.md"]);
+        assert_eq!(run.action, Some(Action::CheckOnly("talk.md".into())));
+        assert!(run.check);
+    }
+
+    #[test]
+    fn check_alone_is_error() {
+        assert_eq!(expect_error(&["--check"]), "--check requires a file or an action to gate");
+    }
+
+    #[test]
+    fn check_multiple_files_is_error() {
+        assert_eq!(
+            expect_error(&["--check", "a.md", "b.md"]),
+            "--check validates one file at a time"
+        );
+    }
+
+    #[test]
+    fn check_rejects_inline_value() {
+        let msg = expect_error(&["--check=talk.md"]);
+        assert!(msg.starts_with("--check does not take a value"));
+    }
+
+    #[test]
+    fn two_actions_rejected() {
+        let msg = expect_error(&["--present", "a.md", "--present", "b.md"]);
+        assert!(msg.starts_with("only one action allowed"));
+    }
+
+    #[test]
+    fn unexpected_positional_with_action() {
+        assert_eq!(
+            expect_error(&["--present", "a.md", "extra.md"]),
+            "unexpected argument 'extra.md'"
+        );
+    }
+
+    // -- import / export ----------------------------------------------------
+
+    #[test]
+    fn import_parses_then_reports_unavailable() {
+        assert_eq!(
+            expect_error(&["--import", "marp", "in.md", "out.md"]),
+            "--import is not available in this version"
+        );
+    }
+
+    #[test]
+    fn export_parses_then_reports_unavailable() {
+        assert_eq!(
+            expect_error(&["--export", "pdf", "in.md", "out.pdf"]),
+            "--export is not available in this version"
+        );
+    }
+
+    #[test]
+    fn import_unknown_format() {
+        assert_eq!(
+            expect_error(&["--import", "keynote", "in", "out"]),
+            "unknown import format 'keynote' (expected marp, pptx, or url)"
+        );
+    }
+
+    #[test]
+    fn export_unknown_format() {
+        assert_eq!(
+            expect_error(&["--export", "docx", "in", "out"]),
+            "unknown export format 'docx' (expected pptx or pdf)"
+        );
+    }
+
+    #[test]
+    fn export_missing_output() {
+        assert_eq!(expect_error(&["--export", "pdf", "in.md"]), EXPORT_USAGE);
+    }
+
+    #[test]
+    fn import_missing_everything() {
+        assert_eq!(expect_error(&["--import"]), IMPORT_USAGE);
+    }
+
+    // -- modifiers ----------------------------------------------------------
+
+    #[test]
+    fn combined_flags_any_order() {
+        let a = expect_run(&["--check", "--theme=firefly", "--present", "talk.md"]);
+        let b = expect_run(&["--present", "talk.md", "--theme", "firefly", "--check"]);
+        assert_eq!(a, b);
+        assert_eq!(a.action, Some(Action::Present("talk.md".into())));
+        assert_eq!(a.theme, Some(ThemeArg::Named { name: "firefly".into() }));
+        assert!(a.check);
+    }
+
+    #[test]
+    fn theme_equals_and_space_forms_match() {
+        let a = expect_run(&["--theme=gruvbox-dark", "--present", "t.md"]);
+        let b = expect_run(&["--theme", "gruvbox-dark", "--present", "t.md"]);
+        assert_eq!(a.theme, b.theme);
+    }
+
+    #[test]
+    fn theme_name_vs_path_classification() {
+        for (value, expect_path) in [
+            ("gruvbox-dark", false),
+            ("firefly", false),
+            ("./my.yaml", true),
+            ("themes/my.yml", true),
+            ("/abs/theme.yaml", true),
+            ("~/theme.yaml", true),
+            ("custom.YML", true),
+            ("C:\\themes\\my.yaml", true),
+        ] {
+            let run = expect_run(&["--theme", value, "--present", "t.md"]);
+            let is_path = matches!(run.theme, Some(ThemeArg::Path { .. }));
+            assert_eq!(is_path, expect_path, "misclassified {value:?}");
+        }
+    }
+
+    #[test]
+    fn theme_missing_value() {
+        assert_eq!(expect_error(&["--theme", "--present", "t.md"]), "--theme requires a value");
+    }
+
+    #[test]
+    fn theme_without_action() {
+        assert_eq!(
+            expect_error(&["--theme=firefly"]),
+            "--theme requires --present, --import, or --export"
+        );
+    }
+
+    // -- unknown flags and editor launch ------------------------------------
+
+    #[test]
+    fn unknown_flag_with_action_is_error() {
+        assert_eq!(expect_error(&["--foo", "--present", "t.md"]), "unknown option '--foo'");
+    }
+
+    #[test]
+    fn unknown_flag_without_action_is_ignored() {
+        let run = expect_run(&["--foo", "talk.md"]);
+        assert_eq!(run.action, None);
+        assert_eq!(run.open, vec!["talk.md".to_string()]);
+    }
+
+    #[test]
+    fn plain_files_collect_for_editor() {
+        let run = expect_run(&["a.md", "b.md"]);
+        assert_eq!(run.open, vec!["a.md".to_string(), "b.md".to_string()]);
+        assert_eq!(run.action, None);
+    }
+
+    #[test]
+    fn empty_args_is_plain_launch() {
+        let run = expect_run(&[]);
+        assert_eq!(run.action, None);
+        assert!(run.open.is_empty());
+    }
+
+    #[test]
+    fn psn_argument_tolerated() {
+        let run = expect_run(&["-psn_0_12345", "--present", "talk.md"]);
+        assert_eq!(run.action, Some(Action::Present("talk.md".into())));
+    }
+
+    // -- help / version -----------------------------------------------------
+
+    #[test]
+    fn help_wins_anywhere() {
+        assert_eq!(parse(&["--present", "t.md", "--help"]), CliArgs::Help);
+        assert_eq!(parse(&["-h"]), CliArgs::Help);
+    }
+
+    #[test]
+    fn version_wins_anywhere() {
+        assert_eq!(parse(&["--version"]), CliArgs::Version);
+        assert_eq!(parse(&["--check", "--version"]), CliArgs::Version);
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -40,6 +40,10 @@ pub struct AppState {
     /// `RunEvent::Opened`) before the frontend mounted its listener. Drained
     /// once on startup by `take_pending_open`.
     pub pending_open: Mutex<Vec<String>>,
+    /// CLI action (`--present` / `--check` / `--theme`) parsed at startup by
+    /// `cli::startup`, before the webview exists. Drained once on startup by
+    /// `take_pending_cli`.
+    pub pending_cli: Mutex<Option<crate::cli::PendingCli>>,
     /// Unix-millisecond deadline before which the watcher should suppress
     /// file-changed events — set by write_file to swallow events caused by
     /// Kova's own atomic rename rather than a genuine external edit.

--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -11,6 +11,12 @@ pub fn take_pending_open(state: State<'_, AppState>) -> Vec<String> {
     std::mem::take(&mut *state.pending_open.lock().unwrap_or_else(|e| e.into_inner()))
 }
 
+/// Drain the CLI action (`--present` / `--check` / `--theme`) parsed at startup.
+#[tauri::command]
+pub fn take_pending_cli(state: State<'_, AppState>) -> Option<crate::cli::PendingCli> {
+    state.pending_cli.lock().unwrap_or_else(|e| e.into_inner()).take()
+}
+
 #[tauri::command]
 pub fn read_file(path: String) -> Result<String, String> {
     file_io::read(&path)

--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -17,6 +17,14 @@ pub fn take_pending_cli(state: State<'_, AppState>) -> Option<crate::cli::Pendin
     state.pending_cli.lock().unwrap_or_else(|e| e.into_inner()).take()
 }
 
+/// Existence probe for --check's media validation. Read-only and cheap —
+/// deliberately not read_file_b64, which would load whole videos to answer
+/// a yes/no question.
+#[tauri::command]
+pub fn path_exists(path: String) -> bool {
+    std::path::Path::new(&path).exists()
+}
+
 #[tauri::command]
 pub fn read_file(path: String) -> Result<String, String> {
     file_io::read(&path)

--- a/src-tauri/src/commands/lifecycle.rs
+++ b/src-tauri/src/commands/lifecycle.rs
@@ -17,19 +17,24 @@ pub fn restart_app(app: tauri::AppHandle) {
     app.restart();
 }
 
-/// Terminal-facing error exit for CLI-initiated flows (`--present` / `--check`).
-/// The launching terminal is the CLI user's surface — and the main window may
-/// still be hidden at this point, which makes a GUI dialog unreliable — so the
-/// report goes to stderr (attaching the parent console on Windows, where the
-/// GUI subsystem otherwise swallows it). Exits the process directly rather
-/// than via `app.exit(code)`: the code passed to `app.exit` does not survive
-/// the run loop's return path (the process ends 0), and this error path has
-/// nothing to clean up — no unsaved edits, no presentation session, and the
-/// wake lock is only ever taken after presenting starts.
+/// Terminal-facing exit for CLI-initiated flows (`--present` / `--check`):
+/// clean end-of-presentation (no message, code 0) or an error report. The
+/// launching terminal is the CLI user's surface — and the main window may
+/// still be hidden when errors fire, which makes a GUI dialog unreliable —
+/// so messages go to stderr (attaching the parent console on Windows, where
+/// the GUI subsystem otherwise swallows it). Exits the process directly
+/// rather than via `app.exit(code)`: the code passed to `app.exit` does not
+/// survive the run loop's return path (the process ends 0). A cold-started
+/// session has no unsaved edits and deliberately skips the window-state
+/// save; the one cleanup that matters — releasing the wake lock, whose
+/// macOS `caffeinate` child would be orphaned by a hard exit — is the
+/// caller's responsibility before invoking this.
 #[tauri::command]
-pub fn cli_error_exit(message: String, code: i32) {
+pub fn cli_exit(message: Option<String>, code: i32) {
     crate::cli::attach_parent_console();
-    eprintln!("kova: {message}");
+    if let Some(msg) = message {
+        eprintln!("kova: {msg}");
+    }
     std::process::exit(code);
 }
 

--- a/src-tauri/src/commands/lifecycle.rs
+++ b/src-tauri/src/commands/lifecycle.rs
@@ -29,6 +29,50 @@ pub fn restart_app(app: tauri::AppHandle) {
 /// save; the one cleanup that matters — releasing the wake lock, whose
 /// macOS `caffeinate` child would be orphaned by a hard exit — is the
 /// caller's responsibility before invoking this.
+/// macOS: symlink the running binary into a PATH directory so `kova` works
+/// from a terminal (docs/plans/kova-cli.md, Phase D). User-initiated via the
+/// app menu — the VS Code "install shell command" pattern — rather than done
+/// silently at install time. Returns the directory linked into; the Err
+/// carries a manual `ln -s` command for the no-writable-dir case. Never
+/// clobbers a `kova` that isn't ours: only replaces symlinks whose target
+/// points into a Kova.app bundle (e.g. after the app was moved).
+#[tauri::command]
+pub fn install_cli_symlink() -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+        // Homebrew's bin (Apple Silicon, then Intel) is on PATH for virtually
+        // every terminal user; /usr/local/bin also covers non-Homebrew setups.
+        for dir in ["/opt/homebrew/bin", "/usr/local/bin"] {
+            let dir_path = std::path::Path::new(dir);
+            if !dir_path.is_dir() {
+                continue;
+            }
+            let link = dir_path.join("kova");
+            match std::fs::read_link(&link) {
+                Ok(target) if target == exe => return Ok(dir.to_string()),
+                Ok(target) if target.to_string_lossy().contains("Kova.app") => {
+                    let _ = std::fs::remove_file(&link);
+                }
+                Ok(_) => continue, // someone else's `kova` — leave it alone
+                Err(_) => {
+                    // Not a symlink. A regular file named `kova` is also not
+                    // ours to overwrite; nothing there at all is fine.
+                    if link.symlink_metadata().is_ok() {
+                        continue;
+                    }
+                }
+            }
+            if std::os::unix::fs::symlink(&exe, &link).is_ok() {
+                return Ok(dir.to_string());
+            }
+        }
+        Err(format!("ln -s \"{}\" /usr/local/bin/kova", exe.display()))
+    }
+    #[cfg(not(target_os = "macos"))]
+    Err("only available on macOS".to_string())
+}
+
 /// Print to the launching terminal's stdout (used for --check reports, which
 /// are data, unlike the error reporting on stderr in cli_exit below).
 #[tauri::command]

--- a/src-tauri/src/commands/lifecycle.rs
+++ b/src-tauri/src/commands/lifecycle.rs
@@ -29,6 +29,14 @@ pub fn restart_app(app: tauri::AppHandle) {
 /// save; the one cleanup that matters — releasing the wake lock, whose
 /// macOS `caffeinate` child would be orphaned by a hard exit — is the
 /// caller's responsibility before invoking this.
+/// Print to the launching terminal's stdout (used for --check reports, which
+/// are data, unlike the error reporting on stderr in cli_exit below).
+#[tauri::command]
+pub fn cli_stdout(text: String) {
+    crate::cli::attach_parent_console();
+    println!("{text}");
+}
+
 #[tauri::command]
 pub fn cli_exit(message: Option<String>, code: i32) {
     crate::cli::attach_parent_console();

--- a/src-tauri/src/commands/lifecycle.rs
+++ b/src-tauri/src/commands/lifecycle.rs
@@ -17,6 +17,22 @@ pub fn restart_app(app: tauri::AppHandle) {
     app.restart();
 }
 
+/// Terminal-facing error exit for CLI-initiated flows (`--present` / `--check`).
+/// The launching terminal is the CLI user's surface — and the main window may
+/// still be hidden at this point, which makes a GUI dialog unreliable — so the
+/// report goes to stderr (attaching the parent console on Windows, where the
+/// GUI subsystem otherwise swallows it). Exits the process directly rather
+/// than via `app.exit(code)`: the code passed to `app.exit` does not survive
+/// the run loop's return path (the process ends 0), and this error path has
+/// nothing to clean up — no unsaved edits, no presentation session, and the
+/// wake lock is only ever taken after presenting starts.
+#[tauri::command]
+pub fn cli_error_exit(message: String, code: i32) {
+    crate::cli::attach_parent_console();
+    eprintln!("kova: {message}");
+    std::process::exit(code);
+}
+
 /// Called by the frontend once the unsaved-changes prompt for an app-level
 /// quit (Cmd+Q, Dock Quit, etc.) has been resolved — either the user chose to
 /// discard/save, or there was nothing to confirm. Marks the exit confirmed so

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod cli;
 mod commands;
 mod file_io;
 mod net_guard;
@@ -10,6 +11,12 @@ use tauri::{Emitter, Manager};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // CLI handling must resolve before the Tauri builder runs: --help,
+    // --version, usage errors, and nonexistent action paths all print to the
+    // terminal and exit without ever creating a window.
+    let startup = cli::startup();
+    let cli_action_active = startup.pending.is_some();
+
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
@@ -36,10 +43,16 @@ pub fn run() {
         .manage(AppState {
             watch: Mutex::new(WatchState { current_file: None, watcher: None }),
             exit_confirmed: AtomicBool::new(false),
-            pending_open: Mutex::new(Vec::new()),
+            // "Open With" on Linux/Windows (and now terminal launches on all
+            // three platforms) passes file paths as CLI arguments; cli::startup
+            // has already collected the ones that exist. The frontend drains
+            // them via take_pending_open after mount. macOS Finder opens arrive
+            // later via RunEvent::Opened below.
+            pending_open: Mutex::new(startup.open),
+            pending_cli: Mutex::new(startup.pending),
             own_write_suppress_until: Arc::new(AtomicU64::new(0)),
         })
-        .setup(|app| {
+        .setup(move |app| {
             // macOS: titleBarStyle Overlay still draws the window title text next
             // to the traffic lights, and setTitle("") doesn't clear it. Hide it at
             // the NSWindow level so only the in-app centered doctitle shows.
@@ -56,19 +69,17 @@ pub fn run() {
                     }
                 }
             }
-            // Linux/Windows: "Open With" passes the file path as a CLI argument.
-        // Buffer it so the frontend can drain via take_pending_open after mount.
-        #[cfg(not(target_os = "macos"))]
-        {
-            let paths: Vec<String> = std::env::args()
-                .skip(1)
-                .filter(|a| !a.starts_with('-') && std::path::Path::new(a).exists())
-                .collect();
-            if !paths.is_empty() {
-                let state = app.state::<AppState>();
-                state.pending_open.lock().unwrap_or_else(|e| e.into_inner()).extend(paths);
+            // The main window is declared visible: false in tauri.conf.json so
+            // CLI actions can run without flashing the editor. Showing it here
+            // (after creation, before the event loop pumps) is flash-free and
+            // identical UX to a config-visible window. Phase B of the CLI work
+            // moves the cli_action_active case's show() into the frontend's
+            // present-entry / check paths; until then show unconditionally so
+            // behaviour is unchanged.
+            let _ = cli_action_active; // Phase B branches on this
+            if let Some(win) = app.get_webview_window("main") {
+                let _ = win.show();
             }
-        }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -101,6 +112,7 @@ pub fn run() {
             commands::fetch_url_text,
             commands::confirm_exit,
             commands::take_pending_open,
+            commands::take_pending_cli,
             commands::export_pdf_native,
         ])
         .build(tauri::generate_context!())
@@ -125,7 +137,16 @@ pub fn run() {
                 .collect();
             if !paths.is_empty() {
                 let state = app_handle.state::<AppState>();
-                state.pending_open.lock().unwrap_or_else(|e| e.into_inner()).extend(paths.iter().cloned());
+                // Dedupe against paths already buffered from argv — a terminal
+                // launch now populates pending_open on macOS too, and the same
+                // file must not open twice if Opened also delivers it.
+                let mut pending = state.pending_open.lock().unwrap_or_else(|e| e.into_inner());
+                for p in &paths {
+                    if !pending.contains(p) {
+                        pending.push(p.clone());
+                    }
+                }
+                drop(pending);
                 let _ = app_handle.emit("open-file", paths);
             }
             return;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,15 +70,15 @@ pub fn run() {
                 }
             }
             // The main window is declared visible: false in tauri.conf.json so
-            // CLI actions can run without flashing the editor. Showing it here
-            // (after creation, before the event loop pumps) is flash-free and
-            // identical UX to a config-visible window. Phase B of the CLI work
-            // moves the cli_action_active case's show() into the frontend's
-            // present-entry / check paths; until then show unconditionally so
-            // behaviour is unchanged.
-            let _ = cli_action_active; // Phase B branches on this
-            if let Some(win) = app.get_webview_window("main") {
-                let _ = win.show();
+            // CLI actions can run without flashing the editor. Normal launches
+            // show it here (after creation, before the event loop pumps —
+            // flash-free, identical UX to a config-visible window). CLI actions
+            // leave it hidden: the frontend shows it when entering presentation,
+            // and a standalone --check never shows it at all.
+            if !cli_action_active {
+                if let Some(win) = app.get_webview_window("main") {
+                    let _ = win.show();
+                }
             }
             Ok(())
         })
@@ -111,6 +111,7 @@ pub fn run() {
             commands::fetch_url_b64,
             commands::fetch_url_text,
             commands::confirm_exit,
+            commands::cli_error_exit,
             commands::take_pending_open,
             commands::take_pending_cli,
             commands::export_pdf_native,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,7 +111,7 @@ pub fn run() {
             commands::fetch_url_b64,
             commands::fetch_url_text,
             commands::confirm_exit,
-            commands::cli_error_exit,
+            commands::cli_exit,
             commands::take_pending_open,
             commands::take_pending_cli,
             commands::export_pdf_native,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,6 +112,8 @@ pub fn run() {
             commands::fetch_url_text,
             commands::confirm_exit,
             commands::cli_exit,
+            commands::cli_stdout,
+            commands::path_exists,
             commands::take_pending_open,
             commands::take_pending_cli,
             commands::export_pdf_native,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,6 +113,7 @@ pub fn run() {
             commands::confirm_exit,
             commands::cli_exit,
             commands::cli_stdout,
+            commands::install_cli_symlink,
             commands::path_exists,
             commands::take_pending_open,
             commands::take_pending_cli,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 860,
         "minWidth": 900,
         "minHeight": 600,
-        "decorations": false
+        "decorations": false,
+        "visible": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,6 +60,10 @@
       "nsis": {
         "installMode": "currentUser",
         "installerHooks": "installer-hooks.nsh"
+      },
+      "wix": {
+        "fragmentPaths": ["wix/path-env.wxs"],
+        "componentRefs": ["KovaPathEnv"]
       }
     },
     "linux": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -9,7 +9,8 @@
         "minWidth": 900,
         "minHeight": 600,
         "titleBarStyle": "Overlay",
-        "trafficLightPosition": { "x": 14, "y": 17 }
+        "trafficLightPosition": { "x": 14, "y": 17 },
+        "visible": false
       }
     ]
   },

--- a/src-tauri/wix/path-env.wxs
+++ b/src-tauri/wix/path-env.wxs
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Appends the install directory to the system PATH so `kova` works from a
+  terminal after an MSI install (docs/plans/kova-cli.md, Phase D). The NSIS
+  installer does the same via installer-hooks.nsh; WiX never runs those
+  hooks, so the MSI needs its own declarative version.
+
+  System="yes" (machine PATH, not per-user) matches the MSI's install scope:
+  Tauri's WiX template installs per-machine under ProgramFiles64Folder.
+  Windows Installer handles the append, repair, and removal-on-uninstall
+  itself (Permanent="no"), so unlike the NSIS side there is no hand-rolled
+  dedupe or excise logic to maintain.
+
+  The RegistryValue exists only as the component KeyPath - an Environment
+  element cannot be one, and every component must have one.
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="KovaPathEnv" Guid="D2626A48-7CD3-429B-89FA-B61EC6EE3A4A" Win64="yes">
+        <Environment Id="KovaPathEnv"
+                     Name="PATH"
+                     Value="[INSTALLDIR]"
+                     Permanent="no"
+                     Part="last"
+                     Action="set"
+                     System="yes" />
+        <RegistryValue Root="HKLM"
+                       Key="Software\Kova\PathEnv"
+                       Name="installed"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+</Wix>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import { parseAspectRatio } from './engine/types';
 import { imageMime } from './engine/export/imageMime';
 import type { Theme } from './engine/theme';
 import { useResolvedSlides } from './hooks/useResolvedSlides';
+import type { PendingCli } from './types/cli';
 
 import './styles/global.css';
 
@@ -82,6 +83,15 @@ function countWords(text: string): number {
 const EMPTY_SLIDES: Slide[] = [];
 const EMPTY_FM: Frontmatter = {};
 
+// take_pending_cli drains once on the Rust side (Option::take), so cache the
+// promise at module level: StrictMode's double-mount and dep-driven effect
+// re-runs all observe the same value instead of the second call's null.
+let pendingCliPromise: Promise<PendingCli | null> | null = null;
+function getPendingCli(): Promise<PendingCli | null> {
+  pendingCliPromise ??= invoke<PendingCli | null>('take_pending_cli').catch(() => null);
+  return pendingCliPromise;
+}
+
 export default function App() {
   const [filePath, setFilePath]           = useState<string | null>(null);
   const [content, setContent]             = useState('');
@@ -92,6 +102,11 @@ export default function App() {
   // Index into visibleSlides (hidden slides skipped) while presenting — kept
   // separate from currentSlideIndex (which indexes the full editor deck).
   const [presentIndex, setPresentIndex]   = useState(0);
+  // Session was started via `kova --present FILE` (docs/plans/kova-cli.md,
+  // Phase B): the editor chrome is never shown, presentation starts as soon as
+  // the deck resolves, and exiting quits the process instead of revealing the
+  // editor. Stays true for the whole session once set.
+  const [coldPresent, setColdPresent]     = useState(false);
   const [settings, setSettings]           = useState<AppSettings>(loadSettings);
   const t = useLocaleTranslator(settings.locale);
   const [showSettings, setShowSettings]   = useState(false);
@@ -507,6 +522,12 @@ export default function App() {
     });
   }, [guardDirty, settings.defaultThemeId]);
 
+  // Cold-start present guards: the load must run once (applyFileContent's
+  // identity changes re-run the drain effect) and presentation must be
+  // entered exactly once (visibleSlides/handlePresentEnter identity changes
+  // re-run the auto-enter effect).
+  const coldLoadStartedRef = useRef(false);
+  const coldEnterFiredRef = useRef(false);
   // Prevents double-exit when the audience window is closed externally while
   // handlePresentExit is already in flight.
   const isExitingRef = useRef(false);
@@ -668,6 +689,29 @@ export default function App() {
     setPresentMode(true);
     await getCurrentWindow().setFullscreen(true).catch(() => {});
   }, [slides, visibleSlides, safeSlideIndex, activeTheme, aspectRatio, docTitle, docDate, settings.presentationMode]);
+
+  // Cold-start present: enter presentation exactly once, as soon as the file
+  // content has been applied (filePath set in the same batch as content).
+  // Slide count is synchronous with content — useResolvedSlides only swaps
+  // media srcs asynchronously — so an empty visibleSlides here is a genuinely
+  // empty deck, not a deck that hasn't resolved yet. The window is hidden
+  // until this point (lib.rs setup skips show() for CLI actions); show it
+  // before entering so monitor detection and fullscreen behave normally.
+  useEffect(() => {
+    if (!coldPresent || coldEnterFiredRef.current || !filePath) return;
+    coldEnterFiredRef.current = true;
+    if (visibleSlides.length === 0) {
+      invoke('cli_error_exit', {
+        message: `'${filePath}' contains no visible slides`,
+        code: 1,
+      }).catch(() => {});
+      return;
+    }
+    (async () => {
+      await getCurrentWindow().show().catch(() => {});
+      await handlePresentEnter(false);
+    })();
+  }, [coldPresent, filePath, visibleSlides, handlePresentEnter]);
 
   // Prevent display sleep while presenting; release on exit.
   // Covers all exit paths (normal, error, external window close).
@@ -834,6 +878,32 @@ export default function App() {
     setMarpLoss(null);
   }, [syncThemeFromContent]);
 
+  // Cold-start present (kova --present FILE): load the file through the same
+  // post-read sequence as a normal open so docDir, theme sync, and the watcher
+  // all populate identically; the auto-enter effect below the present handlers
+  // starts the presentation once the deck is derived. Errors report to the
+  // launching terminal — the window is still hidden here, so a GUI dialog
+  // could be invisible; stderr is the CLI user's surface anyway.
+  useEffect(() => {
+    if (coldLoadStartedRef.current) return;
+    (async () => {
+      const cli = await getPendingCli();
+      if (!cli?.present || coldLoadStartedRef.current) return;
+      coldLoadStartedRef.current = true;
+      setColdPresent(true);
+      try {
+        await invoke('stop_watching').catch(() => {});
+        const text: string = await invoke('read_file', { path: cli.present });
+        await applyFileContent(text, cli.present);
+      } catch {
+        await invoke('cli_error_exit', {
+          message: `cannot read '${cli.present}'`,
+          code: 1,
+        }).catch(() => {});
+      }
+    })();
+  }, [applyFileContent]);
+
   // Startup restore — only when the user has opted in via Settings. Best-effort:
   // a deleted/moved/unreadable file just leaves the app at its normal blank
   // startup state rather than surfacing an error for what is, after all, a
@@ -845,6 +915,12 @@ export default function App() {
     const session = loadLastSession();
     if (!session) return;
     (async () => {
+      // A cold-start present (kova --present) owns this session — restoring
+      // the last file would race the CLI file's load through applyFileContent
+      // and whichever resolves last would win, possibly presenting the wrong
+      // deck. The CLI drain is cached, so this await costs one IPC roundtrip.
+      const cli = await getPendingCli();
+      if (cli?.present) return;
       try {
         const text: string = await invoke('read_file', { path: session.path });
         await applyFileContent(text, session.path);
@@ -865,8 +941,11 @@ export default function App() {
   // when there's no open file (e.g. after File > New) rather than leaving a
   // stale pointer to whatever was open before.
   useEffect(() => {
+    // A presentation-only run (kova --present) must not clobber the editor's
+    // last-session record — the user never opened this file for editing.
+    if (coldPresent) return;
     saveLastSession(filePath ? { path: filePath, slideIndex: safeSlideIndex } : null);
-  }, [filePath, safeSlideIndex]);
+  }, [filePath, safeSlideIndex, coldPresent]);
 
   // Maintain the "Open Recent" list whenever a file becomes the open document.
   useEffect(() => {
@@ -1680,19 +1759,8 @@ export default function App() {
   }, [editMenuOpen]);
 
 
-  return (
-    <I18nProvider locale={settings.locale}>
-    <div className="app">
-      {fileDragOver && !presentMode && !presenterMode && (
-        <div style={{
-          position: 'fixed', inset: 0, zIndex: 5000, pointerEvents: 'none',
-          border: '2px dashed #D94F00', borderRadius: 4,
-          background: 'rgba(217,79,0,0.06)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-        }}>
-          <span style={{ color: '#D94F00', fontSize: 14, fontWeight: 500 }}>{t('app.dropToOpen')}</span>
-        </div>
-      )}
+  const presentationOverlays = (
+    <>
       {presentMode && (
         <PresentationOverlay
           slides={visibleSlides}
@@ -1723,6 +1791,46 @@ export default function App() {
           onExit={handlePresentExit}
         />
       )}
+    </>
+  );
+
+  // Cold-start present (kova --present FILE): the editor chrome never mounts.
+  // Before presentation starts this renders a minimal loading surface (only
+  // visible for the instant between the window being shown and the overlay
+  // mounting); during presentation it renders just the overlays, so nothing
+  // editor-shaped can flash behind them or during exit.
+  if (coldPresent) {
+    return (
+      <I18nProvider locale={settings.locale}>
+        <div className="app">
+          {presentationOverlays}
+          {!presentMode && !presenterMode && (
+            <div style={{
+              height: '100vh',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>
+              <span style={{ opacity: 0.6, fontSize: 14 }}>{t('app.presentLoading')}</span>
+            </div>
+          )}
+        </div>
+      </I18nProvider>
+    );
+  }
+
+  return (
+    <I18nProvider locale={settings.locale}>
+    <div className="app">
+      {fileDragOver && !presentMode && !presenterMode && (
+        <div style={{
+          position: 'fixed', inset: 0, zIndex: 5000, pointerEvents: 'none',
+          border: '2px dashed #D94F00', borderRadius: 4,
+          background: 'rgba(217,79,0,0.06)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <span style={{ color: '#D94F00', fontSize: 14, fontWeight: 500 }}>{t('app.dropToOpen')}</span>
+        </div>
+      )}
+      {presentationOverlays}
       <div className="app-toolbar">
         {/* macOS uses native traffic lights (titleBarStyle: Overlay) + the native
             menu bar, so reserve a draggable strip for the lights and drop the

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { invoke, convertFileSrc } from '@tauri-apps/api/core';
-import { open, save } from '@tauri-apps/plugin-dialog';
+import { open, save, message } from '@tauri-apps/plugin-dialog';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { availableMonitors, currentMonitor, getCurrentWindow } from '@tauri-apps/api/window';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
@@ -1765,6 +1765,19 @@ export default function App() {
     present: () => { void handlePresentEnter(); },
     toggleInspector: () => setShowInspector((v) => !v),
     openSettings: () => setShowSettings(true),
+    installCli: () => {
+      void (async () => {
+        try {
+          const dir = await invoke<string>('install_cli_symlink');
+          await message(t('app.cliInstallSuccess', { dir }), { title: 'Kova' });
+        } catch (e) {
+          await message(t('app.cliInstallFailure', { command: String(e) }), {
+            title: 'Kova',
+            kind: 'error',
+          });
+        }
+      })();
+    },
   };
   const stableMenuHandlers = useRef<MacMenuHandlers>({
     newFile: () => menuHandlersRef.current.newFile(),
@@ -1783,6 +1796,7 @@ export default function App() {
     present: () => menuHandlersRef.current.present(),
     toggleInspector: () => menuHandlersRef.current.toggleInspector(),
     openSettings: () => menuHandlersRef.current.openSettings(),
+    installCli: () => menuHandlersRef.current.installCli(),
   }).current;
 
   useEffect(() => {
@@ -1791,6 +1805,7 @@ export default function App() {
       present: t('macMenu.present'),
       view: t('macMenu.view'),
       toggleInspector: t('macMenu.toggleInspector'),
+      installCli: t('macMenu.installCli'),
       file: t('app.menuFile'),
       edit: t('app.menuEdit'),
       newFile: t('app.menuNew'),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -528,6 +528,11 @@ export default function App() {
   // re-run the auto-enter effect).
   const coldLoadStartedRef = useRef(false);
   const coldEnterFiredRef = useRef(false);
+  // Render-updated mirror of coldPresent for the audience window's
+  // tauri://error and tauri://destroyed once-handlers, whose closures
+  // outlive the render that registered them.
+  const coldPresentRef = useRef(coldPresent);
+  coldPresentRef.current = coldPresent;
   // Prevents double-exit when the audience window is closed externally while
   // handlePresentExit is already in flight.
   const isExitingRef = useRef(false);
@@ -547,6 +552,16 @@ export default function App() {
       const audienceWin = await WebviewWindow.getByLabel('audience');
       if (audienceWin) await audienceWin.close().catch(() => {});
     } catch { /* ignore */ }
+    // Cold-started session (kova --present): exiting the presentation is
+    // exiting the app — there is no editor session to return to. Release the
+    // wake lock explicitly first: cli_exit is a hard process exit, so the
+    // effect that normally releases it on presentMode→false never runs, and
+    // an orphaned macOS caffeinate child would keep the machine awake.
+    if (coldPresent) {
+      await invoke('set_wake_lock', { active: false }).catch(() => {});
+      await invoke('cli_exit', { code: 0 }).catch(() => {});
+      return;
+    }
     setPresentMode(false);
     setPresenterMode(false);
     // Land the editor on whatever slide we exited on (translate visible→full).
@@ -554,7 +569,7 @@ export default function App() {
     if (full >= 0) setCurrentSlideIndex(full);
     await getCurrentWindow().setFullscreen(false).catch(() => {});
     isExitingRef.current = false;
-  }, [slides, visibleSlides, safePresentIndex]);
+  }, [slides, visibleSlides, safePresentIndex, coldPresent]);
 
   const handlePresentEnter = useCallback(async (eOrFromCurrent?: React.MouseEvent | boolean) => {
     if (visibleSlides.length === 0) return;
@@ -655,9 +670,18 @@ export default function App() {
         });
 
         // If window creation fails, clean up the ready listener and reset state.
+        // Cold-started sessions have no editor to fall back to — report and quit.
         audienceWin.once('tauri://error', () => {
           clearTimeout(readyTimeoutId);
           unlistenReady?.();
+          if (coldPresentRef.current) {
+            invoke('set_wake_lock', { active: false }).catch(() => {});
+            invoke('cli_exit', {
+              message: 'failed to create the presentation window',
+              code: 1,
+            }).catch(() => {});
+            return;
+          }
           setPresentMode(false);
           setPresenterMode(false);
           getCurrentWindow().setFullscreen(false).catch(() => {});
@@ -671,6 +695,13 @@ export default function App() {
         audienceWin.once('tauri://destroyed', () => {
           if (isExitingRef.current) return; // normal exit already in progress
           if (presentSessionRef.current !== sessionId) return; // stale session
+          // Cold-started session: the audience window going away ends the
+          // presentation, and ending the presentation ends the app.
+          if (coldPresentRef.current) {
+            invoke('set_wake_lock', { active: false }).catch(() => {});
+            invoke('cli_exit', { code: 0 }).catch(() => {});
+            return;
+          }
           setPresentMode(false);
           setPresenterMode(false);
           getCurrentWindow().setFullscreen(false).catch(() => {});
@@ -701,7 +732,7 @@ export default function App() {
     if (!coldPresent || coldEnterFiredRef.current || !filePath) return;
     coldEnterFiredRef.current = true;
     if (visibleSlides.length === 0) {
-      invoke('cli_error_exit', {
+      invoke('cli_exit', {
         message: `'${filePath}' contains no visible slides`,
         code: 1,
       }).catch(() => {});
@@ -896,7 +927,7 @@ export default function App() {
         const text: string = await invoke('read_file', { path: cli.present });
         await applyFileContent(text, cli.present);
       } catch {
-        await invoke('cli_error_exit', {
+        await invoke('cli_exit', {
           message: `cannot read '${cli.present}'`,
           code: 1,
         }).catch(() => {});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import type { Keybindings } from './engine/keybindings';
 import { I18nProvider, useLocaleTranslator, formatFallbackDate } from './i18n';
 
 import { parseDocument } from './engine/parser/markdownToSlides';
+import { collectDiagnostics, formatCheckReport } from './engine/parser/diagnostics';
 import { extractFrontmatter, patchFrontmatter } from './engine/parser/frontmatter';
 import { parseBgLine, formatBgLine } from './engine/parser/bgImage';
 import { fetchUpdate } from './engine/updater';
@@ -127,6 +128,18 @@ async function resolveCliTheme(arg: CliThemeArg): Promise<Theme | null> {
     }
   } catch { /* fall through to unknown */ }
   return fail(`unknown theme '${arg.name}'`);
+}
+
+// Theme ids --check validates frontmatter `theme:` against — built-ins plus
+// whatever community themes are installed in the config dir.
+async function knownThemeIds(): Promise<string[]> {
+  const ids = BUILT_IN_THEMES.map((t) => t.id);
+  try {
+    const [, entries] = await invoke<[string, Array<[string, string]>]>('load_custom_themes');
+    return [...ids, ...entries.map(([id]) => id)];
+  } catch {
+    return ids;
+  }
 }
 
 export default function App() {
@@ -969,21 +982,45 @@ export default function App() {
     if (coldLoadStartedRef.current) return;
     (async () => {
       const cli = await getPendingCli();
-      if (!cli?.present || coldLoadStartedRef.current) return;
+      if (coldLoadStartedRef.current) return;
+      // --present FILE, or standalone --check FILE (which never shows a window:
+      // the loading branch renders behind a window that lib.rs never shows, and
+      // the process exits from this effect).
+      const target = cli?.present ?? cli?.check_only;
+      if (!cli || !target) return;
       coldLoadStartedRef.current = true;
       setColdPresent(true);
       // Resolve --theme before loading the deck: theme errors are fail-fast
       // (stderr + exit 1) like a missing presentation file, and nothing has
       // rendered yet at this point.
       let cliTheme: Theme | null = null;
-      if (cli.theme) {
+      if (cli.theme && cli.present) {
         cliTheme = await resolveCliTheme(cli.theme);
         if (!cliTheme) return; // reported and exiting
       }
       try {
+        const text: string = await invoke('read_file', { path: target });
+        // --check: validate before anything renders. The report goes to
+        // stdout (it is data; errors about the invocation itself go to
+        // stderr). Standalone check exits either way; as a gate before
+        // --present, errors abort with exit 1 and warnings continue into
+        // the presentation.
+        if (cli.check || cli.check_only) {
+          const diags = await collectDiagnostics(text, {
+            docDir: dirOf(target),
+            themeIds: await knownThemeIds(),
+            fileExists: (p) =>
+              invoke<boolean>('path_exists', { path: p }).then(Boolean).catch(() => false),
+          });
+          const { report, errors } = formatCheckReport(target, diags);
+          await invoke('cli_stdout', { text: report }).catch(() => {});
+          if (cli.check_only || errors > 0) {
+            await invoke('cli_exit', { code: errors > 0 ? 1 : 0 }).catch(() => {});
+            return;
+          }
+        }
         await invoke('stop_watching').catch(() => {});
-        const text: string = await invoke('read_file', { path: cli.present });
-        await applyFileContent(text, cli.present);
+        await applyFileContent(text, target);
         if (cliTheme) {
           // --theme replaces the deck's *base* theme; frontmatter
           // theme_overrides still apply on top. Set overrides explicitly:
@@ -1000,7 +1037,7 @@ export default function App() {
         }
       } catch {
         await invoke('cli_exit', {
-          message: `cannot read '${cli.present}'`,
+          message: `cannot read '${target}'`,
           code: 1,
         }).catch(() => {});
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,7 @@ import { parseAspectRatio } from './engine/types';
 import { imageMime } from './engine/export/imageMime';
 import type { Theme } from './engine/theme';
 import { useResolvedSlides } from './hooks/useResolvedSlides';
-import type { PendingCli } from './types/cli';
+import type { PendingCli, CliThemeArg } from './types/cli';
 
 import './styles/global.css';
 
@@ -90,6 +90,43 @@ let pendingCliPromise: Promise<PendingCli | null> | null = null;
 function getPendingCli(): Promise<PendingCli | null> {
   pendingCliPromise ??= invoke<PendingCli | null>('take_pending_cli').catch(() => null);
   return pendingCliPromise;
+}
+
+// Resolve a --theme argument to a Theme, or report to the terminal and exit 1
+// (returning null while the process shuts down). Named themes check built-ins
+// first, then the installed community themes — loaded directly here rather
+// than through the allThemes state, which may not have populated yet when the
+// cold-start path runs. Path themes get a `cli:`-prefixed id so a file named
+// light.yaml can never collide with (and silently lose to) a built-in id.
+async function resolveCliTheme(arg: CliThemeArg): Promise<Theme | null> {
+  const fail = async (message: string) => {
+    await invoke('cli_exit', { message, code: 1 }).catch(() => {});
+    return null;
+  };
+  if (arg.type === 'path') {
+    let text: string;
+    try {
+      text = await invoke<string>('read_file', { path: arg.path });
+    } catch {
+      return fail(`cannot read theme '${arg.path}'`);
+    }
+    const base = arg.path.replace(/\\/g, '/').split('/').pop() ?? arg.path;
+    const parsed = parseThemeYaml(`cli:${base.replace(/\.ya?ml$/i, '')}`, text);
+    if (!parsed.ok) return fail(`invalid theme '${arg.path}': ${parsed.error}`);
+    return parsed.theme;
+  }
+  const builtIn = BUILT_IN_THEMES.find((t) => t.id === arg.name);
+  if (builtIn) return builtIn;
+  try {
+    const [, entries] = await invoke<[string, Array<[string, string]>]>('load_custom_themes');
+    for (const [id, yaml] of entries) {
+      if (id !== arg.name) continue;
+      const parsed = parseThemeYaml(id, yaml);
+      if (parsed.ok) return parsed.theme;
+      return fail(`invalid theme '${arg.name}': ${parsed.error}`);
+    }
+  } catch { /* fall through to unknown */ }
+  return fail(`unknown theme '${arg.name}'`);
 }
 
 export default function App() {
@@ -386,7 +423,13 @@ export default function App() {
         const results: ThemeParseResult[] = entries.map(([id, yaml]) => parseThemeYaml(id, yaml));
         const custom = results.filter((r): r is Extract<ThemeParseResult, { ok: true }> => r.ok).map((r) => r.theme);
         const errors = results.filter((r): r is Extract<ThemeParseResult, { ok: false }> => !r.ok).map((r) => r.error);
-        setAllThemes(custom.length > 0 ? [...BUILT_IN_THEMES, ...custom] : BUILT_IN_THEMES);
+        setAllThemes(() => {
+          const base = custom.length > 0 ? [...BUILT_IN_THEMES, ...custom] : BUILT_IN_THEMES;
+          // Keep a --theme=path/to.yaml theme alive: it lives outside the
+          // config dir, so rebuilding the list from disk would drop it.
+          const cliTheme = cliThemeRef.current;
+          return cliTheme && !base.some((t) => t.id === cliTheme.id) ? [...base, cliTheme] : base;
+        });
         if (errors.length > 0) setWarnMessage(`Theme parse error:\n${errors.join('\n')}`);
       })
       .catch(() => {});
@@ -468,7 +511,9 @@ export default function App() {
         setShowExternalChangeDialog(true);
       } else {
         // No unsaved edits — reload silently then surface a dismissable banner.
-        syncThemeFromContent(newContent);
+        // Skip the frontmatter theme re-sync when a CLI --theme override is
+        // active: it supersedes the deck's theme for the whole session.
+        if (!cliThemeRef.current) syncThemeFromContent(newContent);
         setContent(newContent);
         setIsDirty(false);
         diskContentRef.current = newContent;
@@ -528,6 +573,11 @@ export default function App() {
   // re-run the auto-enter effect).
   const coldLoadStartedRef = useRef(false);
   const coldEnterFiredRef = useRef(false);
+  // Theme resolved from --theme, if any. Consulted by reloadCustomThemes (so
+  // a later community-theme reload doesn't drop it from allThemes) and by the
+  // watcher's silent-reload path (an external file edit re-syncing the theme
+  // from frontmatter must not clobber the CLI override mid-presentation).
+  const cliThemeRef = useRef<Theme | null>(null);
   // Render-updated mirror of coldPresent for the audience window's
   // tauri://error and tauri://destroyed once-handlers, whose closures
   // outlive the render that registered them.
@@ -922,10 +972,32 @@ export default function App() {
       if (!cli?.present || coldLoadStartedRef.current) return;
       coldLoadStartedRef.current = true;
       setColdPresent(true);
+      // Resolve --theme before loading the deck: theme errors are fail-fast
+      // (stderr + exit 1) like a missing presentation file, and nothing has
+      // rendered yet at this point.
+      let cliTheme: Theme | null = null;
+      if (cli.theme) {
+        cliTheme = await resolveCliTheme(cli.theme);
+        if (!cliTheme) return; // reported and exiting
+      }
       try {
         await invoke('stop_watching').catch(() => {});
         const text: string = await invoke('read_file', { path: cli.present });
         await applyFileContent(text, cli.present);
+        if (cliTheme) {
+          // --theme replaces the deck's *base* theme; frontmatter
+          // theme_overrides still apply on top. Set overrides explicitly:
+          // syncThemeFromContent (inside applyFileContent) skips them when
+          // the frontmatter theme is missing from the library, and that
+          // missing-theme state is irrelevant under a CLI override.
+          cliThemeRef.current = cliTheme;
+          const id = cliTheme.id;
+          setAllThemes((prev) => prev.some((t) => t.id === id) ? prev : [...prev, cliTheme]);
+          setActiveThemeId(id);
+          setMissingThemeId(null);
+          const { frontmatter: fm } = extractFrontmatter(text);
+          setThemeOverrides(sanitiseThemeOverrides(fm.theme_overrides as Record<string, unknown> ?? {}));
+        }
       } catch {
         await invoke('cli_exit', {
           message: `cannot read '${cli.present}'`,

--- a/src/engine/__tests__/diagnostics.test.ts
+++ b/src/engine/__tests__/diagnostics.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { collectDiagnostics, formatCheckReport, type CheckContext } from '../parser/diagnostics';
+
+const ctx = (overrides: Partial<CheckContext> = {}): CheckContext => ({
+  docDir: '/deck',
+  themeIds: ['light', 'dark', 'firefly'],
+  fileExists: async () => true,
+  ...overrides,
+});
+
+const CLEAN = `---
+title: Test Deck
+theme: dark
+---
+
+# Title Slide
+
+---
+
+## Second
+
+- point
+`;
+
+describe('collectDiagnostics', () => {
+  it('reports nothing for a clean document', async () => {
+    const diags = await collectDiagnostics(CLEAN, ctx());
+    expect(diags).toEqual([]);
+  });
+
+  it('reports frontmatter YAML parse errors with a document line', async () => {
+    const doc = `---\ntitle: ok\nbad: [unclosed\n---\n\n# Slide\n`;
+    const diags = await collectDiagnostics(doc, ctx());
+    const yamlErr = diags.find((d) => d.message.startsWith('frontmatter YAML:'));
+    expect(yamlErr).toBeDefined();
+    expect(yamlErr!.severity).toBe('error');
+    expect(yamlErr!.line).toBeGreaterThanOrEqual(2);
+  });
+
+  it('warns on unknown frontmatter keys with their line', async () => {
+    const doc = `---\ntitle: ok\npaginate: true\n---\n\n# Slide\n`;
+    const diags = await collectDiagnostics(doc, ctx());
+    expect(diags).toEqual([
+      { line: 3, severity: 'warning', message: "unknown frontmatter key 'paginate'" },
+    ]);
+  });
+
+  it('warns on an unknown theme, errors nothing else', async () => {
+    const doc = `---\ntheme: nonexistent\n---\n\n# Slide\n`;
+    const diags = await collectDiagnostics(doc, ctx());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe('warning');
+    expect(diags[0].message).toContain("unknown theme 'nonexistent'");
+    expect(diags[0].line).toBe(2);
+  });
+
+  it('accepts a known community theme id', async () => {
+    const doc = `---\ntheme: firefly\n---\n\n# Slide\n`;
+    expect(await collectDiagnostics(doc, ctx())).toEqual([]);
+  });
+
+  it('errors on unknown layout names with their line', async () => {
+    const doc = `# Slide\n\n<!-- layout: sideways -->\n`;
+    const diags = await collectDiagnostics(doc, ctx());
+    expect(diags).toEqual([
+      { line: 3, severity: 'error', message: "unknown layout 'sideways'" },
+    ]);
+  });
+
+  it('accepts every real layout name', async () => {
+    const doc = `# Slide\n\n<!-- layout: three-column -->\n`;
+    expect(await collectDiagnostics(doc, ctx())).toEqual([]);
+  });
+
+  it('errors on unknown bang-directives', async () => {
+    const doc = `# Slide\n\n!sparkle[hello](5)\n`;
+    const diags = await collectDiagnostics(doc, ctx());
+    expect(diags).toEqual([
+      { line: 3, severity: 'error', message: "unknown directive '!sparkle'" },
+    ]);
+  });
+
+  it('accepts known directives and reserved words', async () => {
+    const doc = `# Slide\n\n!progress[Done](80)\n\n!toc\n\n!ref[Some citation]\n`;
+    expect(await collectDiagnostics(doc, ctx())).toEqual([]);
+  });
+
+  it('ignores directive-like lines inside fenced code blocks', async () => {
+    const doc = '# Slide\n\n```sh\n!notreal[x](1)\n<!-- layout: bogus -->\n```\n';
+    expect(await collectDiagnostics(doc, ctx())).toEqual([]);
+  });
+
+  it('does not mistake image syntax for a directive', async () => {
+    const doc = `# Slide\n\n![alt text](pic.png)\n`;
+    expect(await collectDiagnostics(doc, ctx())).toEqual([]);
+  });
+
+  it('errors on a deck with no visible slides', async () => {
+    const doc = `# Only\n<!-- hidden -->\n\ncontent\n`;
+    const diags = await collectDiagnostics(doc, ctx());
+    expect(diags).toEqual([
+      { line: 0, severity: 'error', message: 'document contains no visible slides' },
+    ]);
+  });
+
+  it('errors on missing local media with the source line', async () => {
+    const doc = `# Slide\n\n![alt](missing.png)\n`;
+    const diags = await collectDiagnostics(doc, ctx({ fileExists: async () => false }));
+    expect(diags).toHaveLength(1);
+    expect(diags[0]).toMatchObject({
+      severity: 'error',
+      message: "media file not found: 'missing.png'",
+    });
+    expect(diags[0].line).toBe(3);
+  });
+
+  it('skips media on hidden slides and remote URLs', async () => {
+    const doc = [
+      '# Visible',
+      '',
+      '![ok](https://example.com/pic.png)',
+      '',
+      '---',
+      '',
+      '# Hidden',
+      '<!-- hidden -->',
+      '',
+      '![gone](nope.png)',
+      '',
+    ].join('\n');
+    const diags = await collectDiagnostics(doc, ctx({ fileExists: async () => false }));
+    expect(diags).toEqual([]);
+  });
+
+  it('dedupes a missing file referenced on multiple slides', async () => {
+    const doc = `# One\n\n![a](shared.png)\n\n---\n\n# Two\n\n![b](shared.png)\n`;
+    const diags = await collectDiagnostics(doc, ctx({ fileExists: async () => false }));
+    expect(diags.filter((d) => d.message.includes('shared.png'))).toHaveLength(1);
+  });
+});
+
+describe('formatCheckReport', () => {
+  it('formats sorted lines with a summary', () => {
+    const { report, errors, warnings } = formatCheckReport('/deck/talk.md', [
+      { line: 9, severity: 'error', message: 'b' },
+      { line: 2, severity: 'warning', message: 'a' },
+    ]);
+    expect(report).toBe(
+      '/deck/talk.md:2: warning: a\n/deck/talk.md:9: error: b\n1 error(s), 1 warning(s)',
+    );
+    expect(errors).toBe(1);
+    expect(warnings).toBe(1);
+  });
+
+  it('reports a clean summary for no diagnostics', () => {
+    const { report, errors, warnings } = formatCheckReport('t.md', []);
+    expect(report).toBe('0 error(s), 0 warning(s)');
+    expect(errors).toBe(0);
+    expect(warnings).toBe(0);
+  });
+});

--- a/src/engine/parser/diagnostics.ts
+++ b/src/engine/parser/diagnostics.ts
@@ -1,0 +1,195 @@
+import yaml from 'js-yaml';
+import { parseDocument } from './markdownToSlides';
+import { localPathFromMediaSrc } from '../resolveMediaPath';
+import type { LayoutType, ListItem, Slide } from '../types';
+
+// Validation pass behind `kova --check` (docs/plans/kova-cli.md, Phase F).
+// Deliberately not a general linter: every diagnostic here maps to something
+// that visibly breaks a presentation or silently changes it. The parser
+// itself stays lenient — this is a separate, opt-in pass over the same input.
+
+export type DiagnosticSeverity = 'error' | 'warning';
+
+export interface Diagnostic {
+  /** 1-based line in the source document; 0 when no single line applies. */
+  line: number;
+  severity: DiagnosticSeverity;
+  message: string;
+}
+
+export interface CheckContext {
+  /** Directory of the document, for resolving relative media paths. */
+  docDir: string;
+  /** Known theme ids (built-in + installed community themes). */
+  themeIds: string[];
+  /** Existence probe for local media paths (IPC-backed in the app, mocked in tests). */
+  fileExists: (path: string) => Promise<boolean>;
+}
+
+const KNOWN_FRONTMATTER_KEYS = new Set([
+  'title', 'author', 'theme', 'theme_overrides', 'aspect_ratio', 'date', 'logo', 'footer',
+]);
+
+// Record keyed by LayoutType so the compiler forces this to stay exhaustive
+// when a layout is added to ../types.ts.
+const LAYOUT_SET: Record<LayoutType, true> = {
+  'title': true, 'section': true, 'title-content': true, 'title-image': true,
+  'split': true, 'full-bleed': true, 'quote': true, 'two-column': true,
+  'three-column': true, 'bsp': true, 'grid': true, 'media': true,
+  'code': true, 'math': true, 'blank': true,
+};
+const KNOWN_LAYOUTS = new Set(Object.keys(LAYOUT_SET));
+
+// Keep in sync with the !directive regexes in markdownToSlides.ts (including
+// its RESERVED_RE words) and LET_RE in ../sheet/constants.ts.
+const KNOWN_DIRECTIVES = new Set([
+  'youtube', 'video', 'poll', 'progress', 'caption', 'ref', 'toc', 'sheet', 'let',
+  'include', 'fmt', 'code',
+]);
+
+// Must match extractFrontmatter's block detection (frontmatter.ts).
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/;
+
+const LAYOUT_COMMENT_RE = /<!--\s*layout:\s*(\S+)\s*-->/;
+// A bang-directive word; deliberately does not match image syntax `![alt](…)`.
+const DIRECTIVE_RE = /^!([a-zA-Z][a-zA-Z0-9]*)/;
+const FENCE_RE = /^\s*(```|~~~)/;
+
+/** 1-based line of the first occurrence of `needle`; 0 if not found. */
+function lineOf(content: string, needle: string): number {
+  const idx = content.indexOf(needle);
+  return idx < 0 ? 0 : content.slice(0, idx).split('\n').length;
+}
+
+function collectHtmlSrcs(html: string, out: string[]): void {
+  for (const match of html.matchAll(/src="([^"]*)"/g)) out.push(match[1]);
+}
+
+function collectItemSrcs(item: ListItem, out: string[]): void {
+  collectHtmlSrcs(item.html, out);
+  item.children.forEach((c) => collectItemSrcs(c, out));
+}
+
+/** All raw media srcs referenced by a slide, in source order. */
+function collectSlideSrcs(slide: Slide): string[] {
+  const out: string[] = [];
+  if (slide.backgroundImage) out.push(slide.backgroundImage.src);
+  for (const el of slide.elements) {
+    if (el.type === 'image' || el.type === 'video') out.push(el.src);
+    else if (el.type === 'paragraph') collectHtmlSrcs(el.html, out);
+    else if (el.type === 'list') el.items.forEach((i) => collectItemSrcs(i, out));
+  }
+  return out;
+}
+
+export async function collectDiagnostics(content: string, ctx: CheckContext): Promise<Diagnostic[]> {
+  const diags: Diagnostic[] = [];
+
+  // Frontmatter YAML errors — extractFrontmatter swallows these (parse failure
+  // falls back to an empty frontmatter), so re-parse here to surface them.
+  const fmMatch = content.match(FRONTMATTER_RE);
+  let fm: Record<string, unknown> = {};
+  if (fmMatch) {
+    try {
+      const parsed = yaml.load(fmMatch[1], { schema: yaml.CORE_SCHEMA });
+      if (parsed && typeof parsed === 'object') fm = parsed as Record<string, unknown>;
+    } catch (e) {
+      const mark = (e as { mark?: { line?: number } }).mark;
+      // mark.line is 0-based within the YAML block; document line 1 is `---`.
+      const line = mark?.line != null ? mark.line + 2 : 0;
+      const firstLine = e instanceof Error ? e.message.split('\n')[0] : String(e);
+      diags.push({ line, severity: 'error', message: `frontmatter YAML: ${firstLine}` });
+    }
+
+    const fmLines = fmMatch[1].split(/\r?\n/);
+    for (const key of Object.keys(fm)) {
+      if (KNOWN_FRONTMATTER_KEYS.has(key)) continue;
+      const i = fmLines.findIndex((l) => l.startsWith(`${key}:`));
+      diags.push({
+        line: i >= 0 ? i + 2 : 0,
+        severity: 'warning',
+        message: `unknown frontmatter key '${key}'`,
+      });
+    }
+
+    if (typeof fm.theme === 'string' && !ctx.themeIds.includes(fm.theme)) {
+      const i = fmLines.findIndex((l) => l.startsWith('theme:'));
+      diags.push({
+        line: i >= 0 ? i + 2 : 0,
+        severity: 'warning',
+        message: `unknown theme '${fm.theme}' (Kova will fall back to the default theme)`,
+      });
+    }
+  }
+
+  // Line scan: unknown layout names and unknown bang-directives, skipping
+  // fenced code blocks (a code sample containing `!something` is not a
+  // directive; mirrors the fence handling in sheet/constants.ts).
+  let inFence = false;
+  content.split('\n').forEach((rawLine, i) => {
+    const line = rawLine.trimEnd();
+    if (FENCE_RE.test(line)) { inFence = !inFence; return; }
+    if (inFence) return;
+
+    const layout = line.match(LAYOUT_COMMENT_RE);
+    if (layout && !KNOWN_LAYOUTS.has(layout[1])) {
+      diags.push({ line: i + 1, severity: 'error', message: `unknown layout '${layout[1]}'` });
+    }
+
+    const directive = line.trimStart().match(DIRECTIVE_RE);
+    if (directive && !KNOWN_DIRECTIVES.has(directive[1])) {
+      diags.push({ line: i + 1, severity: 'error', message: `unknown directive '!${directive[1]}'` });
+    }
+  });
+
+  // Parse the document. The parser is lenient by design; an outright throw is
+  // itself a diagnostic rather than a crash of the check.
+  let slides: Slide[] = [];
+  try {
+    slides = parseDocument(content).slides;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    diags.push({ line: 0, severity: 'error', message: `failed to parse document: ${msg}` });
+    return diags;
+  }
+
+  const visible = slides.filter((s) => !s.hidden);
+  if (visible.length === 0) {
+    diags.push({ line: 0, severity: 'error', message: 'document contains no visible slides' });
+  }
+
+  // Local media existence — hidden slides are skipped (they don't render);
+  // remote/data URLs are skipped (existence is not checkable here). Dedupe by
+  // resolved path so one missing file used on five slides reports once.
+  const seen = new Set<string>();
+  for (const slide of visible) {
+    for (const src of collectSlideSrcs(slide)) {
+      const local = localPathFromMediaSrc(src, ctx.docDir);
+      if (!local || seen.has(local)) continue;
+      seen.add(local);
+      if (!(await ctx.fileExists(local))) {
+        diags.push({
+          line: lineOf(content, src),
+          severity: 'error',
+          message: `media file not found: '${src}'`,
+        });
+      }
+    }
+  }
+
+  return diags;
+}
+
+/** Terminal report: one `FILE:LINE: severity: message` per line, sorted by
+ *  line, with the `N error(s), M warning(s)` summary last. */
+export function formatCheckReport(
+  file: string,
+  diags: Diagnostic[],
+): { report: string; errors: number; warnings: number } {
+  const sorted = [...diags].sort((a, b) => a.line - b.line);
+  const errors = diags.filter((d) => d.severity === 'error').length;
+  const warnings = diags.length - errors;
+  const lines = sorted.map((d) => `${file}:${d.line}: ${d.severity}: ${d.message}`);
+  lines.push(`${errors} error(s), ${warnings} warning(s)`);
+  return { report: lines.join('\n'), errors, warnings };
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -259,6 +259,8 @@ const en = {
     connecting: 'Connecting…',
     dropToOpen: 'Drop to open',
     presentLoading: 'Preparing presentation…',
+    cliInstallSuccess: "The 'kova' command was installed to {{dir}}. Newly opened terminals can now run kova.",
+    cliInstallFailure: "Couldn't install the 'kova' command automatically. Run this in a terminal instead:\n\n{{command}}",
     menuFile: 'File',
     menuEdit: 'Edit',
     menuNew: 'New',
@@ -337,6 +339,7 @@ const en = {
     present: 'Present',
     view: 'View',
     toggleInspector: 'Toggle Inspector',
+    installCli: "Install 'kova' Command in PATH",
   },
   settings: {
     windowTitle: 'Settings',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -258,6 +258,7 @@ const en = {
   app: {
     connecting: 'Connecting…',
     dropToOpen: 'Drop to open',
+    presentLoading: 'Preparing presentation…',
     menuFile: 'File',
     menuEdit: 'Edit',
     menuNew: 'New',

--- a/src/macMenu.ts
+++ b/src/macMenu.ts
@@ -27,12 +27,14 @@ export interface MacMenuHandlers {
   present: () => void;
   toggleInspector: () => void;
   openSettings: () => void;
+  installCli: () => void;
 }
 
 export interface MacMenuLabels {
   present: string;
   view: string;
   toggleInspector: string;
+  installCli: string;
   file: string;
   edit: string;
   newFile: string;
@@ -72,6 +74,7 @@ export async function buildMacMenu(h: MacMenuHandlers, recents: string[], labels
           { item: { About: { name: 'Kova', version } } },
           { item: 'Separator' },
           { text: 'Settings…', accelerator: 'CmdOrCtrl+,', action: () => h.openSettings() },
+          { text: labels.installCli, action: () => h.installCli() },
           { item: 'Separator' },
           { item: 'Services' },
           { item: 'Separator' },

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,0 +1,17 @@
+// Mirrors PendingCli / ThemeArg in src-tauri/src/cli.rs (serde-serialised,
+// drained once via the take_pending_cli command). Keep the two in sync.
+
+export type CliThemeArg =
+  | { type: 'named'; name: string }
+  | { type: 'path'; path: string };
+
+export interface PendingCli {
+  /** Canonicalised absolute path to present (`kova --present FILE`). */
+  present: string | null;
+  /** `--theme` override; applied in place of the deck's frontmatter theme. */
+  theme: CliThemeArg | null;
+  /** `--check` given as a modifier: validate before running the action. */
+  check: boolean;
+  /** Canonicalised absolute path for standalone `kova --check FILE`. */
+  check_only: string | null;
+}


### PR DESCRIPTION
## Summary

Implements the CLI portion of the development roadmap, following @a1880's suggestion on batch processing from the command line. After a standard install, Kova can be driven from a terminal on all three platforms:

```
kova --present FILE                        launch straight into presentation mode
kova --theme=NAME|PATH --present FILE      override the deck's theme for the run
kova --check FILE                          validate syntax headlessly, exit 0/1
kova --check --theme=dark --present FILE   modifiers compose with the action
kova --help / --version
```

`--import` and `--export` parse fully but exit 2 with "not available in this version" so the grammar is stable and scripts fail loudly; their implementations are the next tranche of work.

## How it works

1. A pure argument parser (`src-tauri/src/cli.rs`, unit tested) runs before the Tauri builder. Help, version, usage errors, and nonexistent paths resolve in the terminal without a window ever being created.
2. The main window is now declared `visible: false` and shown explicitly: normal launches show it in setup (flash-free, identical UX to before), CLI actions keep it hidden until presentation starts, and a standalone `--check` never shows it at all.
3. Cold-start presenting loads the file through the same code path as a normal open and enters via the same logic as the Present button, monitor detection and single/dual/mirror modes included. Exiting a cold-started presentation quits the process, releasing the wake lock explicitly first (an orphaned macOS `caffeinate` child would otherwise keep the machine awake).
4. `--check` is a new opt-in diagnostics pass (`src/engine/parser/diagnostics.ts`); the parser itself stays lenient. It reports frontmatter YAML errors, unknown keys/themes (warnings), unknown layouts and directives, missing local media, and empty decks, as `FILE:LINE: severity: message` lines with a summary, designed for CI use.
5. PATH registration: the NSIS installer appends the per-user PATH via installer hooks, the MSI does the same for the system PATH via a WiX fragment (it installs per-machine), and macOS gets an app-menu action that symlinks the binary into `/opt/homebrew/bin` or `/usr/local/bin`, never clobbering a `kova` that is not ours.

## Verification

- Linux: developed and verified throughout (all flag paths, exit codes, error cases; the error paths are fully headless and were exercised end to end).
- Windows: NSIS `-setup.exe` and MSI both verified on a VM: install, `kova --version` from a fresh terminal, present, and uninstall removing the PATH entry.
- macOS: verified on hardware: menu install action, terminal argument parsing (new ground for macOS, which previously ignored argv entirely), cold present and clean exit.
- 613 vitest tests (17 new for diagnostics) and 38 Rust tests (27 new for the parser) pass; test builds of the full release pipeline ran green on all three platforms.

## Notes for review

1. The `!a.starts_with('-')` argv scan this replaces would have opened `--present`'s file argument in the editor; parsing is now a single pass, active on macOS too, with the `RunEvent::Opened` handler deduping against argv.
2. `app.exit(code)` does not propagate an exit code through the run loop (process ends 0), so CLI exits use `std::process::exit` after explicit cleanup.
3. Windows terminal output requires `AttachConsole(ATTACH_PARENT_PROCESS)`; release builds use the GUI subsystem.
4. Release-notes suggestion when this ships: credit @a1880 for the batch-processing suggestion.