### PR TITLE
fix(parser): ignore ??? speaker-note marker inside ~~~ fences

### DIFF
--- a/src/engine/__tests__/speakerNotes.test.ts
+++ b/src/engine/__tests__/speakerNotes.test.ts
@@ -58,9 +58,9 @@ describe('extractSpeakerNotes', () => {
     expect(notes).toBe('Note one\n\n???\n\nNote two');
   });
 
-  it('splits on ??? inside a ~~~ tilde fence (only backtick fences are recognised)', () => {
-    const { content, notes } = extractSpeakerNotes('~~~\n???\n~~~\n\nAfter');
-    expect(content).toBe('~~~');
-    expect(notes).toBe('~~~\n\nAfter');
+  it('ignores ??? inside a tilde fence (issue #179)', () => {
+    const { content, notes } = extractSpeakerNotes('~~~\n???\n~~~\n\n???\n\nReal notes');
+    expect(content).toContain('???'); // the one inside the fence stays
+    expect(notes).toBe('Real notes');
   });
 });

--- a/src/engine/parser/speakerNotes.ts
+++ b/src/engine/parser/speakerNotes.ts
@@ -5,7 +5,8 @@ export function extractSpeakerNotes(slideContent: string): { content: string; no
 
   for (let i = 0; i < lines.length; i++) {
     const t = lines[i].trim();
-    if (t.startsWith('```')) inFence = !inFence;
+    // Match backtick and tilde fences (CommonMark); same as bgImage / slide split.
+    if (/^(`{3,}|~{3,})/.test(t)) inFence = !inFence;
     if (!inFence && t === '???') {
       return {
         content: lines.slice(0, i).join('\n').trim(),


### PR DESCRIPTION
## Summary
- Fixes #179: `extractSpeakerNotes` now treats `~~~` fences like backtick fences when looking for `???`.
- Flips the existing unit test that previously encoded the wrong behaviour.

## Test plan
- [x] `npx vitest run src/engine/__tests__/speakerNotes.test.ts`
- [x] Deck with `???` inside `~~~` keeps that line in the body; real notes still split on a standalone `???`

Closes #179