### PR TITLE
fix(cli): apply toRawUrl on --import url fetches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { InfoBanner } from './components/InfoBanner';
 import { isMarp, importMarp } from './engine/import/marp';
 import { parsePptx } from './engine/import/parsePptx';
 import { pptxToMarkdown } from './engine/import/pptxToMarkdown';
+import { toRawUrl } from './engine/import/toRawUrl';
 import { MissingThemeBanner } from './components/MissingThemeBanner';
 import { loadSettings, saveSettings, EDITOR_FONT_OPTIONS } from './store/settings';
 import type { AppSettings } from './store/settings';
@@ -201,9 +202,9 @@ async function runCliImport(imp: PendingImport, check: boolean): Promise<void> {
       await finish(lines.join('\n'));
       return;
     }
-    // url — fetched verbatim, no conversion (matches ImportUrlModal: if the
-    // remote content is a Marp deck, that's detected on open, not on fetch).
-    const text: string = await invoke('fetch_url_text', { url: imp.input });
+    // url — rewrite GitHub/GitLab/Bitbucket blob URLs to raw (same as ImportUrlModal).
+    // Marp detection still happens on open, not on fetch.
+    const text: string = await invoke('fetch_url_text', { url: toRawUrl(imp.input) });
     if (!(await gate(text, imp.output, dirOf(imp.output)))) return;
     await invoke('write_file', { path: imp.output, content: text });
     await finish(`wrote '${imp.output}'`);

--- a/src/components/ImportUrlModal.tsx
+++ b/src/components/ImportUrlModal.tsx
@@ -2,38 +2,11 @@ import { useState, useRef, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { useT } from '../i18n';
 import { ModalShell } from './ModalShell';
+import { toRawUrl } from '../engine/import/toRawUrl';
 
 interface ImportUrlModalProps {
   onImported: (text: string) => void;
   onClose: () => void;
-}
-
-// Convert standard web URLs for common Git hosts to their raw content equivalents.
-function toRawUrl(input: string): string {
-  try {
-    const u = new URL(input);
-
-    // GitHub: /user/repo/blob/branch/path → raw.githubusercontent.com/user/repo/branch/path
-    if (u.hostname === 'github.com') {
-      const m = u.pathname.match(/^(\/[^/]+\/[^/]+)\/blob(\/.+)$/);
-      if (m) return `https://raw.githubusercontent.com${m[1]}${m[2]}`;
-    }
-
-    // GitLab: /user/repo/-/blob/branch/path → /user/repo/-/raw/branch/path
-    if (u.hostname === 'gitlab.com' || u.hostname.endsWith('.gitlab.com')) {
-      const m = u.pathname.match(/^(.+\/-\/)blob(\/.+)$/);
-      if (m) return `${u.origin}${m[1]}raw${m[2]}`;
-    }
-
-    // Bitbucket: /user/repo/src/branch/path → /user/repo/raw/branch/path
-    if (u.hostname === 'bitbucket.org') {
-      const m = u.pathname.match(/^(\/[^/]+\/[^/]+)\/src(\/.+)$/);
-      if (m) return `${u.origin}${m[1]}/raw${m[2]}`;
-    }
-  } catch {
-    // Not a valid URL — pass through and let the backend error naturally.
-  }
-  return input;
 }
 
 export function ImportUrlModal({ onImported, onClose }: ImportUrlModalProps) {

--- a/src/engine/__tests__/toRawUrl.test.ts
+++ b/src/engine/__tests__/toRawUrl.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { toRawUrl } from '../import/toRawUrl';
+
+describe('toRawUrl (issue #197)', () => {
+  it('rewrites GitHub blob URLs to raw.githubusercontent.com', () => {
+    expect(toRawUrl('https://github.com/user/repo/blob/main/talk.md')).toBe(
+      'https://raw.githubusercontent.com/user/repo/main/talk.md',
+    );
+  });
+
+  it('rewrites GitLab blob URLs to raw', () => {
+    expect(toRawUrl('https://gitlab.com/user/repo/-/blob/main/talk.md')).toBe(
+      'https://gitlab.com/user/repo/-/raw/main/talk.md',
+    );
+  });
+
+  it('rewrites Bitbucket src URLs to raw', () => {
+    expect(toRawUrl('https://bitbucket.org/user/repo/src/main/talk.md')).toBe(
+      'https://bitbucket.org/user/repo/raw/main/talk.md',
+    );
+  });
+
+  it('passes through already-raw and unknown hosts', () => {
+    expect(toRawUrl('https://raw.githubusercontent.com/user/repo/main/talk.md')).toBe(
+      'https://raw.githubusercontent.com/user/repo/main/talk.md',
+    );
+    expect(toRawUrl('https://example.com/deck.md')).toBe('https://example.com/deck.md');
+  });
+});

--- a/src/engine/import/toRawUrl.ts
+++ b/src/engine/import/toRawUrl.ts
@@ -1,0 +1,27 @@
+/** Rewrite common git-host blob/browse URLs to their raw content equivalents. */
+export function toRawUrl(input: string): string {
+  try {
+    const u = new URL(input);
+
+    // GitHub: /user/repo/blob/branch/path → raw.githubusercontent.com/user/repo/branch/path
+    if (u.hostname === 'github.com') {
+      const m = u.pathname.match(/^(\/[^/]+\/[^/]+)\/blob(\/.+)$/);
+      if (m) return `https://raw.githubusercontent.com${m[1]}${m[2]}`;
+    }
+
+    // GitLab: /user/repo/-/blob/branch/path → /user/repo/-/raw/branch/path
+    if (u.hostname === 'gitlab.com' || u.hostname.endsWith('.gitlab.com')) {
+      const m = u.pathname.match(/^(.+\/-\/)blob(\/.+)$/);
+      if (m) return `${u.origin}${m[1]}raw${m[2]}`;
+    }
+
+    // Bitbucket: /user/repo/src/branch/path → /user/repo/raw/branch/path
+    if (u.hostname === 'bitbucket.org') {
+      const m = u.pathname.match(/^(\/[^/]+\/[^/]+)\/src(\/.+)$/);
+      if (m) return `${u.origin}${m[1]}/raw${m[2]}`;
+    }
+  } catch {
+    // Not a valid URL — pass through and let the backend error naturally.
+  }
+  return input;
+}


### PR DESCRIPTION
## Summary
- Fixes #197: CLI `--import url` uses the same GitHub/GitLab/Bitbucket blob→raw rewrite as the GUI.
- Extracted `toRawUrl` to `src/engine/import/toRawUrl.ts` for shared use.

## Test plan
- [x] `npx vitest run src/engine/__tests__/toRawUrl.test.ts`
- [x] `kova --import url 'https://github.com/…/blob/…/deck.md' out.md` writes Markdown

Closes #197