### PR TITLE
docs: fix document title and Title Case section headings in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
-# Security
+# Security Policy
 
-## Reporting a vulnerability
+## Reporting a Vulnerability
 
 Report privately via [GitHub Security
 Advisories](https://github.com/KovaMD/Kova/security/advisories/new) — visible
@@ -8,7 +8,7 @@ only to you and the maintainers until a fix ships. Or ping us in the [Matrix
 room](https://matrix.to/#/#kova-md:matrix.org) and we'll open the advisory.
 Please don't use public issues. We aim to acknowledge within a few days.
 
-## Verifying a download
+## Verifying a Download
 
 You don't have to trust the release binaries blindly — every release can be
 checked back to the source.
@@ -43,7 +43,7 @@ The APT and RPM repositories (`deb.kova.md`, `rpm.kova.md`) are GPG-signed;
 `apt`/`dnf` verify signatures automatically once the key is added (see the
 README). Desktop auto-updates are signed with Tauri's updater key.
 
-## What runs on the code
+## What Runs on the Code
 
 - Dependency and code scanning via [Snyk](https://snyk.io) on pull requests.
 - Releases are built only from tagged commits on this repository, in GitHub


### PR DESCRIPTION
## Description
This PR updates the H1 document title and section heading Title Case formatting in `SECURITY.md`.

## Details
1. Updated document header (`# Security` $\to$ `# Security Policy`).
2. Updated section headers (`## Reporting a vulnerability` $\to$ `## Reporting a Vulnerability`, `## Verifying a download` $\to$ `## Verifying a Download`, and `## What runs on the code` $\to$ `## What Runs on the Code`).