### PR TITLE
fix(cli): refuse to overwrite existing markdown deck as import destination

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -230,6 +230,11 @@ pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
                         "--import output must be a .md file, got '{output}'"
                     ));
                 }
+                if std::path::Path::new(&output).exists() && has_extension(&input, &[".md", ".markdown"]) {
+                    return CliArgs::Error(format!(
+                        "refusing to overwrite existing markdown file '{output}' during --import — specify output path with -o or choose a non-existing filename"
+                    ));
+                }
                 if let Err(e) = set_action(&mut action, Action::Import { format, input, output }) {
                     return e;
                 }


### PR DESCRIPTION
## Description
This PR resolves issue #198 by adding a safety check in `src-tauri/src/cli.rs` during `--import`.

## Details
- Prevents `kova --import marp jan.md feb.md` shell glob expansion from accidentally overwriting an existing `feb.md` markdown deck.
- Returns a clear error message requiring an explicit output flag (`-o`) or a non-existing destination filename.