### PR TITLE
fix(cli): rewrite Git host blob URLs to raw endpoints in CLI URL import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { ModalShell } from './components/ModalShell';
 import { InfoBanner } from './components/InfoBanner';
 import { isMarp, importMarp } from './engine/import/marp';
 import { parsePptx } from './engine/import/parsePptx';
+import { toRawUrl } from './utils/toRawUrl';
 import { pptxToMarkdown } from './engine/import/pptxToMarkdown';
 import { MissingThemeBanner } from './components/MissingThemeBanner';
 import { loadSettings, saveSettings, EDITOR_FONT_OPTIONS } from './store/settings';
@@ -201,9 +202,9 @@ async function runCliImport(imp: PendingImport, check: boolean): Promise<void> {
       await finish(lines.join('\n'));
       return;
     }
-    // url — fetched verbatim, no conversion (matches ImportUrlModal: if the
-    // remote content is a Marp deck, that's detected on open, not on fetch).
-    const text: string = await invoke('fetch_url_text', { url: imp.input });
+    // url — convert web blob URLs for Git hosts (matches ImportUrlModal)
+    const targetUrl = toRawUrl(imp.input);
+    const text: string = await invoke('fetch_url_text', { url: targetUrl });
     if (!(await gate(text, imp.output, dirOf(imp.output)))) return;
     await invoke('write_file', { path: imp.output, content: text });
     await finish(`wrote '${imp.output}'`);

--- a/src/components/ImportUrlModal.tsx
+++ b/src/components/ImportUrlModal.tsx
@@ -2,38 +2,11 @@ import { useState, useRef, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { useT } from '../i18n';
 import { ModalShell } from './ModalShell';
+import { toRawUrl } from '../utils/toRawUrl';
 
 interface ImportUrlModalProps {
   onImported: (text: string) => void;
   onClose: () => void;
-}
-
-// Convert standard web URLs for common Git hosts to their raw content equivalents.
-function toRawUrl(input: string): string {
-  try {
-    const u = new URL(input);
-
-    // GitHub: /user/repo/blob/branch/path → raw.githubusercontent.com/user/repo/branch/path
-    if (u.hostname === 'github.com') {
-      const m = u.pathname.match(/^(\/[^/]+\/[^/]+)\/blob(\/.+)$/);
-      if (m) return `https://raw.githubusercontent.com${m[1]}${m[2]}`;
-    }
-
-    // GitLab: /user/repo/-/blob/branch/path → /user/repo/-/raw/branch/path
-    if (u.hostname === 'gitlab.com' || u.hostname.endsWith('.gitlab.com')) {
-      const m = u.pathname.match(/^(.+\/-\/)blob(\/.+)$/);
-      if (m) return `${u.origin}${m[1]}raw${m[2]}`;
-    }
-
-    // Bitbucket: /user/repo/src/branch/path → /user/repo/raw/branch/path
-    if (u.hostname === 'bitbucket.org') {
-      const m = u.pathname.match(/^(\/[^/]+\/[^/]+)\/src(\/.+)$/);
-      if (m) return `${u.origin}${m[1]}/raw${m[2]}`;
-    }
-  } catch {
-    // Not a valid URL — pass through and let the backend error naturally.
-  }
-  return input;
 }
 
 export function ImportUrlModal({ onImported, onClose }: ImportUrlModalProps) {

--- a/src/utils/toRawUrl.ts
+++ b/src/utils/toRawUrl.ts
@@ -1,0 +1,27 @@
+// Convert standard web URLs for common Git hosts to their raw content equivalents.
+export function toRawUrl(input: string): string {
+  try {
+    const u = new URL(input);
+
+    // GitHub: /user/repo/blob/branch/path → raw.githubusercontent.com/user/repo/branch/path
+    if (u.hostname === 'github.com') {
+      const m = u.pathname.match(/^(\/[^/]+\/[^/]+)\/blob(\/.+)$/);
+      if (m) return `https://raw.githubusercontent.com${m[1]}${m[2]}`;
+    }
+
+    // GitLab: /user/repo/-/blob/branch/path → /user/repo/-/raw/branch/path
+    if (u.hostname === 'gitlab.com' || u.hostname.endsWith('.gitlab.com')) {
+      const m = u.pathname.match(/^(.+\/-\/)blob(\/.+)$/);
+      if (m) return `${u.origin}${m[1]}raw${m[2]}`;
+    }
+
+    // Bitbucket: /user/repo/src/branch/path → /user/repo/raw/branch/path
+    if (u.hostname === 'bitbucket.org') {
+      const m = u.pathname.match(/^(\/[^/]+\/[^/]+)\/src(\/.+)$/);
+      if (m) return `${u.origin}${m[1]}/raw${m[2]}`;
+    }
+  } catch {
+    // Not a valid URL — pass through and let the backend error naturally.
+  }
+  return input;
+}


### PR DESCRIPTION
## Description
This PR resolves issue #197 by extracting `toRawUrl` to a shared utility module and calling it in `runCliImport` (`src/App.tsx`).

## Details
- Extracted `toRawUrl` helper from `ImportUrlModal.tsx` to `src/utils/toRawUrl.ts`.
- Updates `runCliImport` to rewrite GitHub, GitLab, and Bitbucket web blob URLs to raw content endpoints prior to calling `fetch_url_text`.
- Aligns CLI `kova --import url` behavior with the GUI **Import from URL** modal.