### PR TITLE
fix(parser): allow mailto: and tel: schemes on markdown links

### DIFF
--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -318,6 +318,18 @@ describe('element parsing', () => {
     expect(para?.type === 'paragraph' && para.html).toContain('<a href="#">link text</a>');
   });
 
+  it('preserves mailto: links (issue #176)', () => {
+    const { slides } = parseDocument(doc('## Slide\n\n[Email me](mailto:ada@example.com)\n'));
+    const para = slides[0].elements.find((e) => e.type === 'paragraph');
+    expect(para?.type === 'paragraph' && para.html).toContain('<a href="mailto:ada@example.com">Email me</a>');
+  });
+
+  it('preserves tel: links (issue #176)', () => {
+    const { slides } = parseDocument(doc('## Slide\n\n[Call](tel:+15551212)\n'));
+    const para = slides[0].elements.find((e) => e.type === 'paragraph');
+    expect(para?.type === 'paragraph' && para.html).toContain('<a href="tel:+15551212">Call</a>');
+  });
+
   it('leaves plain table cell text unchanged', () => {
     const { slides } = parseDocument(doc([
       '## Slide',

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -676,6 +676,8 @@ function referenceInlineToHtml(raw: string): string {
 
 function escUrl(url: string): string {
   const lower = url.trim().toLowerCase();
+  // Images stay on the network/local schemes; links also allow mailto:/tel:
+  // via escLinkUrl (issue #176).
   const ALLOWED = ['https:', 'http:', 'asset:', 'tauri:'];
   if (!ALLOWED.some(s => lower.startsWith(s))) return '#';
   return url.replace(/"/g, '%22');
@@ -692,11 +694,16 @@ const BARE_HOST_RE = /^[^\s/?#]+\.[a-z]{2,}(?:[/?#]|$)/i;
 // expect them to just work (issue #142), unlike images which are normally
 // local files. Treat protocol-relative and bare-host links as https; anything
 // else unrecognised still falls through to escUrl's allow-list/strip.
+// Contact schemes (mailto:/tel:) are allowed for links only (issue #176).
 function escLinkUrl(url: string): string {
   const trimmed = url.trim();
   if (trimmed.startsWith('//')) return escUrl('https:' + trimmed);
   if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && BARE_HOST_RE.test(trimmed)) {
     return escUrl('https://' + trimmed);
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith('mailto:') || lower.startsWith('tel:')) {
+    return trimmed.replace(/"/g, '%22');
   }
   return escUrl(trimmed);
 }


### PR DESCRIPTION
## Summary
- Fixes #176: `[Email](mailto:…)` / `[Call](tel:…)` keep their href instead of becoming `#`.
- Applied in `escLinkUrl` only so image `escUrl` stays strict.
- Unit tests for mailto + tel (and javascript: still stripped).

## Test plan
- [x] `npx vitest run src/engine/__tests__/parser.test.ts -t "mailto|tel:"`
- [ ] Click a mailto link in preview — opens mail client / correct href

Closes #176