### PR TITLE
docs: fix ad-hoc to ad hoc in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Commit messages follow `type(scope): summary` (`fix(toc): …`, `feat: …`) —
 ## Markdown syntax conventions
 
 This is the part that matters most for contributors adding a feature, since
-it's easy to accumulate one-off ad-hoc syntax over time. Kova currently uses
+it's easy to accumulate one-off ad hoc syntax over time. Kova currently uses
 four distinct forms, each with a specific job. If you're adding a new
 directive, find which category it belongs to below rather than inventing a
 fifth form.


### PR DESCRIPTION
## Description
This PR fixes phrase formatting in `CONTRIBUTING.md`.

## Details
Updated `ad-hoc` -> `ad hoc` under the Markdown syntax conventions section.