### PR TITLE
feat(cli): support PDF layout options in PendingExport and runPdfExportCapture

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1539,7 +1539,7 @@ export default function App() {
           await finish(lines.join('\n'));
           return;
         }
-        const outcome = await runPdfExportCapture([...visibleSlides], coldExport.output, {});
+        const outcome = await runPdfExportCapture([...visibleSlides], coldExport.output, coldExport.pdfOpts ?? {});
         const lines = [`wrote '${coldExport.output}'`];
         if (outcome.usedFallback) {
           lines.push(`note: native PDF export failed, used raster fallback (${outcome.fallbackReason})`);

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -23,6 +23,12 @@ export interface PendingExport {
   input: string;
   /** Absolute path — not required to exist yet, it's the file being written. */
   output: string;
+  /** Optional PDF layout options for CLI exports (--notes, --per-page, --paper). */
+  pdfOpts?: {
+    perPage?: number;
+    notes?: boolean;
+    paper?: string;
+  };
 }
 
 export interface PendingCli {


### PR DESCRIPTION
## Description
This PR resolves issue #200 by adding support for `pdfOpts` to `PendingExport` (`src/types/cli.ts`) and threading it through to `runPdfExportCapture` in `src/App.tsx`.

## Details
- Adds optional `pdfOpts` property (`perPage`, `notes`, `paper`) to the `PendingExport` type interface.
- Updates `runPdfExportCapture` in `src/App.tsx` to pass `coldExport.pdfOpts ?? {}` so CLI PDF exports can render speaker notes, multi-page layouts, and custom paper sizes matching GUI exports.