### PR TITLE
fix(export): stop PPTX from garbling inline KaTeX text

### DIFF
--- a/src/engine/export/__tests__/exportPptxKatex.test.ts
+++ b/src/engine/export/__tests__/exportPptxKatex.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { exportToPptx } from '../exportPptx';
+import { parseDocument } from '../../parser/markdownToSlides';
+import { DEFAULT_THEME } from '../../theme';
+
+// Regression for issue #170: KaTeX inline HTML has MathML + visual layers;
+// walking both text nodes used to garble PPTX runs (e.g. "x2x^2x2").
+
+async function slide1Text(md: string): Promise<string> {
+  const { slides } = parseDocument(md);
+  const res = await exportToPptx(slides, {}, DEFAULT_THEME, 'en');
+  const zip = await JSZip.loadAsync(res.base64, { base64: true });
+  const xml = await zip.file('ppt/slides/slide1.xml')!.async('string');
+  // Concatenate all <a:t>…</a:t> text runs in document order.
+  return [...xml.matchAll(/<a:t[^>]*>([^<]*)<\/a:t>/g)].map((m) => m[1]).join('');
+}
+
+describe('exportPptx inline KaTeX (issue #170)', () => {
+  it('exports a single TeX fragment, not duplicated MathML+HTML text', async () => {
+    const text = await slide1Text(
+      '---\ntitle: Inline math\n---\n\n## Quadratic\n\nThe equation $x^2$ is quadratic.\n',
+    );
+    expect(text).toContain('x^2');
+    expect(text).toContain('The equation');
+    expect(text).toContain('is quadratic');
+    // The classic garble pattern from walking both KaTeX layers.
+    expect(text).not.toMatch(/x2x\^2x2/);
+    expect(text).not.toMatch(/x2x2/);
+  });
+
+  it('handles multiple inline formulas in one paragraph', async () => {
+    const text = await slide1Text(
+      '## Slide\n\nCompare $a$ and $b^2$ carefully.\n',
+    );
+    expect(text).toContain('a');
+    expect(text).toContain('b^2');
+    expect(text).toContain('Compare');
+    expect(text).not.toMatch(/aab\^2/);
+  });
+});

--- a/src/engine/export/__tests__/exportPptxKatex.test.ts
+++ b/src/engine/export/__tests__/exportPptxKatex.test.ts
@@ -39,4 +39,30 @@ describe('exportPptx inline KaTeX (issue #170)', () => {
     expect(text).toContain('Compare');
     expect(text).not.toMatch(/aab\^2/);
   });
+
+  it('does not garble inline math in table cells (stripHtml path)', async () => {
+    const text = await slide1Text(
+      '## Table\n\n| formula |\n|--------|\n| $x^2$ |\n',
+    );
+    expect(text).toContain('x^2');
+    expect(text).not.toMatch(/x2x\^2x2/);
+    expect(text).not.toMatch(/x2x2/);
+  });
+
+  it('does not garble inline math in list items', async () => {
+    const text = await slide1Text(
+      '## List\n\n- The term $x^2$ appears here\n',
+    );
+    expect(text).toContain('x^2');
+    expect(text).toContain('The term');
+    expect(text).not.toMatch(/x2x\^2x2/);
+  });
+
+  it('does not garble inline math in a blockquote', async () => {
+    const text = await slide1Text(
+      '## Quote\n\n> Energy is $E=mc^2$ roughly\n',
+    );
+    expect(text).toContain('E=mc^2');
+    expect(text).not.toMatch(/Emc2E=mc\^2/);
+  });
 });

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -859,6 +859,16 @@ const HLJS_STYLE: Record<string, { color: string; bold?: true; italic?: true }> 
 
 type PptxRun = { text: string; options: Record<string, unknown> };
 
+// KaTeX emits both MathML (accessible) and HTML layers. Walking both text
+// nodes concatenates duplicated runs (e.g. "x2x^2x2") — issue #170. Prefer
+// the TeX source from the MathML annotation when present.
+function katexTexSource(el: Element): string | null {
+  if (!el.classList?.contains('katex')) return null;
+  const ann = el.querySelector('annotation[encoding="application/x-tex"]');
+  const tex = ann?.textContent?.trim();
+  return tex || null;
+}
+
 // Walk markdown-generated HTML (bold, italic, code, links) into PptxGenJS runs.
 function htmlToInlineRuns(
   html: string,
@@ -889,27 +899,22 @@ function htmlToInlineRuns(
       const el = node as Element;
       const tag = el.tagName.toLowerCase();
 
-      // KaTeX emits both MathML (accessible) and HTML layers; walking both
-      // concatenates duplicated text (e.g. "x2x^2x2"). Prefer the TeX source
-      // from the MathML annotation and skip the rest of the subtree (issue #170).
+      const tex = katexTexSource(el);
+      if (tex !== null) {
+        runs.push({
+          text: tex,
+          options: {
+            color,
+            italic: true,
+            ...(bold ? { bold: true } : {}),
+            ...(href ? { hyperlink: { url: href } } : {}),
+          },
+        });
+        return;
+      }
+      // Fallback: strip MathML and walk only the visual HTML layer once.
       if (el.classList?.contains('katex')) {
-        const ann = el.querySelector('annotation[encoding="application/x-tex"]');
-        const tex = ann?.textContent?.trim();
-        if (tex) {
-          runs.push({
-            text: tex,
-            options: {
-              color,
-              italic: true,
-              ...(bold ? { bold: true } : {}),
-              ...(href ? { hyperlink: { url: href } } : {}),
-            },
-          });
-          return;
-        }
-        // Fallback: strip MathML and walk only the visual HTML layer once.
-        const mathml = el.querySelector('.katex-mathml');
-        mathml?.remove();
+        el.querySelector('.katex-mathml')?.remove();
       }
 
       const isBold = tag === 'strong' || tag === 'b';
@@ -1546,7 +1551,33 @@ function stripHtml(html: string): string {
   // entity decoding — inlineToHtml() escapes & < > into entities, and
   // textContent decodes them back correctly (including numeric entities),
   // instead of leaving e.g. "AT&amp;T" as literal text in the exported pptx.
+  // Walk with the same KaTeX helper as htmlToInlineRuns so table cells don't
+  // reintroduce the MathML+HTML duplication (issue #170 / PR #174 review).
   const div = document.createElement('div');
   div.innerHTML = withAltText;
-  return div.textContent ?? '';
+  return flattenHtmlText(div);
+}
+
+/** Plain-text flatten that collapses KaTeX roots to a single TeX fragment. */
+function flattenHtmlText(root: Node): string {
+  let out = '';
+  function walk(node: Node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      out += node.textContent ?? '';
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+    const el = node as Element;
+    const tex = katexTexSource(el);
+    if (tex !== null) {
+      out += tex;
+      return;
+    }
+    if (el.classList?.contains('katex')) {
+      el.querySelector('.katex-mathml')?.remove();
+    }
+    for (const child of node.childNodes) walk(child);
+  }
+  walk(root);
+  return out;
 }

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -888,6 +888,30 @@ function htmlToInlineRuns(
     } else if (node.nodeType === Node.ELEMENT_NODE) {
       const el = node as Element;
       const tag = el.tagName.toLowerCase();
+
+      // KaTeX emits both MathML (accessible) and HTML layers; walking both
+      // concatenates duplicated text (e.g. "x2x^2x2"). Prefer the TeX source
+      // from the MathML annotation and skip the rest of the subtree (issue #170).
+      if (el.classList?.contains('katex')) {
+        const ann = el.querySelector('annotation[encoding="application/x-tex"]');
+        const tex = ann?.textContent?.trim();
+        if (tex) {
+          runs.push({
+            text: tex,
+            options: {
+              color,
+              italic: true,
+              ...(bold ? { bold: true } : {}),
+              ...(href ? { hyperlink: { url: href } } : {}),
+            },
+          });
+          return;
+        }
+        // Fallback: strip MathML and walk only the visual HTML layer once.
+        const mathml = el.querySelector('.katex-mathml');
+        mathml?.remove();
+      }
+
       const isBold = tag === 'strong' || tag === 'b';
       // '#' is escUrl's sentinel for a stripped/invalid href (see markdownToSlides.ts) — never link to it.
       const linkHref = tag === 'a' ? el.getAttribute('href') : null;


### PR DESCRIPTION
## Summary
- Fixes #170: PPTX export no longer concatenates KaTeX MathML + HTML text layers into garbled runs like `x2x^2x2`.
- `htmlToInlineRuns` detects `.katex` roots and emits the `application/x-tex` annotation once (italic), matching a readable inline formula in PowerPoint.
- Adds `exportPptxKatex.test.ts` regression coverage for single and multiple inline formulas.

## Test plan
- [x] `npx vitest run src/engine/export/__tests__/exportPptxKatex.test.ts`
- [x] `npx tsc --noEmit`
- [x] Export a deck with `$x^2$` in a paragraph — PPTX body shows `x^2`, not `x2x^2x2`
- [x] Preview still renders KaTeX normally (unchanged)

Closes #170