### PR TITLE
fix(cli): honour --check when paired with --import

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -773,6 +773,24 @@ mod tests {
     }
 
     #[test]
+    fn check_with_import_keeps_check_modifier() {
+        // --check used to be accepted then ignored for --import (issue #178).
+        // The parser must keep the modifier so the frontend can gate the write.
+        let run = expect_run(&["--check", "--import", "marp", "in.md", "out.md"]);
+        assert!(run.check);
+        assert_eq!(
+            run.action,
+            Some(Action::Import {
+                format: ImportFormat::Marp,
+                input: "in.md".into(),
+                output: "out.md".into(),
+            })
+        );
+        let reversed = expect_run(&["--import", "marp", "in.md", "out.md", "--check"]);
+        assert!(reversed.check);
+    }
+
+    #[test]
     fn theme_equals_and_space_forms_match() {
         let a = expect_run(&["--theme=gruvbox-dark", "--present", "t.md"]);
         let b = expect_run(&["--theme", "gruvbox-dark", "--present", "t.md"]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { I18nProvider, useLocaleTranslator, formatFallbackDate } from './i18n';
 
 import { parseDocument } from './engine/parser/markdownToSlides';
 import { collectDiagnostics, formatCheckReport } from './engine/parser/diagnostics';
+import { evaluateImportCheck } from './engine/cli/importCheckGate';
 import { extractFrontmatter, patchFrontmatter } from './engine/parser/frontmatter';
 import { parseBgLine, formatBgLine } from './engine/parser/bgImage';
 import { fetchUpdate } from './engine/updater';
@@ -149,7 +150,8 @@ async function knownThemeIds(): Promise<string[]> {
 // runs entirely outside React state, and the process exits from here.
 // Mirrors the exact conversion each in-app import flow uses (ImportPptxModal,
 // ImportUrlModal, the Marp-detection prompt) so CLI output matches the GUI's.
-async function runCliImport(imp: PendingImport): Promise<void> {
+// When `--check` is also set, validate markdown before writing (issue #178).
+async function runCliImport(imp: PendingImport, check: boolean): Promise<void> {
   const finish = async (report: string) => {
     await invoke('cli_stdout', { text: report }).catch(() => {});
     await invoke('cli_exit', { code: 0 }).catch(() => {});
@@ -157,10 +159,29 @@ async function runCliImport(imp: PendingImport): Promise<void> {
   const fail = async (message: string) => {
     await invoke('cli_exit', { message, code: 1 }).catch(() => {});
   };
+  const checkCtx = async (docDir: string) => ({
+    docDir,
+    themeIds: await knownThemeIds(),
+    fileExists: (p: string) =>
+      invoke<boolean>('path_exists', { path: p }).then(Boolean).catch(() => false),
+  });
+  /** Run --check on markdown; returns false when the write must be skipped. */
+  const gate = async (markdown: string, label: string, docDir: string): Promise<boolean> => {
+    const result = await evaluateImportCheck(check, markdown, label, await checkCtx(docDir));
+    if (!result.enabled) return true;
+    await invoke('cli_stdout', { text: result.report }).catch(() => {});
+    if (result.errors > 0) {
+      await invoke('cli_exit', { code: 1 }).catch(() => {});
+      return false;
+    }
+    return true;
+  };
 
   try {
     if (imp.format === 'marp') {
       const text: string = await invoke('read_file', { path: imp.input });
+      // Check the import input before converting / writing (issue #178).
+      if (!(await gate(text, imp.input, dirOf(imp.input)))) return;
       const { markdown, dropped } = importMarp(text);
       await invoke('write_file', { path: imp.output, content: markdown });
       const suffix = dropped.length > 0 ? ` (simplified: ${dropped.join(', ')})` : '';
@@ -169,9 +190,11 @@ async function runCliImport(imp: PendingImport): Promise<void> {
     }
     if (imp.format === 'pptx') {
       // Media referenced by the deck is extracted alongside the output file,
-      // same as the in-app import modal.
+      // same as the in-app import modal. PPTX itself isn't Markdown — check
+      // the converted deck before writing so --check still gates the output.
       const parsed = await parsePptx(imp.input, dirOf(imp.output));
       const markdown = pptxToMarkdown(parsed);
+      if (!(await gate(markdown, imp.output, dirOf(imp.output)))) return;
       await invoke('write_file', { path: imp.output, content: markdown });
       const lines = [`wrote '${imp.output}' (${parsed.slides.length} slides)`];
       for (const w of parsed.warnings) lines.push(`warning: ${w}`);
@@ -181,6 +204,7 @@ async function runCliImport(imp: PendingImport): Promise<void> {
     // url — fetched verbatim, no conversion (matches ImportUrlModal: if the
     // remote content is a Marp deck, that's detected on open, not on fetch).
     const text: string = await invoke('fetch_url_text', { url: imp.input });
+    if (!(await gate(text, imp.output, dirOf(imp.output)))) return;
     await invoke('write_file', { path: imp.output, content: text });
     await finish(`wrote '${imp.output}'`);
   } catch (err) {
@@ -1042,7 +1066,7 @@ export default function App() {
       // runs and exits before any of the present/check logic below.
       if (cli?.import) {
         coldLoadStartedRef.current = true;
-        await runCliImport(cli.import);
+        await runCliImport(cli.import, cli.check);
         return;
       }
       // --present FILE, standalone --check FILE (which never shows a window:

--- a/src/engine/__tests__/importCheckGate.test.ts
+++ b/src/engine/__tests__/importCheckGate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateImportCheck } from '../cli/importCheckGate';
+import type { CheckContext } from '../parser/diagnostics';
+
+const ctx = (overrides: Partial<CheckContext> = {}): CheckContext => ({
+  docDir: '/deck',
+  themeIds: ['light', 'dark'],
+  fileExists: async () => true,
+  ...overrides,
+});
+
+const CLEAN = `---
+title: Test
+theme: dark
+---
+
+# Slide
+`;
+
+const BAD = `---
+title: Test
+---
+
+<!-- layout: not-a-real-layout -->
+
+# Slide
+`;
+
+describe('evaluateImportCheck (issue #178)', () => {
+  it('is a no-op when --check is off', async () => {
+    const result = await evaluateImportCheck(false, BAD, 'in.md', ctx());
+    expect(result).toEqual({ enabled: false });
+  });
+
+  it('reports a clean document with zero errors', async () => {
+    const result = await evaluateImportCheck(true, CLEAN, 'in.md', ctx());
+    expect(result.enabled).toBe(true);
+    if (!result.enabled) return;
+    expect(result.errors).toBe(0);
+    expect(result.report).toContain('0 error(s)');
+  });
+
+  it('surfaces errors so the caller can skip the write', async () => {
+    const result = await evaluateImportCheck(true, BAD, '/deck/in.md', ctx());
+    expect(result.enabled).toBe(true);
+    if (!result.enabled) return;
+    expect(result.errors).toBeGreaterThan(0);
+    expect(result.report).toContain('unknown layout');
+    expect(result.report).toContain('/deck/in.md');
+  });
+});

--- a/src/engine/cli/importCheckGate.ts
+++ b/src/engine/cli/importCheckGate.ts
@@ -1,0 +1,23 @@
+import { collectDiagnostics, formatCheckReport, type CheckContext } from '../parser/diagnostics';
+
+/** Result of optionally gating an import write with `kova --check`. */
+export type ImportCheckGate =
+  | { enabled: false }
+  | { enabled: true; report: string; errors: number };
+
+/**
+ * When `--check` is paired with `--import`, validate markdown content before
+ * writing the output file (issue #178). Returns a report for stdout and an
+ * error count; callers must skip the write and exit 1 when `errors > 0`.
+ */
+export async function evaluateImportCheck(
+  check: boolean,
+  content: string,
+  fileLabel: string,
+  ctx: CheckContext,
+): Promise<ImportCheckGate> {
+  if (!check) return { enabled: false };
+  const diags = await collectDiagnostics(content, ctx);
+  const { report, errors } = formatCheckReport(fileLabel, diags);
+  return { enabled: true, report, errors };
+}


### PR DESCRIPTION
## Summary
- Fixes #178: `kova --check --import …` validates markdown before writing output (no longer skips the check path).
- Marp/url: check the import input; PPTX: check the converted markdown before write.
- Errors print the usual check report to stdout and exit 1 without writing.
- Unit test for the gate helper + Rust CLI test that `--check` stays set with `--import`.

## Test plan
- [x] `npx vitest run src/engine/__tests__/importCheckGate.test.ts`
- [x] `cargo test check_with_import_keeps_check_modifier --lib`
- [x] `kova --check --import marp` with a bad layout in the input → report + exit 1, no output file
- [x] Same with a clean deck → writes output as before

Closes #178