### PR TITLE
fix(parser): allowlist <u> so Mod-U underline reaches slides

### DIFF
--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -365,6 +365,19 @@ describe('inline HTML generation', () => {
     expect(para?.type === 'paragraph' && para.html).toContain('<em>italic</em>');
   });
 
+  it('preserves <u> underline tags from the editor (issue #175)', () => {
+    const { slides } = parseDocument(doc('## Slide\n\nThis is <u>underlined</u> text.\n'));
+    const para = slides[0].elements.find((e) => e.type === 'paragraph');
+    expect(para?.type === 'paragraph' && para.html).toContain('<u>underlined</u>');
+  });
+
+  it('strips non-allowlisted inline HTML tags', () => {
+    const { slides } = parseDocument(doc('## Slide\n\nHello <span>world</span>.\n'));
+    const para = slides[0].elements.find((e) => e.type === 'paragraph');
+    expect(para?.type === 'paragraph' && para.html).toContain('world');
+    expect(para?.type === 'paragraph' && para.html).not.toContain('<span>');
+  });
+
   it('escapes HTML entities in text nodes', () => {
     const { slides } = parseDocument(doc('## Slide\n\n1 < 2 & 3 > 0\n'));
     const para = slides[0].elements.find((e) => e.type === 'paragraph');

--- a/src/engine/export/__tests__/exportPptxUnderline.test.ts
+++ b/src/engine/export/__tests__/exportPptxUnderline.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { exportToPptx } from '../exportPptx';
+import { DEFAULT_THEME } from '../../theme';
+import type { Slide, SlideElement } from '../../types';
+
+function para(html: string, text = html.replace(/<[^>]+>/g, '')): SlideElement {
+  return { type: 'paragraph', text, html };
+}
+
+function makeSlide(elements: SlideElement[]): Slide {
+  return {
+    index: 0, raw: '', title: 'Title', titleLevel: 2,
+    elements, speakerNotes: '', references: [], layout: 'title-content', hidden: false,
+  };
+}
+
+async function slideXml(slide: Slide): Promise<string> {
+  const res = await exportToPptx([slide], {}, DEFAULT_THEME, 'en');
+  const zip = await JSZip.loadAsync(res.base64, { base64: true });
+  return zip.file('ppt/slides/slide1.xml')!.async('string');
+}
+
+describe('exportPptx underline (issue #175)', () => {
+  it('emits underline formatting for <u> runs in slide1.xml', async () => {
+    const xml = await slideXml(makeSlide([para('This is <u>underlined</u> text.')]));
+    // pptxgenjs encodes underline: { style: 'sng' } as u="sng" on <a:rPr>.
+    expect(xml).toMatch(/\bu="sng"/);
+    expect(xml).toContain('underlined');
+  });
+});

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -887,6 +887,7 @@ function htmlToInlineRuns(
     italic: boolean,
     isCode: boolean,
     strike: boolean,
+    underline: boolean,
     color: string,
     href: string | null,
   ) {
@@ -901,6 +902,7 @@ function htmlToInlineRuns(
           ...(italic ? { italic: true } : {}),
           ...(isCode ? { fontFace: codeFont } : {}),
           ...(strike ? { strike: true } : {}),
+          ...(underline ? { underline: { style: 'sng' } } : {}),
           ...(href   ? { hyperlink: { url: href } } : {}),
         },
       });
@@ -917,6 +919,7 @@ function htmlToInlineRuns(
             italic: true,
             ...(bold ? { bold: true } : {}),
             ...(strike ? { strike: true } : {}),
+            ...(underline ? { underline: { style: 'sng' } } : {}),
             ...(href ? { hyperlink: { url: href } } : {}),
           },
         });
@@ -938,6 +941,7 @@ function htmlToInlineRuns(
           italic || tag === 'em' || tag === 'i',
           isCode || tag === 'code',
           strike || tag === 'del' || tag === 's',
+          underline || tag === 'u',
           // Link colour wins over bold colour when both apply (e.g. a bolded
           // link, or bold text nested inside a link), matching the existing
           // precedent that link text always takes accentColor regardless of
@@ -951,7 +955,7 @@ function htmlToInlineRuns(
     }
   }
 
-  for (const child of div.childNodes) walk(child, false, false, false, false, defaultColor, null);
+  for (const child of div.childNodes) walk(child, false, false, false, false, false, defaultColor, null);
   return runs.length > 0 ? runs : [{ text: stripHtml(html) || ' ', options: { color: defaultColor } }];
 }
 

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -653,6 +653,13 @@ function inlineToHtml(children: Node[]): string {
           return `<code>${escHtml(node.value as string)}</code>`;
         }
       }
+      // Raw HTML inlines from the editor (e.g. Mod-U → <u>…</u>). remark emits
+      // bare `html` nodes with no children, so the default branch would drop them.
+      case 'html': {
+        const v = String(node.value ?? '').trim().toLowerCase();
+        if (v === '<u>' || v === '</u>') return String(node.value).trim();
+        return '';
+      }
       default:            return node.children ? inlineToHtml(node.children) : '';
     }
   }).join('');


### PR DESCRIPTION
## Summary
- Fixes #175: allowlist `<u>`/`</u>` in `inlineToHtml` so editor Mod-U survives to preview/PDF.
- PPTX `htmlToInlineRuns` maps `<u>` to underline runs (`u="sng"` in slide XML).
- Parser + PPTX regression tests.

## Test plan
- [x] `npx vitest run` for underline parser + `exportPptxUnderline` tests
- [x] Mod-U in editor → underlined text in live preview
- [x] Export PPTX and confirm underline in PowerPoint / Keynote

Closes #175