### PR TITLE
fix(export): preserve strikethrough in PPTX runs

### DIFF
--- a/src/engine/export/__tests__/exportPptxStrike.test.ts
+++ b/src/engine/export/__tests__/exportPptxStrike.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { exportToPptx } from '../exportPptx';
+import { DEFAULT_THEME } from '../../theme';
+import type { Slide, SlideElement } from '../../types';
+
+function para(html: string, text = html.replace(/<[^>]+>/g, '')): SlideElement {
+  return { type: 'paragraph', text, html };
+}
+
+function makeSlide(elements: SlideElement[]): Slide {
+  return {
+    index: 0, raw: '', title: 'Edits', titleLevel: 2,
+    elements, speakerNotes: '', references: [], layout: 'title-content', hidden: false,
+  };
+}
+
+async function slideXml(slide: Slide): Promise<string> {
+  const res = await exportToPptx([slide], {}, DEFAULT_THEME, 'en');
+  const zip = await JSZip.loadAsync(res.base64, { base64: true });
+  return zip.file('ppt/slides/slide1.xml')!.async('string');
+}
+
+describe('exportPptx strikethrough (issue #177)', () => {
+  it('emits strike formatting for <del> runs in slide1.xml', async () => {
+    const xml = await slideXml(makeSlide([para('This is <del>old</del> and <strong>new</strong>.')]));
+    // pptxgenjs encodes boolean strike as <a:strike val="sngStrike"/>.
+    expect(xml).toContain('sngStrike');
+    expect(xml).toContain('old');
+  });
+
+  it('emits strike formatting for <s> runs', async () => {
+    const xml = await slideXml(makeSlide([para('use <s>legacy</s> API')]));
+    expect(xml).toContain('sngStrike');
+    expect(xml).toContain('legacy');
+  });
+});

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -881,7 +881,15 @@ function htmlToInlineRuns(
   div.innerHTML = html;
   const runs: PptxRun[] = [];
 
-  function walk(node: Node, bold: boolean, italic: boolean, isCode: boolean, color: string, href: string | null) {
+  function walk(
+    node: Node,
+    bold: boolean,
+    italic: boolean,
+    isCode: boolean,
+    strike: boolean,
+    color: string,
+    href: string | null,
+  ) {
     if (node.nodeType === Node.TEXT_NODE) {
       const text = node.textContent ?? '';
       if (!text) return;
@@ -892,6 +900,7 @@ function htmlToInlineRuns(
           ...(bold   ? { bold: true }   : {}),
           ...(italic ? { italic: true } : {}),
           ...(isCode ? { fontFace: codeFont } : {}),
+          ...(strike ? { strike: true } : {}),
           ...(href   ? { hyperlink: { url: href } } : {}),
         },
       });
@@ -907,6 +916,7 @@ function htmlToInlineRuns(
             color,
             italic: true,
             ...(bold ? { bold: true } : {}),
+            ...(strike ? { strike: true } : {}),
             ...(href ? { hyperlink: { url: href } } : {}),
           },
         });
@@ -927,6 +937,7 @@ function htmlToInlineRuns(
           bold   || isBold,
           italic || tag === 'em' || tag === 'i',
           isCode || tag === 'code',
+          strike || tag === 'del' || tag === 's',
           // Link colour wins over bold colour when both apply (e.g. a bolded
           // link, or bold text nested inside a link), matching the existing
           // precedent that link text always takes accentColor regardless of
@@ -940,7 +951,7 @@ function htmlToInlineRuns(
     }
   }
 
-  for (const child of div.childNodes) walk(child, false, false, false, defaultColor, null);
+  for (const child of div.childNodes) walk(child, false, false, false, false, defaultColor, null);
   return runs.length > 0 ? runs : [{ text: stripHtml(html) || ' ', options: { color: defaultColor } }];
 }
 


### PR DESCRIPTION
## Summary
- Fixes #177: `htmlToInlineRuns` tracks `<del>` / `<s>` and sets pptxgenjs `strike` on text runs.
- Regression test asserts `sngStrike` appears in `slide1.xml` for struck content.

## Test plan
- [x] `npx vitest run src/engine/export/__tests__/exportPptxStrike.test.ts`
- [ ] Export a deck with `~~old~~` and confirm strikethrough in PowerPoint / Keynote

Closes #177