### PR TITLE
fix(export): format display math with body font and italic styling in PPTX export

### DIFF
--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -1252,7 +1252,7 @@ function addElements(s: PS, elements: SlideElement[], t: Theme, area: Area, warn
         break;
 
       case 'math':
-        runs.push({ text: el.value, options: { fontFace: firstFont(t.fonts.code), fontSize: 15, breakLine: true } });
+        runs.push({ text: el.value, options: { fontFace: firstFont(t.fonts.body), fontSize: 16, italic: true, breakLine: true } });
         if (el.caption) {
           runs.push({ text: el.caption, options: { fontSize: 11, italic: true, breakLine: true, paraSpaceAfter: 4 } });
         }


### PR DESCRIPTION
## Description
This PR resolves issue #196 by updating the `math` element case in `src/engine/export/exportPptx.ts`.

## Details
- Previously, display math (`79330…79330`) was exported using `firstFont(t.fonts.code)` as non-italic monospace text in PPTX runs.
- This PR changes the text run configuration for `math` elements to use `firstFont(t.fonts.body)` with `italic: true` and `fontSize: 16` so mathematical equations match standard presentation typography.