### PR TITLE
feat(cli): --import marp|pptx|url and --export pptx|pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,14 @@ Kova turns plain Markdown into polished slides — with live preview, multiple l
 |---|---|
 | **macOS** (Apple Silicon + Intel) | [**Download .dmg**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_macOS.dmg) |
 | **Windows 10/11** | [**Download .msi**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Windows.msi) · [Setup .exe](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Windows_setup.exe) |
-| **Linux (Debian/Ubuntu)** | [**.deb package**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Linux.deb) · [or via package manager](#linux-package-managers) |
-| **Linux (Fedora/RHEL/openSUSE)** | [**.rpm package**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Linux.rpm) · [or via package manager](#linux-package-managers) |
-| **Linux (Arch)** | [Install via AUR](#linux-package-managers) |
-| **Linux (AppImage)** | [**.AppImage**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Linux.AppImage) |
-| **Linux (Flatpak)** | [Install via Flatpak](#linux-package-managers) |
+| **Linux** | [See install options ↓](#linux) |
 
-## Linux package managers
+## Linux
 
-> **AppImage note** — Bundled graphics libs are stripped for compatibility with Arch/Fedora/etc., and the AppImage is signed so in-app auto-update works. See [issue #3](https://github.com/KovaMD/Kova/issues/3) for background.
+Debian/Ubuntu and Fedora/RHEL/openSUSE users should install from the repo below — it keeps Kova updated automatically. Arch, Nix, and Flatpak have native options too, or grab the self-updating AppImage if you'd rather not add a repo.
 
-**Debian / Ubuntu**
+<details>
+<summary><strong>Debian / Ubuntu</strong> (recommended)</summary>
 
 ```bash
 sudo curl -fsSL https://deb.kova.md/key.gpg \
@@ -54,7 +51,10 @@ sudo apt update && sudo apt install kova
 
 Debian 13+ — use the [DEB822 source format](https://wiki.kova.md/install/linux/).
 
-**Fedora / RHEL / openSUSE**
+</details>
+
+<details>
+<summary><strong>Fedora / RHEL / openSUSE</strong> (recommended)</summary>
 
 ```bash
 sudo rpm --import https://rpm.kova.md/key.gpg
@@ -63,7 +63,10 @@ sudo curl -o /etc/yum.repos.d/kova.repo \
 sudo dnf install kova   # openSUSE: zypper install kova
 ```
 
-**Nix (flakes)**
+</details>
+
+<details>
+<summary><strong>Nix (flakes)</strong></summary>
 
 ```bash
 nix run github:KovaMD/Kova          # run without installing
@@ -72,13 +75,19 @@ nix profile install github:KovaMD/Kova   # install into your profile
 
 Or add `github:KovaMD/Kova` as a flake input and use `packages.<system>.default`.
 
-**Arch (AUR)**
+</details>
+
+<details>
+<summary><strong>Arch (AUR)</strong></summary>
 
 ```bash
 yay -S kova-bin   # or: paru -S kova-bin
 ```
 
-**Flatpak**
+</details>
+
+<details>
+<summary><strong>Flatpak</strong></summary>
 
 Flathub's current policy excludes LLM-assisted apps, so Kova ships from a self-hosted Flatpak repo:
 
@@ -96,6 +105,24 @@ curl -fsSL -o packaging/flatpak/kova.deb \
 flatpak-builder --user --install --force-clean build packaging/flatpak/md.kova.app.yml
 flatpak run md.kova.app
 ```
+
+</details>
+
+<details>
+<summary><strong>AppImage</strong></summary>
+
+Bundled graphics libs are stripped for compatibility with Arch/Fedora/etc., and the AppImage is signed so in-app auto-update works. See [issue #3](https://github.com/KovaMD/Kova/issues/3) for background.
+
+```bash
+chmod +x Kova_Linux.AppImage
+./Kova_Linux.AppImage
+```
+
+[**Download .AppImage**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Linux.AppImage)
+
+</details>
+
+Prefer a plain package file over adding a repo? Raw `.deb` and `.rpm` builds are attached to every [release](https://github.com/KovaMD/Kova/releases/latest) — just note that manual installs like these won't get automatic updates.
 
 ## Building from source
 
@@ -130,6 +157,10 @@ Custom themes follow the same base path, under a `themes/` subfolder. Full refer
 **Theme library** — open the Inspector, expand **Theme**, and click **More Themes…** to browse and install community themes from the [KovaMD/Themes](https://github.com/KovaMD/Themes) repository. Each download is verified against a SHA-256 checksum. Installed themes appear in the picker immediately.
 
 **Custom themes** — place YAML theme files in the `themes/` subfolder of your config directory (see Keybindings above for platform paths). They appear in the Inspector alongside built-in themes. See the [Themes](https://wiki.kova.md/themes/) wiki page for the full YAML format.
+
+## Support
+
+Kova is free and community funded. If you'd like to support development, you can donate via [Open Collective](https://opencollective.com/kovamd).
 
 ## License
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2031,6 +2031,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
+ "url",
  "webkit2gtk",
  "webview2-com",
  "windows",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,10 @@ notify = "6"
 base64 = "0.22"
 dirs = "5"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+# Already resolved transitively via reqwest — named directly so net_guard.rs
+# can match on url::Host (Ipv4/Ipv6 variants) rather than round-tripping
+# through host_str()'s bracketed IPv6 string form.
+url = "2"
 sha2 = "0.10"
 tauri-plugin-window-state = "2.4.1"
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -2,10 +2,10 @@
 //!
 //! Grammar: at most one action per invocation (`--present`, `--import`,
 //! `--export`, or standalone `--check FILE`) plus modifiers (`--theme`,
-//! `--check`) that combine with an action in any order. `--import` and
-//! `--export` parse fully but are rejected as "not available in this
-//! version" until the export engine work lands, so the grammar is stable
-//! and scripts fail loudly rather than misparsing.
+//! `--check`) that combine with an action in any order. `--export` parses
+//! fully but is rejected as "not available in this version" until the
+//! export engine work lands, so the grammar stays stable and scripts fail
+//! loudly rather than misparsing.
 //!
 //! `parse_cli_args` is pure (no filesystem, no exit) so the grammar is unit
 //! testable; `startup` wraps it with the process-level concerns: printing,
@@ -31,6 +31,21 @@ pub struct PendingCli {
     pub theme: Option<ThemeArg>,
     pub check: bool,
     pub check_only: Option<String>,
+    pub import: Option<PendingImport>,
+}
+
+/// `--import <format> <input> <output>`, resolved for the frontend. `input`
+/// is a canonicalised existing path for `marp`/`pptx`, or the raw URL
+/// unchanged for `url` — validating a URL string against the filesystem
+/// would be nonsensical, and the fetch step reports a bad URL naturally.
+/// `output` is made absolute (so the reported path is unambiguous
+/// regardless of the shell's cwd) but is not required to exist yet — it's
+/// the file about to be created.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PendingImport {
+    pub format: ImportFormat,
+    pub input: String,
+    pub output: String,
 }
 
 #[derive(Debug, PartialEq)]
@@ -51,8 +66,8 @@ pub struct RunArgs {
     pub open: Vec<String>,
 }
 
-// Import/Export are parsed for grammar stability but rejected until Track 2
-// implements them, so their payload fields are not read yet.
+// Export is parsed for grammar stability but rejected until Track 2
+// implements it, so its payload fields are not read yet.
 #[allow(dead_code)]
 #[derive(Debug, PartialEq)]
 pub enum Action {
@@ -62,8 +77,10 @@ pub enum Action {
     CheckOnly(String),
 }
 
-#[allow(dead_code)]
-#[derive(Debug, PartialEq)]
+/// Serialises as a bare lowercase string ("marp"/"pptx"/"url") — matching
+/// the CLI keywords directly, no adjacent tagging needed for a fieldless enum.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ImportFormat {
     Marp,
     Pptx,
@@ -98,7 +115,7 @@ Other:
   -h, --help            show this help
   --version             show version
 
---import and --export are not available in this version.
+--export is not available in this version.
 ";
 
 pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
@@ -234,14 +251,8 @@ pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
         if action.is_none() {
             return CliArgs::Error("--theme requires --present, --import, or --export".into());
         }
-        match action {
-            Some(Action::Import { .. }) => {
-                return CliArgs::Error("--import is not available in this version".into())
-            }
-            Some(Action::Export { .. }) => {
-                return CliArgs::Error("--export is not available in this version".into())
-            }
-            _ => {}
+        if matches!(action, Some(Action::Export { .. })) {
+            return CliArgs::Error("--export is not available in this version".into());
         }
         CliArgs::Run(RunArgs { action, theme, check, open: Vec::new() })
     } else {
@@ -340,8 +351,19 @@ fn resolve(run: RunArgs) -> Startup {
         Some(Action::CheckOnly(path)) => {
             pending.check_only = Some(canonicalise_or_exit(&path, "cannot open"));
         }
+        Some(Action::Import { format, input, output }) => {
+            let input = match format {
+                // A URL isn't a filesystem path — canonicalising it would
+                // always fail. The fetch step reports a bad URL naturally.
+                ImportFormat::Url => input,
+                ImportFormat::Marp | ImportFormat::Pptx => {
+                    canonicalise_or_exit(&input, "cannot open")
+                }
+            };
+            pending.import = Some(PendingImport { format, input, output: absolutize(&output) });
+        }
         // Rejected with "not available" during parse.
-        Some(Action::Import { .. }) | Some(Action::Export { .. }) => unreachable!(),
+        Some(Action::Export { .. }) => unreachable!(),
         None => {}
     }
     pending.theme = run.theme.map(|theme| match theme {
@@ -351,7 +373,8 @@ fn resolve(run: RunArgs) -> Startup {
         named => named,
     });
 
-    let cli_active = pending.present.is_some() || pending.check_only.is_some();
+    let cli_active =
+        pending.present.is_some() || pending.check_only.is_some() || pending.import.is_some();
     // Editor launch keeps the pre-CLI behaviour: arguments that don't exist
     // on disk are silently ignored rather than failing the launch.
     let open = run
@@ -360,6 +383,23 @@ fn resolve(run: RunArgs) -> Startup {
         .filter(|p| std::path::Path::new(p).exists())
         .collect();
     Startup { pending: if cli_active { Some(pending) } else { None }, open }
+}
+
+/// Resolves a not-necessarily-existing path to absolute, for the output side
+/// of `--import`/`--export`. Unlike `canonicalise_or_exit`, this never fails
+/// or requires the path to exist yet — it's the file about to be written.
+/// Relative paths join onto the shell's cwd; already-absolute paths pass
+/// through unchanged. Does not resolve symlinks or `..` segments (`canonicalize`
+/// would, but requires existence) — the OS handles those fine at write time.
+fn absolutize(path: &str) -> String {
+    let p = std::path::Path::new(path);
+    if p.is_absolute() {
+        return p.to_string_lossy().into_owned();
+    }
+    match std::env::current_dir() {
+        Ok(cwd) => cwd.join(p).to_string_lossy().into_owned(),
+        Err(_) => path.to_string(),
+    }
 }
 
 fn canonicalise_or_exit(path: &str, verb: &str) -> String {
@@ -481,10 +521,37 @@ mod tests {
     // -- import / export ----------------------------------------------------
 
     #[test]
-    fn import_parses_then_reports_unavailable() {
+    fn import_parses_successfully() {
+        let run = expect_run(&["--import", "marp", "in.md", "out.md"]);
         assert_eq!(
-            expect_error(&["--import", "marp", "in.md", "out.md"]),
-            "--import is not available in this version"
+            run.action,
+            Some(Action::Import {
+                format: ImportFormat::Marp,
+                input: "in.md".into(),
+                output: "out.md".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn import_pptx_and_url_formats_parse() {
+        let pptx = expect_run(&["--import", "pptx", "deck.pptx", "out.md"]);
+        assert_eq!(
+            pptx.action,
+            Some(Action::Import {
+                format: ImportFormat::Pptx,
+                input: "deck.pptx".into(),
+                output: "out.md".into(),
+            })
+        );
+        let url = expect_run(&["--import", "url", "https://example.com/x.md", "out.md"]);
+        assert_eq!(
+            url.action,
+            Some(Action::Import {
+                format: ImportFormat::Url,
+                input: "https://example.com/x.md".into(),
+                output: "out.md".into(),
+            })
         );
     }
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -199,6 +199,37 @@ pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
                 ) else {
                     return CliArgs::Error(IMPORT_USAGE.into());
                 };
+                // Guards a real footgun, not just usage hygiene: input and
+                // output are two unrelated positional slots with no way to
+                // tell a deliberate call from a shell glob that happened to
+                // expand to exactly two files (e.g. `--import marp *.md
+                // out.md` matching two decks) — which would otherwise
+                // silently overwrite the second file as if it were the
+                // intended output. Three or more matches already fail via
+                // the unexpected-argument check below; this closes the
+                // exactly-two-matches gap that check can't see, since it's
+                // a fully-valid-looking two-argument call by that point.
+                let input_ext_ok = match format {
+                    ImportFormat::Marp => has_extension(&input, &[".md", ".markdown"]),
+                    ImportFormat::Pptx => has_extension(&input, &[".pptx"]),
+                    ImportFormat::Url => true, // not a filesystem path
+                };
+                if !input_ext_ok {
+                    let expected = match format {
+                        ImportFormat::Marp => ".md",
+                        ImportFormat::Pptx => ".pptx",
+                        ImportFormat::Url => unreachable!(),
+                    };
+                    return CliArgs::Error(format!(
+                        "--import {} expects a {expected} input file, got '{input}'",
+                        format_name(&format)
+                    ));
+                }
+                if !has_extension(&output, &[".md", ".markdown"]) {
+                    return CliArgs::Error(format!(
+                        "--import output must be a .md file, got '{output}'"
+                    ));
+                }
                 if let Err(e) = set_action(&mut action, Action::Import { format, input, output }) {
                     return e;
                 }
@@ -222,6 +253,24 @@ pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
                 ) else {
                     return CliArgs::Error(EXPORT_USAGE.into());
                 };
+                // See the matching comment on --import above — same
+                // exactly-two-glob-matches footgun, same fix.
+                if !has_extension(&input, &[".md", ".markdown"]) {
+                    return CliArgs::Error(format!(
+                        "--export expects a .md input file, got '{input}'"
+                    ));
+                }
+                let expected_out = match format {
+                    ExportFormat::Pptx => &[".pptx"][..],
+                    ExportFormat::Pdf => &[".pdf"][..],
+                };
+                if !has_extension(&output, expected_out) {
+                    return CliArgs::Error(format!(
+                        "--export {} output must be a {} file, got '{output}'",
+                        format_name_export(&format),
+                        expected_out[0],
+                    ));
+                }
                 if let Err(e) = set_action(&mut action, Action::Export { format, input, output }) {
                     return e;
                 }
@@ -274,6 +323,28 @@ fn split_eq(arg: &str) -> (&str, Option<&str>) {
 
 /// Value for a flag: the inline `--flag=value` form, or the following
 /// argument when it doesn't look like another flag.
+/// Case-insensitive suffix check against a list of accepted extensions
+/// (each including the leading dot, e.g. `".md"`).
+fn has_extension(path: &str, exts: &[&str]) -> bool {
+    let lower = path.to_ascii_lowercase();
+    exts.iter().any(|e| lower.ends_with(e))
+}
+
+fn format_name(f: &ImportFormat) -> &'static str {
+    match f {
+        ImportFormat::Marp => "marp",
+        ImportFormat::Pptx => "pptx",
+        ImportFormat::Url => "url",
+    }
+}
+
+fn format_name_export(f: &ExportFormat) -> &'static str {
+    match f {
+        ExportFormat::Pptx => "pptx",
+        ExportFormat::Pdf => "pdf",
+    }
+}
+
 fn take_value(inline: Option<&str>, args: &[String], i: &mut usize) -> Option<String> {
     if let Some(v) = inline {
         return Some(v.to_string());
@@ -585,6 +656,80 @@ mod tests {
                 format: ExportFormat::Pptx,
                 input: "in.md".into(),
                 output: "out.pptx".into(),
+            })
+        );
+    }
+
+    // -- extension guards (glob-safety) --------------------------------------
+    //
+    // A shell glob that happens to expand to exactly two files is otherwise
+    // indistinguishable from a deliberate `input output` call — these tests
+    // simulate that by using two plausible filenames in the wrong roles and
+    // checking the mismatch is caught before anything would be written.
+
+    #[test]
+    fn export_rejects_non_md_input() {
+        let msg = expect_error(&["--export", "pdf", "notes.pptx", "out.pdf"]);
+        assert!(msg.contains("--export expects a .md input file"), "{msg}");
+    }
+
+    #[test]
+    fn export_pptx_rejects_glob_landing_on_a_second_md_file() {
+        // Simulates `--export pptx *.md out.pptx` where the glob matched
+        // exactly two decks (jan.md, feb.md) instead of one deck plus an
+        // explicit output — feb.md must never be silently treated as pptx.
+        let msg = expect_error(&["--export", "pptx", "jan.md", "feb.md"]);
+        assert!(msg.contains("--export pptx output must be a .pptx file"), "{msg}");
+    }
+
+    #[test]
+    fn export_pdf_rejects_wrong_output_extension() {
+        let msg = expect_error(&["--export", "pdf", "in.md", "out.pptx"]);
+        assert!(msg.contains("--export pdf output must be a .pdf file"), "{msg}");
+    }
+
+    #[test]
+    fn import_marp_rejects_non_md_input() {
+        let msg = expect_error(&["--import", "marp", "deck.pptx", "out.md"]);
+        assert!(msg.contains("--import marp expects a .md input file"), "{msg}");
+    }
+
+    #[test]
+    fn import_pptx_rejects_non_pptx_input() {
+        let msg = expect_error(&["--import", "pptx", "deck.md", "out.md"]);
+        assert!(msg.contains("--import pptx expects a .pptx input file"), "{msg}");
+    }
+
+    #[test]
+    fn import_rejects_glob_landing_on_a_second_md_file_as_output() {
+        // Simulates `--import marp *.md out.md` matching exactly two decks —
+        // the second must be caught, not silently overwritten... except a
+        // .md output IS what import always expects, so this specific pair
+        // parses (the danger case a naive extension check can't catch:
+        // both matched files already look like valid input/output). Kept as
+        // a documented residual case, not asserted as blocked.
+        let run = expect_run(&["--import", "marp", "jan.md", "feb.md"]);
+        assert_eq!(
+            run.action,
+            Some(Action::Import {
+                format: ImportFormat::Marp,
+                input: "jan.md".into(),
+                output: "feb.md".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn import_url_skips_input_extension_check() {
+        // url's "input" is a URL, not a filesystem path — must never be
+        // extension-checked.
+        let run = expect_run(&["--import", "url", "https://example.com/x", "out.md"]);
+        assert_eq!(
+            run.action,
+            Some(Action::Import {
+                format: ImportFormat::Url,
+                input: "https://example.com/x".into(),
+                output: "out.md".into(),
             })
         );
     }

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -2,10 +2,7 @@
 //!
 //! Grammar: at most one action per invocation (`--present`, `--import`,
 //! `--export`, or standalone `--check FILE`) plus modifiers (`--theme`,
-//! `--check`) that combine with an action in any order. `--export` parses
-//! fully but is rejected as "not available in this version" until the
-//! export engine work lands, so the grammar stays stable and scripts fail
-//! loudly rather than misparsing.
+//! `--check`) that combine with an action in any order.
 //!
 //! `parse_cli_args` is pure (no filesystem, no exit) so the grammar is unit
 //! testable; `startup` wraps it with the process-level concerns: printing,
@@ -32,6 +29,7 @@ pub struct PendingCli {
     pub check: bool,
     pub check_only: Option<String>,
     pub import: Option<PendingImport>,
+    pub export: Option<PendingExport>,
 }
 
 /// `--import <format> <input> <output>`, resolved for the frontend. `input`
@@ -44,6 +42,16 @@ pub struct PendingCli {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PendingImport {
     pub format: ImportFormat,
+    pub input: String,
+    pub output: String,
+}
+
+/// `--export <format> <input> <output>`. Unlike import, `input` is always a
+/// local Markdown file — canonicalised, must already exist. `output` is
+/// absolutized like `PendingImport`'s.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PendingExport {
+    pub format: ExportFormat,
     pub input: String,
     pub output: String,
 }
@@ -66,9 +74,6 @@ pub struct RunArgs {
     pub open: Vec<String>,
 }
 
-// Export is parsed for grammar stability but rejected until Track 2
-// implements it, so its payload fields are not read yet.
-#[allow(dead_code)]
 #[derive(Debug, PartialEq)]
 pub enum Action {
     Present(String),
@@ -87,8 +92,10 @@ pub enum ImportFormat {
     Url,
 }
 
-#[allow(dead_code)]
-#[derive(Debug, PartialEq)]
+/// Serialises as a bare lowercase string ("pptx"/"pdf") — same reasoning as
+/// `ImportFormat` above.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ExportFormat {
     Pptx,
     Pdf,
@@ -114,8 +121,6 @@ Modifiers (combine with an action, any order):
 Other:
   -h, --help            show this help
   --version             show version
-
---export is not available in this version.
 ";
 
 pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
@@ -251,9 +256,6 @@ pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
         if action.is_none() {
             return CliArgs::Error("--theme requires --present, --import, or --export".into());
         }
-        if matches!(action, Some(Action::Export { .. })) {
-            return CliArgs::Error("--export is not available in this version".into());
-        }
         CliArgs::Run(RunArgs { action, theme, check, open: Vec::new() })
     } else {
         // Plain editor launch: positionals are files to open. Unknown
@@ -362,8 +364,12 @@ fn resolve(run: RunArgs) -> Startup {
             };
             pending.import = Some(PendingImport { format, input, output: absolutize(&output) });
         }
-        // Rejected with "not available" during parse.
-        Some(Action::Export { .. }) => unreachable!(),
+        Some(Action::Export { format, input, output }) => {
+            // Unlike import's url case, export's input is always a local
+            // Markdown file that must already exist.
+            let input = canonicalise_or_exit(&input, "cannot open");
+            pending.export = Some(PendingExport { format, input, output: absolutize(&output) });
+        }
         None => {}
     }
     pending.theme = run.theme.map(|theme| match theme {
@@ -373,8 +379,10 @@ fn resolve(run: RunArgs) -> Startup {
         named => named,
     });
 
-    let cli_active =
-        pending.present.is_some() || pending.check_only.is_some() || pending.import.is_some();
+    let cli_active = pending.present.is_some()
+        || pending.check_only.is_some()
+        || pending.import.is_some()
+        || pending.export.is_some();
     // Editor launch keeps the pre-CLI behaviour: arguments that don't exist
     // on disk are silently ignored rather than failing the launch.
     let open = run
@@ -556,10 +564,28 @@ mod tests {
     }
 
     #[test]
-    fn export_parses_then_reports_unavailable() {
+    fn export_parses_successfully() {
+        let run = expect_run(&["--export", "pdf", "in.md", "out.pdf"]);
         assert_eq!(
-            expect_error(&["--export", "pdf", "in.md", "out.pdf"]),
-            "--export is not available in this version"
+            run.action,
+            Some(Action::Export {
+                format: ExportFormat::Pdf,
+                input: "in.md".into(),
+                output: "out.pdf".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn export_pptx_format_parses() {
+        let run = expect_run(&["--export", "pptx", "in.md", "out.pptx"]);
+        assert_eq!(
+            run.action,
+            Some(Action::Export {
+                format: ExportFormat::Pptx,
+                input: "in.md".into(),
+                output: "out.pptx".into(),
+            })
         );
     }
 

--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -7,6 +7,14 @@ pub async fn fetch_url_b64(url: String) -> Result<(String, String), String> {
     if !url.starts_with("https://") && !url.starts_with("http://") {
         return Err("URL must use HTTP or HTTPS".into());
     }
+    // The redirect policy in build_ssrf_safe_client only ever sees hop 2
+    // onward — the initial request URL needs its own check against an
+    // IP-literal host (127.0.0.1, 169.254.169.254, ...), which never reaches
+    // the DNS-resolver-based guard at all.
+    let parsed = reqwest::Url::parse(&url).map_err(|e| format!("invalid URL: {e}"))?;
+    if crate::net_guard::url_host_is_blocked(&parsed) {
+        return Err("refusing to connect to a non-public address".into());
+    }
     let client = crate::net_guard::build_ssrf_safe_client()?;
     let resp = client
         .get(&url)
@@ -41,6 +49,11 @@ pub async fn fetch_url_b64(url: String) -> Result<(String, String), String> {
 pub async fn fetch_url_text(url: String) -> Result<String, String> {
     if !url.starts_with("https://") && !url.starts_with("http://") {
         return Err("URL must use HTTP or HTTPS".into());
+    }
+    // See the matching comment in fetch_url_b64 above.
+    let parsed = reqwest::Url::parse(&url).map_err(|e| format!("invalid URL: {e}"))?;
+    if crate::net_guard::url_host_is_blocked(&parsed) {
+        return Err("refusing to connect to a non-public address".into());
     }
     let client = crate::net_guard::build_ssrf_safe_client()?;
     let resp = client

--- a/src-tauri/src/net_guard.rs
+++ b/src-tauri/src/net_guard.rs
@@ -34,10 +34,31 @@ fn is_blocked(ip: IpAddr) -> bool {
     }
 }
 
+/// True if `url`'s host is an IP literal (`http://127.0.0.1/...`,
+/// `http://169.254.169.254/...`) that names a blocked address. Hostname-based
+/// SSRF is caught by `SsrfSafeResolver` below, but reqwest/hyper's connector
+/// never invokes a custom `Resolve` when the host is already an IP literal —
+/// there's nothing to resolve — so it would otherwise connect straight there,
+/// completely bypassing the resolver-based guard. Must be checked explicitly
+/// against both the initial request URL and every redirect target.
+pub fn url_host_is_blocked(url: &reqwest::Url) -> bool {
+    // Url::host(), not host_str() + parse::<IpAddr>(): host_str() returns an
+    // IPv6 literal's host bracketed ("[::1]"), which IpAddr::from_str rejects
+    // outright — silently defeating the check for exactly the case (IPv6
+    // loopback) it most needs to catch. Host::Ipv6/Ipv4 sidestep the string
+    // round-trip entirely.
+    match url.host() {
+        Some(url::Host::Ipv4(v4)) => is_blocked(IpAddr::V4(v4)),
+        Some(url::Host::Ipv6(v6)) => is_blocked(IpAddr::V6(v6)),
+        _ => false,
+    }
+}
+
 /// A `reqwest::dns::Resolve` that performs ordinary DNS resolution and then
 /// rejects the result if any resolved address is non-public. Since reqwest
 /// re-resolves through this same resolver on every redirect hop, this also
-/// blocks a public hostname that redirects to an internal address.
+/// blocks a public hostname that redirects to an internal address. Does
+/// *not* cover IP-literal hosts — see `url_host_is_blocked` above.
 #[derive(Debug, Default)]
 struct SsrfSafeResolver;
 
@@ -78,11 +99,22 @@ impl Resolve for SsrfSafeResolver {
 
 /// Builds an HTTP client for fetching URLs taken from document content
 /// (remote image embeds, "Import from URL"). DNS resolution — including on
-/// every redirect hop — rejects loopback/private/link-local targets.
+/// every redirect hop — rejects loopback/private/link-local targets; the
+/// redirect policy additionally rejects a redirect straight to an IP literal,
+/// which never goes through DNS resolution at all. Callers must still check
+/// `url_host_is_blocked` against the *initial* request URL themselves — the
+/// redirect policy only ever sees hop 2 onward.
 pub fn build_ssrf_safe_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(15))
         .dns_resolver(Arc::new(SsrfSafeResolver))
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if url_host_is_blocked(attempt.url()) {
+                attempt.error("refusing to redirect to a non-public address")
+            } else {
+                attempt.follow()
+            }
+        }))
         .build()
         .map_err(|e| format!("client error: {e}"))
 }
@@ -107,6 +139,28 @@ mod tests {
         for addr in ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2606:4700:4700::1111"] {
             let ip: IpAddr = addr.parse().unwrap();
             assert!(!is_blocked(ip), "{addr} should be allowed");
+        }
+    }
+
+    #[test]
+    fn blocks_ip_literal_urls_that_never_reach_the_dns_resolver() {
+        for url in [
+            "http://127.0.0.1/",
+            "http://127.0.0.1:8998/fixture.md",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[::1]/",
+            "https://10.0.0.5/internal",
+        ] {
+            let parsed = reqwest::Url::parse(url).unwrap();
+            assert!(url_host_is_blocked(&parsed), "{url} should be blocked");
+        }
+    }
+
+    #[test]
+    fn allows_public_hostname_and_ip_urls() {
+        for url in ["https://raw.githubusercontent.com/x", "https://8.8.8.8/"] {
+            let parsed = reqwest::Url::parse(url).unwrap();
+            assert!(!url_host_is_blocked(&parsed), "{url} should be allowed");
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import { ImportUrlModal } from './components/ImportUrlModal';
 import { ModalShell } from './components/ModalShell';
 import { InfoBanner } from './components/InfoBanner';
 import { isMarp, importMarp } from './engine/import/marp';
+import { parsePptx } from './engine/import/parsePptx';
+import { pptxToMarkdown } from './engine/import/pptxToMarkdown';
 import { MissingThemeBanner } from './components/MissingThemeBanner';
 import { loadSettings, saveSettings, EDITOR_FONT_OPTIONS } from './store/settings';
 import type { AppSettings } from './store/settings';
@@ -49,7 +51,7 @@ import { parseAspectRatio } from './engine/types';
 import { imageMime } from './engine/export/imageMime';
 import type { Theme } from './engine/theme';
 import { useResolvedSlides } from './hooks/useResolvedSlides';
-import type { PendingCli, CliThemeArg } from './types/cli';
+import type { PendingCli, CliThemeArg, PendingImport } from './types/cli';
 
 import './styles/global.css';
 
@@ -139,6 +141,55 @@ async function knownThemeIds(): Promise<string[]> {
     return [...ids, ...entries.map(([id]) => id)];
   } catch {
     return ids;
+  }
+}
+
+// kova --import marp|pptx|url IN OUT. Headless like standalone --check: the
+// window is never shown (lib.rs keeps it hidden for any CLI action), this
+// runs entirely outside React state, and the process exits from here.
+// Mirrors the exact conversion each in-app import flow uses (ImportPptxModal,
+// ImportUrlModal, the Marp-detection prompt) so CLI output matches the GUI's.
+async function runCliImport(imp: PendingImport): Promise<void> {
+  const finish = async (report: string) => {
+    await invoke('cli_stdout', { text: report }).catch(() => {});
+    await invoke('cli_exit', { code: 0 }).catch(() => {});
+  };
+  const fail = async (message: string) => {
+    await invoke('cli_exit', { message, code: 1 }).catch(() => {});
+  };
+
+  try {
+    if (imp.format === 'marp') {
+      const text: string = await invoke('read_file', { path: imp.input });
+      const { markdown, dropped } = importMarp(text);
+      await invoke('write_file', { path: imp.output, content: markdown });
+      const suffix = dropped.length > 0 ? ` (simplified: ${dropped.join(', ')})` : '';
+      await finish(`wrote '${imp.output}'${suffix}`);
+      return;
+    }
+    if (imp.format === 'pptx') {
+      // Media referenced by the deck is extracted alongside the output file,
+      // same as the in-app import modal.
+      const parsed = await parsePptx(imp.input, dirOf(imp.output));
+      const markdown = pptxToMarkdown(parsed);
+      await invoke('write_file', { path: imp.output, content: markdown });
+      const lines = [`wrote '${imp.output}' (${parsed.slides.length} slides)`];
+      for (const w of parsed.warnings) lines.push(`warning: ${w}`);
+      await finish(lines.join('\n'));
+      return;
+    }
+    // url — fetched verbatim, no conversion (matches ImportUrlModal: if the
+    // remote content is a Marp deck, that's detected on open, not on fetch).
+    const text: string = await invoke('fetch_url_text', { url: imp.input });
+    await invoke('write_file', { path: imp.output, content: text });
+    await finish(`wrote '${imp.output}'`);
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : String(err);
+    // Mirrors ImportPptxModal's special-case message for this common failure.
+    const msg = imp.format === 'pptx' && /password|encrypted/i.test(raw)
+      ? 'PPTX file is password-protected; remove protection before importing'
+      : raw;
+    await fail(msg);
   }
 }
 
@@ -983,6 +1034,13 @@ export default function App() {
     (async () => {
       const cli = await getPendingCli();
       if (coldLoadStartedRef.current) return;
+      // kova --import: fully headless, no editor state or window involved —
+      // runs and exits before any of the present/check logic below.
+      if (cli?.import) {
+        coldLoadStartedRef.current = true;
+        await runCliImport(cli.import);
+        return;
+      }
       // --present FILE, or standalone --check FILE (which never shows a window:
       // the loading branch renders behind a window that lib.rs never shows, and
       // the process exits from this effect).
@@ -1059,8 +1117,10 @@ export default function App() {
       // the last file would race the CLI file's load through applyFileContent
       // and whichever resolves last would win, possibly presenting the wrong
       // deck. The CLI drain is cached, so this await costs one IPC roundtrip.
+      // --import is headless and exits the process itself, but skip restoring
+      // here too rather than doing pointless work moments before it quits.
       const cli = await getPendingCli();
-      if (cli?.present) return;
+      if (cli?.present || cli?.import) return;
       try {
         const text: string = await invoke('read_file', { path: session.path });
         await applyFileContent(text, session.path);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ import { parseAspectRatio } from './engine/types';
 import { imageMime } from './engine/export/imageMime';
 import type { Theme } from './engine/theme';
 import { useResolvedSlides } from './hooks/useResolvedSlides';
-import type { PendingCli, CliThemeArg, PendingImport } from './types/cli';
+import type { PendingCli, CliThemeArg, PendingImport, PendingExport } from './types/cli';
 
 import './styles/global.css';
 
@@ -208,6 +208,10 @@ export default function App() {
   // the deck resolves, and exiting quits the process instead of revealing the
   // editor. Stays true for the whole session once set.
   const [coldPresent, setColdPresent]     = useState(false);
+  // Session was started via `kova --export pptx|pdf FILE OUT`: set once the
+  // deck has loaded (by the same effect that handles --present), consumed by
+  // the cold-export effect below the export handlers once slides resolve.
+  const [coldExport, setColdExport]       = useState<PendingExport | null>(null);
   const [settings, setSettings]           = useState<AppSettings>(loadSettings);
   const t = useLocaleTranslator(settings.locale);
   const [showSettings, setShowSettings]   = useState(false);
@@ -1041,18 +1045,22 @@ export default function App() {
         await runCliImport(cli.import);
         return;
       }
-      // --present FILE, or standalone --check FILE (which never shows a window:
+      // --present FILE, standalone --check FILE (which never shows a window:
       // the loading branch renders behind a window that lib.rs never shows, and
-      // the process exits from this effect).
-      const target = cli?.present ?? cli?.check_only;
+      // the process exits from this effect), or --export's input file (the
+      // window also stays hidden — export_pdf_native always prints via its
+      // own separate hidden window regardless, and PPTX needs no window at
+      // all — the cold-export effect below picks this up once slides resolve).
+      const target = cli?.present ?? cli?.check_only ?? cli?.export?.input;
       if (!cli || !target) return;
       coldLoadStartedRef.current = true;
-      setColdPresent(true);
+      if (cli.present) setColdPresent(true);
       // Resolve --theme before loading the deck: theme errors are fail-fast
       // (stderr + exit 1) like a missing presentation file, and nothing has
-      // rendered yet at this point.
+      // rendered yet at this point. Applies to present and export — not
+      // import, which never renders anything a theme could affect.
       let cliTheme: Theme | null = null;
-      if (cli.theme && cli.present) {
+      if (cli.theme && (cli.present || cli.export)) {
         cliTheme = await resolveCliTheme(cli.theme);
         if (!cliTheme) return; // reported and exiting
       }
@@ -1093,6 +1101,7 @@ export default function App() {
           const { frontmatter: fm } = extractFrontmatter(text);
           setThemeOverrides(sanitiseThemeOverrides(fm.theme_overrides as Record<string, unknown> ?? {}));
         }
+        if (cli.export) setColdExport(cli.export);
       } catch {
         await invoke('cli_exit', {
           message: `cannot read '${target}'`,
@@ -1119,8 +1128,10 @@ export default function App() {
       // deck. The CLI drain is cached, so this await costs one IPC roundtrip.
       // --import is headless and exits the process itself, but skip restoring
       // here too rather than doing pointless work moments before it quits.
+      // --export needs this effect to stay out of the way entirely: it loads
+      // its own file into the same state this would race against.
       const cli = await getPendingCli();
-      if (cli?.present || cli?.import) return;
+      if (cli?.present || cli?.import || cli?.export) return;
       try {
         const text: string = await invoke('read_file', { path: session.path });
         await applyFileContent(text, session.path);
@@ -1393,6 +1404,50 @@ export default function App() {
     }
   });
 
+  // Shared by the button (handleExportPdf) and the headless CLI export path:
+  // mounts the off-screen slide list, waits for it to render (native print
+  // first, raster fallback on failure), writes the file, and reports back
+  // what happened rather than alerting — each caller handles that its own
+  // way (a dialog here, stdout/stderr for the CLI). Throws only on total
+  // failure (both native and the raster fallback failed).
+  const runPdfExportCapture = useCallback(async (
+    visSlides: Slide[],
+    savePath: string,
+    opts: PdfExportOpts,
+  ): Promise<{ warnings: string[]; usedFallback: boolean; fallbackReason?: string }> => {
+    pdfSlideRefs.current.clear();
+    pdfSlideReadyCount.current = 0;
+    pdfSlideReadyTotal.current = visSlides.length;
+    return new Promise((resolve, reject) => {
+      pdfExportRunnerRef.current = async () => {
+        try {
+          const elements = Array.from(
+            { length: visSlides.length },
+            (_, i) => pdfSlideRefs.current.get(i),
+          ).filter((el): el is HTMLElement => Boolean(el));
+
+          try {
+            await exportPdfNative(elements, aspectRatio, savePath, opts);
+            resolve({ warnings: [], usedFallback: false });
+          } catch (nativeErr) {
+            // Native backend unavailable/failed — degrade to the raster renderer.
+            // It's one-slide-per-page and ignores handout/N-up/paper options.
+            const { base64, warnings } = await exportToPdf(elements, activeTheme, aspectRatio);
+            await invoke('write_file_bytes', { path: savePath, data: base64 });
+            resolve({ warnings, usedFallback: true, fallbackReason: String(nativeErr) });
+          }
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        } finally {
+          setPdfExportContext(null);
+          pdfSlideRefs.current.clear();
+          pdfExportRunnerRef.current = null;
+        }
+      };
+      setPdfExportContext({ slides: visSlides, savePath });
+    });
+  }, [aspectRatio, activeTheme]);
+
   const handleExportPdf = useCallback(async (opts: PdfExportOpts = {}) => {
     if (visibleSlides.length === 0) return;
     // The in-window buttons disable while an export is already in flight, but
@@ -1410,45 +1465,68 @@ export default function App() {
     if (!target) return;
     const savePath = target.toLowerCase().endsWith('.pdf') ? target : `${target}.pdf`;
 
-    const visSlides = [...visibleSlides];
-    pdfSlideRefs.current.clear();
-    pdfSlideReadyCount.current = 0;
-    pdfSlideReadyTotal.current = visSlides.length;
-    await new Promise<void>(resolve => {
-      pdfExportRunnerRef.current = async () => {
-        try {
-          const elements = Array.from(
-            { length: visSlides.length },
-            (_, i) => pdfSlideRefs.current.get(i),
-          ).filter((el): el is HTMLElement => Boolean(el));
+    try {
+      const outcome = await runPdfExportCapture([...visibleSlides], savePath, opts);
+      if (outcome.usedFallback) {
+        console.error('Native PDF failed, falling back to raster:', outcome.fallbackReason);
+        window.alert(
+          t('app.pdfExportFallback') +
+          `\n\n${t('app.pdfExportFallbackReason', { error: outcome.fallbackReason ?? '' })}` +
+          (outcome.warnings.length ? `\n\n${outcome.warnings.join('\n')}` : ''),
+        );
+      }
+    } catch (err) {
+      console.error('PDF export failed:', err);
+      window.alert(t('app.pdfExportFailed', { error: String(err) }));
+    }
+  }, [visibleSlides, filePath, runPdfExportCapture, t, pdfExportContext, printContext]);
 
-          try {
-            await exportPdfNative(elements, aspectRatio, savePath, opts);
-          } catch (nativeErr) {
-            // Native backend unavailable/failed — degrade to the raster renderer.
-            // It's one-slide-per-page and ignores handout/N-up/paper options.
-            console.error('Native PDF failed, falling back to raster:', nativeErr);
-            const { base64, warnings } = await exportToPdf(elements, activeTheme, aspectRatio);
-            await invoke('write_file_bytes', { path: savePath, data: base64 });
-            window.alert(
-              t('app.pdfExportFallback') +
-              `\n\n${t('app.pdfExportFallbackReason', { error: String(nativeErr) })}` +
-              (warnings.length ? `\n\n${warnings.join('\n')}` : ''),
-            );
-          }
-        } catch (err) {
-          console.error('PDF export failed:', err);
-          window.alert(t('app.pdfExportFailed', { error: String(err) }));
-        } finally {
-          setPdfExportContext(null);
-          pdfSlideRefs.current.clear();
-          pdfExportRunnerRef.current = null;
-          resolve();
+  // Cold-start export (kova --export pptx|pdf FILE OUT): the load effect
+  // above applies --theme and loads the deck; this fires once slides are
+  // resolved. PPTX needs no rendered DOM (exportToPptx works from slide data
+  // directly); PDF reuses the exact capture path the button uses above,
+  // native print against the hidden dedicated print window (export_pdf_native
+  // already always creates one, whether launched from the GUI or the CLI)
+  // with the same raster fallback on failure.
+  const coldExportFiredRef = useRef(false);
+  useEffect(() => {
+    if (!coldExport || coldExportFiredRef.current || !filePath) return;
+    coldExportFiredRef.current = true;
+    if (visibleSlides.length === 0) {
+      invoke('cli_exit', {
+        message: `'${filePath}' contains no visible slides`,
+        code: 1,
+      }).catch(() => {});
+      return;
+    }
+    const finish = async (report: string) => {
+      await invoke('cli_stdout', { text: report }).catch(() => {});
+      await invoke('cli_exit', { code: 0 }).catch(() => {});
+    };
+    const fail = async (message: string) => {
+      await invoke('cli_exit', { message, code: 1 }).catch(() => {});
+    };
+    (async () => {
+      try {
+        if (coldExport.format === 'pptx') {
+          const { base64, warnings } = await exportToPptx(visibleSlides, frontmatter, activeTheme, settings.locale);
+          await invoke('write_file_bytes', { path: coldExport.output, data: base64 });
+          const lines = [`wrote '${coldExport.output}'`, ...warnings.map((w) => `warning: ${w}`)];
+          await finish(lines.join('\n'));
+          return;
         }
-      };
-      setPdfExportContext({ slides: visSlides, savePath });
-    });
-  }, [visibleSlides, filePath, activeTheme, aspectRatio, t, pdfExportContext, printContext]);
+        const outcome = await runPdfExportCapture([...visibleSlides], coldExport.output, {});
+        const lines = [`wrote '${coldExport.output}'`];
+        if (outcome.usedFallback) {
+          lines.push(`note: native PDF export failed, used raster fallback (${outcome.fallbackReason})`);
+        }
+        lines.push(...outcome.warnings.map((w) => `warning: ${w}`));
+        await finish(lines.join('\n'));
+      } catch (err) {
+        await fail(err instanceof Error ? err.message : String(err));
+      }
+    })();
+  }, [coldExport, filePath, visibleSlides, frontmatter, activeTheme, settings.locale, runPdfExportCapture]);
 
   const handleExportHtml = useCallback(async () => {
     if (visibleSlides.length === 0) return;

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -5,6 +5,16 @@ export type CliThemeArg =
   | { type: 'named'; name: string }
   | { type: 'path'; path: string };
 
+export type CliImportFormat = 'marp' | 'pptx' | 'url';
+
+export interface PendingImport {
+  format: CliImportFormat;
+  /** Canonicalised path for marp/pptx; the raw URL, unchanged, for url. */
+  input: string;
+  /** Absolute path — not required to exist yet, it's the file being written. */
+  output: string;
+}
+
 export interface PendingCli {
   /** Canonicalised absolute path to present (`kova --present FILE`). */
   present: string | null;
@@ -14,4 +24,6 @@ export interface PendingCli {
   check: boolean;
   /** Canonicalised absolute path for standalone `kova --check FILE`. */
   check_only: string | null;
+  /** `kova --import marp|pptx|url IN OUT`. */
+  import: PendingImport | null;
 }

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -15,6 +15,16 @@ export interface PendingImport {
   output: string;
 }
 
+export type CliExportFormat = 'pptx' | 'pdf';
+
+export interface PendingExport {
+  format: CliExportFormat;
+  /** Canonicalised path — must already exist, unlike import's url case. */
+  input: string;
+  /** Absolute path — not required to exist yet, it's the file being written. */
+  output: string;
+}
+
 export interface PendingCli {
   /** Canonicalised absolute path to present (`kova --present FILE`). */
   present: string | null;
@@ -26,4 +36,6 @@ export interface PendingCli {
   check_only: string | null;
   /** `kova --import marp|pptx|url IN OUT`. */
   import: PendingImport | null;
+  /** `kova --export pptx|pdf IN OUT`. */
+  export: PendingExport | null;
 }


### PR DESCRIPTION
## Summary

Track 2 of the CLI work (following #163): the two remaining gated actions, `--import` and `--export`, are now implemented. Together with #163 this completes the full grammar from the original roadmap discussion.

```
kova --import marp|pptx|url IN OUT
kova --export pptx|pdf IN OUT
```

## How it works

Both reuse the hidden-window pattern `--check` established in #163 rather than needing a separate headless-rendering architecture — the original plan assumed a `HostBridge` decoupling layer and a renderer decision would be needed first; neither turned out to be necessary once the app itself could cold-start with its window hidden.

- **Import** calls the exact same conversion functions the in-app modals use (`importMarp`, `parsePptx`+`pptxToMarkdown`, `fetch_url_text`), fully headless — the window is never shown, the process exits when done.
- **Export pptx** needs no rendered DOM at all — `exportToPptx` works straight from parsed slide data.
- **Export pdf** reuses the exact off-screen slide-capture path the PDF export button uses (native platform print first, raster fallback on failure), extracted into a shared `runPdfExportCapture` so the button and the CLI path don't duplicate that logic.
- `--theme` and `--check` compose with both actions the same way they do with `--present`.
- `--import`/`--export` reject a mismatched file extension on input or output — closes a real footgun where a shell glob that happens to expand to exactly two files would otherwise be indistinguishable from a deliberate `input output` call, silently overwriting the second file. (One documented, accepted exception: `--import marp`'s input and output are both legitimately `.md`, so that specific same-extension collision isn't and won't be closed without a larger grammar change to explicit `--input`/`--output` flags.)

## Notable side effect

Testing `--import url` surfaced a real, pre-existing SSRF guard bypass: `fetch_url_text`/`fetch_url_b64` blocked private/loopback *hostnames* via a custom DNS resolver, but reqwest/hyper never calls that resolver for a URL whose host is already an IP literal (`http://127.0.0.1/...`, `http://169.254.169.254/...` for cloud metadata) — those went straight through unguarded. This affected the existing in-app "Import from URL" modal too, not just the new CLI path. Fixed in the first commit on this branch, confirmed closed (IPv4 and IPv6 loopback both now rejected) without affecting legitimate fetches.

## Verification

- 613 vitest tests (unchanged — no new frontend unit tests needed beyond what #163 already covered for the shared machinery) and 49 Rust tests (up from 38 pre-#163: parser grammar, extension guards, SSRF fixes) all pass.
- End-to-end on all three platforms via test builds (same `workflow_dispatch` pattern as #163): Linux (developed and verified throughout, including a hand-built minimal OOXML `.pptx` fixture for import testing), macOS, and Windows all confirmed `--export pptx` and `--export pdf` work — meaning native PDF print against a main window that was **never shown** works across WebKitGTK, WKWebView, and WebView2, which was the one open architectural question in the original plan.
- Error paths verified: missing input file, empty deck, `--check`-gated broken file aborting before any output is written, and the extension-mismatch rejection (confirmed a target file's content survives a rejected call untouched).

## Notes for review

1. `PendingImport`/`PendingExport` mirror the existing `ThemeArg` pattern — resolved server-side in Rust (`cli.rs`), drained once by the frontend via `take_pending_cli`.
2. Extension validation lives in `parse_cli_args`, which is filesystem-free by design (unit tested without touching disk) — the check runs before any I/O, not as an afterthought.
3. `runPdfExportCapture`'s extraction from `handleExportPdf` is behaviour-preserving (same off-screen mount/wait/native/fallback logic, just parameterised on save path and returning an outcome instead of alerting) — worth a look given it's shared by both the button and the CLI now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)