### PR TITLE
feat(presenter): allow cycling aspect ratio from presenter overlay HUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2106,6 +2106,7 @@ export default function App() {
           laserColor={settings.laserColor}
           onNavigate={setPresentIndex}
           onExit={handlePresentExit}
+          onToggleAspectRatio={handleAspectRatioCycle}
         />
       )}
     </>

--- a/src/components/presentation/PresenterOverlay.tsx
+++ b/src/components/presentation/PresenterOverlay.tsx
@@ -21,6 +21,7 @@ interface Props {
   laserColor?: string;
   onNavigate: (index: number) => void;
   onExit: () => void;
+  onToggleAspectRatio?: () => void;
 }
 
 const HUD_H           = 56;  // px
@@ -31,7 +32,7 @@ const STORAGE_KEY     = 'kova:presenter-right-w';
 
 export function PresenterOverlay({
   slides, currentIndex, theme, docTitle, docDate, aspectRatio,
-  showNextSlide, showTimer, notesFontSize, laserColor = '#ff2020', onNavigate, onExit,
+  showNextSlide, showTimer, notesFontSize, laserColor = '#ff2020', onNavigate, onExit, onToggleAspectRatio,
 }: Props) {
   const t = useT();
   const slide     = slides[currentIndex];
@@ -391,6 +392,17 @@ export function PresenterOverlay({
           onClick={() => setLaserActive((p) => !p)}
           title={t('presentation.toggleLaser')}
         >{t('presentation.laserButton')}</button>
+
+        {onToggleAspectRatio && (
+          <>
+            <div className="pres-presenter__hud-divider" />
+            <button
+              className="pres-presenter__btn"
+              onClick={onToggleAspectRatio}
+              title={aspectRatio.label}
+            >{aspectRatio.label}</button>
+          </>
+        )}
 
         <div className="pres-presenter__hud-divider" />
 


### PR DESCRIPTION
## Description
This PR resolves issue #137 by adding an aspect ratio toggle button to the Presenter Overlay HUD bar in `PresenterOverlay.tsx`.

## Details
- Adds `onToggleAspectRatio` prop to `PresenterOverlay` interface.
- Renders an aspect ratio button in the presenter overlay HUD that cycles between 16:9 and 4:3 ratios directly while presenting.