### PR TITLE
fix(windows): make PATH registration optional and scope-selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ Kova turns plain Markdown into polished slides — with live preview, multiple l
 | Platform | Download |
 |---|---|
 | **macOS** (Apple Silicon + Intel) | [**Download .dmg**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_macOS.dmg) |
-| **Windows 10/11** | [**Download .msi**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Windows.msi) · [Setup .exe](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Windows_setup.exe) |
+| **Windows 10/11** | [**Download .msi**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Windows.msi) (installs for all users) · [Setup .exe](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Windows_setup.exe) (installs for just you) |
 | **Linux** | [See install options ↓](#linux) |
+
+Both Windows installers offer a checkbox to add Kova to PATH so `kova` works from a terminal — the `.msi` adds it to the system PATH, the `.exe` to your user PATH, matching each installer's install scope.
 
 ## Linux
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Kova turns plain Markdown into polished slides — with live preview, multiple l
 | **Windows 10/11** | [**Download .msi**](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Windows.msi) (installs for all users) · [Setup .exe](https://github.com/KovaMD/Kova/releases/latest/download/Kova_Windows_setup.exe) (installs for just you) |
 | **Linux** | [See install options ↓](#linux) |
 
-Both Windows installers offer a checkbox to add Kova to PATH so `kova` works from a terminal — the `.msi` adds it to the system PATH, the `.exe` to your user PATH, matching each installer's install scope.
+Both Windows installers let you skip adding Kova to PATH so `kova` works from a terminal. The `.exe` (per-user) always uses your own user PATH; the `.msi` (all users) lets you pick system PATH, your user PATH only, or neither.
 
 ## Linux
 

--- a/src-tauri/installer-hooks.nsh
+++ b/src-tauri/installer-hooks.nsh
@@ -16,6 +16,13 @@
 ;
 ; Terminals opened before the install won't see the new PATH — Windows only
 ; delivers WM_SETTINGCHANGE to new processes.
+;
+; PATH addition is opt-out via a Yes/No prompt (issue #168) rather than a
+; wizard-page checkbox: Tauri's NSIS template only exposes four fixed hook
+; macros (PRE/POSTINSTALL, PRE/POSTUNINSTALL), not a way to add a new page,
+; and both spare Finish-page checkbox slots (MUI_FINISHPAGE_SHOWREADME /
+; MUI_FINISHPAGE_RUN) are already used for the desktop shortcut and "run
+; Kova now" options. A plain MessageBox needs no template fork.
 
 !include "WinMessages.nsh"
 
@@ -55,6 +62,10 @@ FunctionEnd
 !insertmacro KOVA_STRIDX_FUNC "un."
 
 !macro NSIS_HOOK_POSTINSTALL
+  ; /SD IDYES: silent installs (`/S`) keep today's default of adding PATH,
+  ; since the message box never displays and IDYES is used automatically.
+  MessageBox MB_YESNO|MB_ICONQUESTION "Add the Kova install folder to your PATH?$\r$\n$\r$\nThis lets you run 'kova' from Command Prompt or PowerShell." /SD IDYES IDNO kova_path_done
+
   ReadRegStr $0 HKCU "Environment" "Path"
   Push $0
   Push "$INSTDIR"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -62,7 +62,7 @@
         "installerHooks": "installer-hooks.nsh"
       },
       "wix": {
-        "fragmentPaths": ["wix/path-env.wxs"],
+        "fragmentPaths": ["wix/path-env.wxs", "wix/path-checkbox-dialog.wxs"],
         "componentRefs": ["KovaPathEnv"]
       }
     },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -63,7 +63,7 @@
       },
       "wix": {
         "fragmentPaths": ["wix/path-env.wxs", "wix/path-checkbox-dialog.wxs"],
-        "componentRefs": ["KovaPathEnv"]
+        "componentRefs": ["KovaPathEnv", "KovaPathEnvUser"]
       }
     },
     "linux": {

--- a/src-tauri/wix/path-checkbox-dialog.wxs
+++ b/src-tauri/wix/path-checkbox-dialog.wxs
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Adds an "Add to PATH" checkbox page to the MSI install wizard (issue
-  #168): the stock WixUI_InstallDir sequence has no spare checkbox slot
-  (the Exit dialog's one optional checkbox is already used for "Launch
-  Kova" in main.wxs), so this splices a new dialog in between InstallDirDlg
-  and VerifyReadyDlg.
+  Adds a "PATH" page to the MSI install wizard (issue #168) letting the
+  user pick system PATH / their own PATH only / no PATH entry, even though
+  the app itself always installs per-machine (Tauri's WiX bundler has no
+  per-user install mode at all — this only changes which registry hive the
+  Environment component targets, not where Kova's files go). The stock
+  WixUI_InstallDir sequence has no spare page for this (the Exit dialog's
+  one optional checkbox is already used for "Launch Kova" in main.wxs), so
+  this splices a new dialog in between InstallDirDlg and VerifyReadyDlg.
 
   Overriding stock WixUI_InstallDir navigation: WiX/MSI evaluates every
   Publish row for a given Dialog+Control+Event in ascending Order, and for
@@ -17,13 +20,16 @@
   bypassed. Same pattern for VerifyReadyDlg's Back button (stock Order="1"
   condition "NOT Installed").
 
-  ADDTOPATH defaults to "1" (checked) so both a plain `msiexec /i` silent
-  install and an interactive install that never reaches this page (the
-  property is public/all-caps, so it carries from the UI sequence into the
-  execute sequence where the Environment component's Condition, in
-  path-env.wxs, is evaluated) keep today's always-add-PATH behaviour.
-  Power users can pass `ADDTOPATH=0` on the msiexec command line for a
-  scripted install with no dialog involved at all.
+  PATHSCOPE defaults to "system" (matches the only behaviour this installer
+  had before issue #168) so both a plain `msiexec /i` silent install and an
+  interactive install that never reaches this page (the property is
+  public/all-caps, so it carries from the UI sequence into the execute
+  sequence where the Environment components' Conditions, in path-env.wxs,
+  are evaluated) keep adding to the system PATH. Power users can pass
+  PATHSCOPE=user or PATHSCOPE=none on the msiexec command line for a
+  scripted install with no dialog involved at all. The "user" choice writes
+  HKCU, not HKLM, so it needs no elevation of its own — though the overall
+  MSI is always elevated anyway to install into Program Files.
 
   This whole Fragment is otherwise unreachable from the product (nothing
   Ref's the Dialog, Property, or Publish rows here), and WiX Fragments are
@@ -34,7 +40,7 @@
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
-    <Property Id="ADDTOPATH" Value="1" />
+    <Property Id="PATHSCOPE" Value="system" />
 
     <UI>
       <Dialog Id="PathOptDlg" Width="370" Height="270" Title="!(loc.InstallDirDlg_Title)">
@@ -43,10 +49,17 @@
         <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
 
         <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Command-Line Access" />
-        <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="Choose whether to add Kova to your PATH." />
+        <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="Choose where to add Kova to PATH." />
 
-        <Control Id="PathLabel" Type="Text" X="20" Y="60" Width="330" Height="40" NoPrefix="yes" Text="Kova includes a command-line interface (kova --present, --check, --import, --export). Adding the install folder to your PATH lets you run 'kova' from Command Prompt or PowerShell." />
-        <Control Id="AddToPathCheckBox" Type="CheckBox" X="20" Y="105" Width="330" Height="18" CheckBoxValue="1" Property="ADDTOPATH" Text="Add Kova to my PATH (recommended)" />
+        <Control Id="PathLabel" Type="Text" X="20" Y="60" Width="330" Height="24" NoPrefix="yes" Text="Kova includes a command-line interface (kova --present, --check, --import, --export). Adding it to PATH lets you run 'kova' from a terminal." />
+
+        <Control Id="PathScopeGroup" Type="RadioButtonGroup" X="20" Y="90" Width="330" Height="60" Property="PATHSCOPE">
+          <RadioButtonGroup Property="PATHSCOPE">
+            <RadioButton Value="system" X="0" Y="0" Width="330" Height="16" Text="Add to the system PATH (every user on this machine, recommended)" />
+            <RadioButton Value="user" X="0" Y="20" Width="330" Height="16" Text="Add to my PATH only" />
+            <RadioButton Value="none" X="0" Y="40" Width="330" Height="16" Text="Don't add Kova to PATH" />
+          </RadioButtonGroup>
+        </Control>
 
         <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)">
           <Publish Event="NewDialog" Value="InstallDirDlg">1</Publish>

--- a/src-tauri/wix/path-checkbox-dialog.wxs
+++ b/src-tauri/wix/path-checkbox-dialog.wxs
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Adds an "Add to PATH" checkbox page to the MSI install wizard (issue
+  #168): the stock WixUI_InstallDir sequence has no spare checkbox slot
+  (the Exit dialog's one optional checkbox is already used for "Launch
+  Kova" in main.wxs), so this splices a new dialog in between InstallDirDlg
+  and VerifyReadyDlg.
+
+  Overriding stock WixUI_InstallDir navigation: WiX/MSI evaluates every
+  Publish row for a given Dialog+Control+Event in ascending Order, and for
+  NewDialog events the last row whose condition is true wins (each fires in
+  turn; the last navigation call is what's shown). So to redirect
+  InstallDirDlg's Next button here instead of straight to VerifyReadyDlg,
+  we add a new row with the SAME condition as the stock one
+  (WixUI_InstallDir.wxs, Order="4") but a higher Order — never a bare "1"
+  condition, or path validation on the Change-folder browse button would be
+  bypassed. Same pattern for VerifyReadyDlg's Back button (stock Order="1"
+  condition "NOT Installed").
+
+  ADDTOPATH defaults to "1" (checked) so both a plain `msiexec /i` silent
+  install and an interactive install that never reaches this page (the
+  property is public/all-caps, so it carries from the UI sequence into the
+  execute sequence where the Environment component's Condition, in
+  path-env.wxs, is evaluated) keep today's always-add-PATH behaviour.
+  Power users can pass `ADDTOPATH=0` on the msiexec command line for a
+  scripted install with no dialog involved at all.
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <Property Id="ADDTOPATH" Value="1" />
+
+    <UI>
+      <Dialog Id="PathOptDlg" Width="370" Height="270" Title="!(loc.InstallDirDlg_Title)">
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="WixUI_Bmp_Banner" />
+        <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+        <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+
+        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Command-Line Access" />
+        <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="Choose whether to add Kova to your PATH." />
+
+        <Control Id="PathLabel" Type="Text" X="20" Y="60" Width="330" Height="40" NoPrefix="yes" Text="Kova includes a command-line interface (kova --present, --check, --import, --export). Adding the install folder to your PATH lets you run 'kova' from Command Prompt or PowerShell." />
+        <Control Id="AddToPathCheckBox" Type="CheckBox" X="20" Y="105" Width="330" Height="18" CheckBoxValue="1" Property="ADDTOPATH" Text="Add Kova to my PATH (recommended)" />
+
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)">
+          <Publish Event="NewDialog" Value="InstallDirDlg">1</Publish>
+        </Control>
+        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)">
+          <Publish Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+          <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+        </Control>
+      </Dialog>
+
+      <!-- Redirect InstallDirDlg's Next button here instead of straight to
+           VerifyReadyDlg. Same condition as the stock Order="4" row
+           (WixUI_InstallDir.wxs) so a not-yet-validated path can't skip
+           past InvalidDirDlg; higher Order so this row wins. -->
+      <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="PathOptDlg" Order="5">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
+
+      <!-- Redirect VerifyReadyDlg's Back button here instead of straight to
+           InstallDirDlg. Same condition as the stock Order="1" row. Stock
+           also has two Order="2" rows (Installed AND (NOT)PATCH, both
+           false here) — use Order="3" rather than "2" so there's no tie
+           with those to worry about; ties on Order are unspecified. -->
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PathOptDlg" Order="3">NOT Installed</Publish>
+    </UI>
+  </Fragment>
+</Wix>

--- a/src-tauri/wix/path-checkbox-dialog.wxs
+++ b/src-tauri/wix/path-checkbox-dialog.wxs
@@ -24,6 +24,13 @@
   path-env.wxs, is evaluated) keep today's always-add-PATH behaviour.
   Power users can pass `ADDTOPATH=0` on the msiexec command line for a
   scripted install with no dialog involved at all.
+
+  This whole Fragment is otherwise unreachable from the product (nothing
+  Ref's the Dialog, Property, or Publish rows here), and WiX Fragments are
+  linked as an all-or-nothing unit — light.exe silently drops an
+  unreferenced one, no error. path-env.wxs's <UI><DialogRef Id="PathOptDlg"
+  /></UI> is what anchors this file into the build; don't remove it there
+  without replacing it some other way.
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>

--- a/src-tauri/wix/path-env.wxs
+++ b/src-tauri/wix/path-env.wxs
@@ -1,25 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Appends the install directory to the system PATH so `kova` works from a
-  terminal after an MSI install (docs/plans/kova-cli.md, Phase D). The NSIS
-  installer does the same via installer-hooks.nsh; WiX never runs those
-  hooks, so the MSI needs its own declarative version.
+  Appends the install directory to PATH so `kova` works from a terminal
+  after an MSI install (docs/plans/kova-cli.md, Phase D; scope choice added
+  for issue #168). The NSIS installer does the same via
+  installer-hooks.nsh; WiX never runs those hooks, so the MSI needs its own
+  declarative version.
 
-  System="yes" (machine PATH, not per-user) matches the MSI's install scope:
-  Tauri's WiX template installs per-machine under ProgramFiles64Folder.
+  Two Components, System="yes"/"no", cover the two scope choices from
+  path-checkbox-dialog.wxs's PATHSCOPE radio buttons independently of the
+  app's own install location: Tauri's WiX template always installs
+  per-machine under ProgramFiles64Folder (there's no per-user mode for the
+  MSI at all), but an Environment component's System attribute is its own,
+  separate setting - "user" scope still writes HKCU\Environment, not
+  HKLM\...\Environment, with no elevation needed for that specific write
+  (the overall MSI install is elevated regardless, to reach Program Files).
+  Windows Installer is documented to resolve HKCU in this Environment-table
+  context to the *launching* user's hive even from that elevated install,
+  not SYSTEM's profile - worth double-checking on a real Windows VM, since
+  it can't be verified from this Linux dev box.
+
   Windows Installer handles the append, repair, and removal-on-uninstall
   itself (Permanent="no"), so unlike the NSIS side there is no hand-rolled
   dedupe or excise logic to maintain.
 
-  The RegistryValue exists only as the component KeyPath - an Environment
-  element cannot be one, and every component must have one.
+  Each RegistryValue exists only as its component's KeyPath - an
+  Environment element cannot be one, and every component must have one.
+  Deliberately scoped to match: HKLM for the system component, HKCU for
+  the user one.
 
-  Condition gates this on ADDTOPATH (issue #168, default "1" - see
-  path-checkbox-dialog.wxs), the public property the install-wizard
-  checkbox and/or `msiexec ADDTOPATH=0` set. A false Component Condition
-  makes MSI treat the whole component as absent for this install, which is
-  the standard way to make a component optional; it does not affect the
-  ComponentRef wiring in tauri.conf.json.
+  Conditions gate each component on PATHSCOPE (issue #168, default
+  "system" - see path-checkbox-dialog.wxs), the public property the
+  install-wizard radio buttons and/or `msiexec PATHSCOPE=user|none` set. A
+  false Component Condition makes MSI treat the whole component as absent
+  for this install, which is the standard way to make a component
+  optional; it does not affect the ComponentRef wiring in tauri.conf.json -
+  BOTH components still need their own ComponentRef there (that wiring is
+  what makes each one install-able at all; Condition only decides whether
+  it actually does on a given run).
 
   The <UI><DialogRef .../></UI> below is load-bearing, not decorative: a
   WiX Fragment is an all-or-nothing linking unit (confirmed by inspecting
@@ -30,7 +47,7 @@
   nothing was pulling in path-checkbox-dialog.wxs's Fragment, so light.exe
   dropped it whole, silently. Referencing PathOptDlg here - any single
   symbol in that Fragment would do - pulls in the entire thing: the
-  Dialog, the ADDTOPATH Property, and both override Publish rows.
+  Dialog, the PATHSCOPE Property, and both override Publish rows.
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
@@ -40,7 +57,7 @@
 
     <DirectoryRef Id="INSTALLDIR">
       <Component Id="KovaPathEnv" Guid="D2626A48-7CD3-429B-89FA-B61EC6EE3A4A" Win64="yes">
-        <Condition>ADDTOPATH = 1</Condition>
+        <Condition>PATHSCOPE = "system"</Condition>
         <Environment Id="KovaPathEnv"
                      Name="PATH"
                      Value="[INSTALLDIR]"
@@ -50,6 +67,23 @@
                      System="yes" />
         <RegistryValue Root="HKLM"
                        Key="Software\Kova\PathEnv"
+                       Name="installed"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+
+      <Component Id="KovaPathEnvUser" Guid="51DFCFE1-6C13-468A-A1DA-9C5606A54DAC" Win64="yes">
+        <Condition>PATHSCOPE = "user"</Condition>
+        <Environment Id="KovaPathEnvUser"
+                     Name="PATH"
+                     Value="[INSTALLDIR]"
+                     Permanent="no"
+                     Part="last"
+                     Action="set"
+                     System="no" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\Kova\PathEnvUser"
                        Name="installed"
                        Type="integer"
                        Value="1"

--- a/src-tauri/wix/path-env.wxs
+++ b/src-tauri/wix/path-env.wxs
@@ -13,11 +13,19 @@
 
   The RegistryValue exists only as the component KeyPath - an Environment
   element cannot be one, and every component must have one.
+
+  Condition gates this on ADDTOPATH (issue #168, default "1" - see
+  path-checkbox-dialog.wxs), the public property the install-wizard
+  checkbox and/or `msiexec ADDTOPATH=0` set. A false Component Condition
+  makes MSI treat the whole component as absent for this install, which is
+  the standard way to make a component optional; it does not affect the
+  ComponentRef wiring in tauri.conf.json.
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
     <DirectoryRef Id="INSTALLDIR">
       <Component Id="KovaPathEnv" Guid="D2626A48-7CD3-429B-89FA-B61EC6EE3A4A" Win64="yes">
+        <Condition>ADDTOPATH = 1</Condition>
         <Environment Id="KovaPathEnv"
                      Name="PATH"
                      Value="[INSTALLDIR]"

--- a/src-tauri/wix/path-env.wxs
+++ b/src-tauri/wix/path-env.wxs
@@ -20,9 +20,24 @@
   makes MSI treat the whole component as absent for this install, which is
   the standard way to make a component optional; it does not affect the
   ComponentRef wiring in tauri.conf.json.
+
+  The <UI><DialogRef .../></UI> below is load-bearing, not decorative: a
+  WiX Fragment is an all-or-nothing linking unit (confirmed by inspecting
+  the actual built MSI with `msiinfo` after the checkbox page shipped with
+  no error but silently didn't exist - Dialog/Property/ControlEvent tables
+  had nothing from path-checkbox-dialog.wxs at all). tauri.conf.json's
+  componentRefs is what makes THIS Fragment reachable from the product;
+  nothing was pulling in path-checkbox-dialog.wxs's Fragment, so light.exe
+  dropped it whole, silently. Referencing PathOptDlg here - any single
+  symbol in that Fragment would do - pulls in the entire thing: the
+  Dialog, the ADDTOPATH Property, and both override Publish rows.
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
+    <UI>
+      <DialogRef Id="PathOptDlg" />
+    </UI>
+
     <DirectoryRef Id="INSTALLDIR">
       <Component Id="KovaPathEnv" Guid="D2626A48-7CD3-429B-89FA-B61EC6EE3A4A" Win64="yes">
         <Condition>ADDTOPATH = 1</Condition>


### PR DESCRIPTION
## Summary
- Closes #168 (reported by @a1880): Windows PATH registration was unconditional and always machine-wide via the MSI, with no way to skip it.
- NSIS `.exe` (per-user installer) now asks Yes/No before writing to the user's PATH (`HKCU`). Silent installs (`/S`) keep today's default (Yes).
- MSI (per-machine installer) gets a new wizard page with a 3-way choice — system PATH / my PATH only / don't add — backed by two `Environment` components (`System="yes"`/`"no"`) gated on a new `PATHSCOPE` property. Silent `msiexec` installs default to `PATHSCOPE=system` (today's only prior behaviour); `PATHSCOPE=user` or `PATHSCOPE=none` work from the command line too.
- The MSI's app files still always install per-machine (Tauri's WiX bundler has no per-user mode at all — confirmed against upstream, tauri-apps/tauri#13792 is still open); only the PATH registration's scope is independently selectable.
- README's Windows download row updated to describe both installers' PATH behaviour.

## Notable fix mid-branch
The first commit's MSI checkbox page silently never made it into the built installer — verified by downloading the actual test-build MSI and inspecting its tables with `msiinfo`. Root cause: WiX Fragments link as an all-or-nothing unit, and nothing referenced the new dialog's Fragment, so `light.exe` dropped it with no error. Fixed by anchoring it via `<DialogRef>` from the already-reachable `path-env.wxs` fragment; documented in code comments so it doesn't get re-broken.

## Test plan
- [x] NSIS: Yes/No PATH prompt appears; No skips the PATH write; verified on a Windows VM.
- [x] MSI: new page appears between install-directory and ready-to-install; all three radio choices verified on a Windows VM (system/user/none each produce the expected `HKLM`/`HKCU`/no PATH entry).
- [x] MSI tables verified directly with `msiinfo` against the built test artifact (Dialog, ControlEvent, RadioButton, Property, Component, Environment) before each VM test round.
- [x] Confirmed `HKCU` writes from the elevated per-machine MSI land in the launching user's own profile, not SYSTEM's.
- [ ] Full cross-platform smoke pass (macOS/Linux unaffected by this change, but worth a sanity build) before merge.
