### PR TITLE
fix(check): report warning diagnostic for invalid color directives

### DIFF
--- a/src/engine/parser/diagnostics.ts
+++ b/src/engine/parser/diagnostics.ts
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import { parseDocument } from './markdownToSlides';
+import { parseDocument, parseColorValue } from './markdownToSlides';
 import { localPathFromMediaSrc } from '../resolveMediaPath';
 import type { LayoutType, ListItem, Slide } from '../types';
 
@@ -134,6 +134,11 @@ export async function collectDiagnostics(content: string, ctx: CheckContext): Pr
     const layout = line.match(LAYOUT_COMMENT_RE);
     if (layout && !KNOWN_LAYOUTS.has(layout[1])) {
       diags.push({ line: i + 1, severity: 'error', message: `unknown layout '${layout[1]}'` });
+    }
+
+    const colorMatch = line.match(/<!--\s*(?:_?color)\s*:\s*([^\s-][^\n]*?)\s*-->/i);
+    if (colorMatch && !parseColorValue(colorMatch[1])) {
+      diags.push({ line: i + 1, severity: 'warning', message: `invalid color value '${colorMatch[1]}'` });
     }
 
     const directive = line.trimStart().match(DIRECTIVE_RE);

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -726,7 +726,7 @@ export type { Frontmatter };
 // matched in full (opening prefix through closing paren) and rejected if they
 // contain quotes or CSS metacharacters (`;`, `{`, `}`). Spaces inside the
 // parentheses are permitted (e.g. `rgb(0, 0, 0)`).
-function parseColorValue(raw: string): string | undefined {
+export function parseColorValue(raw: string): string | undefined {
   const v = raw.trim();
   if (!v) return undefined;
   if (/^#[0-9a-fA-F]{3,8}$/.test(v)) return v;


### PR DESCRIPTION
## Description
This PR resolves issue #199 by adding a diagnostic check for invalid per-slide `<!-- color: … -->` and `<!-- _color: … -->` directives in `src/engine/parser/diagnostics.ts`.

## Details
- Exported `parseColorValue` from `markdownToSlides.ts` to validate color syntax.
- Updated `collectDiagnostics` in `diagnostics.ts` to inspect color directives and emit a `warning` diagnostic when a color value cannot be parsed, alerting authors during `kova --check`.