### PR TITLE
fix(import): preserve Marp ![bg] so overlay text survives import

### DIFF
--- a/src/engine/import/__tests__/marp.test.ts
+++ b/src/engine/import/__tests__/marp.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { isMarp, importMarp } from '../marp';
+import { parseDocument } from '../../parser/markdownToSlides';
 
 describe('isMarp', () => {
   it('detects marp:true frontmatter only', () => {
@@ -22,11 +23,29 @@ describe('isMarp', () => {
 });
 
 describe('importMarp', () => {
-  it('maps ![bg] to full-bleed and strips marp:true', () => {
+  it('preserves ![bg] as native bg (image-only → full-bleed via parser)', () => {
     const { markdown } = importMarp('---\nmarp: true\n---\n![bg](a.jpg)');
-    expect(markdown).toContain('<!-- layout:full-bleed -->');
-    expect(markdown).toContain('![](a.jpg)');
+    expect(markdown).toContain('![bg](a.jpg)');
+    expect(markdown).not.toContain('<!-- layout:full-bleed -->');
+    expect(markdown).not.toContain('![](a.jpg)');
     expect(markdown).not.toContain('marp: true');
+  });
+
+  it('preserves ![bg] + title so overlay text survives import (issue #169)', () => {
+    const { markdown } = importMarp(
+      '---\nmarp: true\n---\n![bg](hero.jpg)\n\n# Title on the photo\n\nBody text.',
+    );
+    expect(markdown).toContain('![bg](hero.jpg)');
+    expect(markdown).toContain('# Title on the photo');
+    expect(markdown).toContain('Body text.');
+    expect(markdown).not.toContain('<!-- layout:full-bleed -->');
+    expect(markdown).not.toContain('![](hero.jpg)');
+
+    // End-to-end: native parser must set backgroundImage (not full-bleed-only).
+    const { slides } = parseDocument(markdown);
+    expect(slides[0].backgroundImage?.src).toBe('hero.jpg');
+    expect(slides[0].layout).not.toBe('full-bleed');
+    expect(slides[0].title).toBe('Title on the photo');
   });
 
   it('drops a style block-scalar without leaking its CSS as frontmatter', () => {
@@ -43,9 +62,10 @@ describe('importMarp', () => {
     expect(markdown).toContain('show_slide_number: true'); // paginate after the block still parsed
   });
 
-  it('maps ![bg left] to split', () => {
+  it('preserves ![bg left] as native bg (split via parser)', () => {
     const { markdown } = importMarp('---\nmarp: true\n---\n![bg left](a.jpg)\n\n# Title');
-    expect(markdown).toContain('<!-- layout:split -->');
+    expect(markdown).toContain('![bg left](a.jpg)');
+    expect(markdown).not.toContain('<!-- layout:split -->');
   });
 
   it('maps frontmatter size and paginate', () => {
@@ -89,21 +109,34 @@ describe('importMarp', () => {
     expect(markdown.split(/^---$/m).length).toBeGreaterThanOrEqual(2);
   });
 
-  it('maps ![bg right] to split', () => {
+  it('preserves ![bg right] as native bg', () => {
     const { markdown } = importMarp('---\nmarp: true\n---\n![bg right](a.jpg)\n\n# Title');
-    expect(markdown).toContain('<!-- layout:split -->');
+    expect(markdown).toContain('![bg right](a.jpg)');
+    expect(markdown).not.toContain('<!-- layout:split -->');
   });
 
-  it('logs bg-sizing when fit/cover modifiers are present', () => {
-    const { dropped } = importMarp('---\nmarp: true\n---\n![bg fit](a.jpg)');
+  it('maps ![bg fit] to native contain and does not drop the line', () => {
+    const { markdown, dropped } = importMarp('---\nmarp: true\n---\n![bg fit](a.jpg)');
+    expect(markdown).toContain('![bg contain](a.jpg)');
+    expect(dropped).not.toContain('bg-sizing');
+  });
+
+  it('logs bg-sizing for percentage modifiers we do not map', () => {
+    const { markdown, dropped } = importMarp('---\nmarp: true\n---\n![bg left:40%](a.jpg)\n\n# Title');
     expect(dropped).toContain('bg-sizing');
+    expect(markdown).toContain('![bg left](a.jpg)');
   });
 
   it('drops a second background image on the same slide', () => {
     const { markdown, dropped } = importMarp('---\nmarp: true\n---\n![bg](a.jpg)\n![bg](b.jpg)');
     expect(dropped).toContain('bg-extra');
-    expect(markdown).toContain('![](a.jpg)');
-    expect(markdown).not.toContain('![](b.jpg)');
+    expect(markdown).toContain('![bg](a.jpg)');
+    expect(markdown).not.toContain('![bg](b.jpg)');
+  });
+
+  it('preserves bg paths that contain spaces', () => {
+    const { markdown } = importMarp('---\nmarp: true\n---\n![bg](my photo.jpg)\n\n# Title');
+    expect(markdown).toContain('![bg](my photo.jpg)');
   });
 
   it('strips Marp image size keywords from alt text', () => {

--- a/src/engine/import/marp.ts
+++ b/src/engine/import/marp.ts
@@ -3,8 +3,14 @@
 // fidelity, and multi-bg tiling are deliberately dropped (Tier 2). Per-slide
 // text colour (`_color` / `_class: invert`) is now mapped onto Kova's native
 // `<!-- color -->` / `<!-- _class: invert -->` directives.
+//
+// `![bg]` lines are preserved as native `![bg…](…)` so the parser can choose
+// full-bleed (image-only) vs text-over-background (issue #169) — previously
+// every bare `![bg]` was forced to `layout:full-bleed` + a plain image, which
+// dropped overlay title/body.
 
 import yaml from 'js-yaml';
+import { formatBgLine, parseBgLine } from '../parser/bgImage';
 
 export interface MarpImportResult {
   markdown: string;
@@ -13,9 +19,6 @@ export interface MarpImportResult {
 }
 
 const FM_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
-// A background-image line, e.g. `![bg left:40%](path.jpg)`. Captures the
-// modifier string and the URL (first whitespace-delimited token inside `()`).
-const BG_LINE = /^!\[bg([^\]]*)\]\(\s*([^)\s]+)[^)]*\)\s*$/;
 const SIZE_KW = /\b[wh]:\d+%?/g;
 const COMMENT = /<!--([\s\S]*?)-->/g;
 
@@ -113,17 +116,18 @@ function transformSlide(slide: string, dropTag: (l: string) => string): string {
   const out: string[] = [];
   let bgUsed = false;
 
-  // Pass 1: background-image lines → layout directive + plain image.
+  // Pass 1: preserve Marp `![bg…](…)` as native bg lines so overlay text is
+  // kept (native parser sets backgroundImage when the slide has title/body).
   for (const line of slide.split(/\r?\n/)) {
-    const bg = line.match(BG_LINE);
-    if (bg) {
-      const mods = bg[1];
-      // logged only — image is kept, just unsized
-      if (/(fit|cover|\d+%|:\s*\d)/.test(mods)) dropTag('bg-sizing');
+    const parsed = parseBgLine(line);
+    if (parsed) {
+      // Percentage / explicit Marp size tokens we don't map — log and drop.
+      // `fit`/`contain` are kept via formatBgLine; bare `cover` is the default.
+      const mods = (line.match(/^!\[bg([^\]]*)\]/)?.[1] ?? '');
+      if (/(\d+%|:\s*\d)/.test(mods)) dropTag('bg-sizing');
       if (bgUsed) { out.push(dropTag('bg-extra')); continue; }
       bgUsed = true;
-      const layout = /\b(left|right)\b/.test(mods) ? 'split' : 'full-bleed';
-      out.push(`<!-- layout:${layout} -->`, `![](${bg[2]})`);
+      out.push(formatBgLine(parsed));
       continue;
     }
     out.push(line);


### PR DESCRIPTION
## Summary
- Fixes #169: Marp import no longer forces `<!-- layout:full-bleed -->` + `![](…)` for bare `![bg]`.
- Emits native `![bg…](…)` (left/right / contain/fit) via the shared `bgImage` helpers so image-only slides still become full-bleed and slides with title/body keep the photo as `backgroundImage`.
- Paths with spaces are preserved (same regex as the native parser).
- Percentage sizing Marp tokens still log `bg-sizing` and are stripped from the alt.

## Test plan
- [x] `npx vitest run src/engine/import/__tests__/marp.test.ts`
- [x] `npx tsc --noEmit`
- [x] Import a Marp deck with `![bg](hero.jpg)` + `# Title` — title overlays the image
- [x] Import image-only `![bg](a.jpg)` — still full-bleed
- [x] Import `![bg left]` / `![bg fit]` — left split / contain sizing

Closes #169