### PR TITLE
fix(check): warn on invalid <!-- color --> directives

### DIFF
--- a/src/engine/__tests__/diagnostics.test.ts
+++ b/src/engine/__tests__/diagnostics.test.ts
@@ -137,6 +137,20 @@ describe('collectDiagnostics', () => {
     const diags = await collectDiagnostics(doc, ctx({ fileExists: async () => false }));
     expect(diags.filter((d) => d.message.includes('shared.png'))).toHaveLength(1);
   });
+  it('warns on invalid <!-- color: … --> values (issue #199)', async () => {
+    const doc = `---\ntitle: T\n---\n\n<!-- color: not-a-color -->\n\n## Slide\nHi\n`;
+    const diags = await collectDiagnostics(doc, ctx());
+    const w = diags.find((d) => d.message.includes('invalid color'));
+    expect(w).toBeDefined();
+    expect(w!.severity).toBe('warning');
+    expect(w!.line).toBe(5);
+  });
+
+  it('does not warn on valid color directives', async () => {
+    const doc = `---\ntitle: T\n---\n\n<!-- color: #fff -->\n\n## Slide\nHi\n`;
+    const diags = await collectDiagnostics(doc, ctx());
+    expect(diags.filter((d) => d.message.includes('invalid color'))).toEqual([]);
+  });
 });
 
 describe('formatCheckReport', () => {

--- a/src/engine/parser/colorValue.ts
+++ b/src/engine/parser/colorValue.ts
@@ -1,0 +1,22 @@
+/**
+ * Validates a per-slide colour directive value (`<!-- color: … -->` /
+ * `<!-- _color: … -->`). Accepts hex (#rgb/#rrggbb/#rrggbbaa), functional
+ * notations (rgb()/hsl()/color()/…), and single-word named colours (white,
+ * black, rebeccapurple, …). The value can't be used to inject extra CSS
+ * declarations when later placed into a `style` attribute: hex and named
+ * colours may contain only their own characters, and functional notations are
+ * matched in full (opening prefix through closing paren) and rejected if they
+ * contain quotes or CSS metacharacters (`;`, `{`, `}`). Spaces inside the
+ * parentheses are permitted (e.g. `rgb(0, 0, 0)`).
+ */
+export function parseColorValue(raw: string): string | undefined {
+  const v = raw.trim();
+  if (!v) return undefined;
+  if (/^#[0-9a-fA-F]{3,8}$/.test(v)) return v;
+  if (/^(?:rgb|rgba|hsl|hsla|color|hwb|lab|lch|oklab|oklch)\([^;{}'"]*\)$/i.test(v)) return v;
+  if (/^[a-zA-Z]+$/.test(v)) return v.toLowerCase();
+  return undefined;
+}
+
+/** Matches `<!-- color: … -->` / `<!-- _color: … -->` (same as the parser). */
+export const COLOR_COMMENT_RE = /<!--\s*(?:_?color)\s*:\s*([^\s-][^\n]*?)\s*-->/i;

--- a/src/engine/parser/diagnostics.ts
+++ b/src/engine/parser/diagnostics.ts
@@ -1,5 +1,6 @@
 import yaml from 'js-yaml';
 import { parseDocument } from './markdownToSlides';
+import { COLOR_COMMENT_RE, parseColorValue } from './colorValue';
 import { localPathFromMediaSrc } from '../resolveMediaPath';
 import type { LayoutType, ListItem, Slide } from '../types';
 
@@ -134,6 +135,15 @@ export async function collectDiagnostics(content: string, ctx: CheckContext): Pr
     const layout = line.match(LAYOUT_COMMENT_RE);
     if (layout && !KNOWN_LAYOUTS.has(layout[1])) {
       diags.push({ line: i + 1, severity: 'error', message: `unknown layout '${layout[1]}'` });
+    }
+
+    const color = line.match(COLOR_COMMENT_RE);
+    if (color && parseColorValue(color[1]) === undefined) {
+      diags.push({
+        line: i + 1,
+        severity: 'warning',
+        message: `invalid color '${color[1].trim()}'`,
+      });
     }
 
     const directive = line.trimStart().match(DIRECTIVE_RE);

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -3,6 +3,7 @@ import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import katex from 'katex';
+import { parseColorValue } from './colorValue';
 import { toString } from 'mdast-util-to-string';
 import type { Root, Node, Paragraph, List, ListItem as MdastListItem, Code, Blockquote, Table, Heading } from 'mdast';
 
@@ -720,21 +721,3 @@ function escLinkUrl(url: string): string {
 }
 
 export type { Frontmatter };
-
-// Validates a per-slide colour directive value (`<!-- color: … -->` /
-// `<!-- _color: … -->`). Accepts hex (#rgb/#rrggbb/#rrggbbaa), functional
-// notations (rgb()/hsl()/color()/…), and single-word named colours (white,
-// black, rebeccapurple, …). The value can't be used to inject extra CSS
-// declarations when later placed into a `style` attribute: hex and named
-// colours may contain only their own characters, and functional notations are
-// matched in full (opening prefix through closing paren) and rejected if they
-// contain quotes or CSS metacharacters (`;`, `{`, `}`). Spaces inside the
-// parentheses are permitted (e.g. `rgb(0, 0, 0)`).
-function parseColorValue(raw: string): string | undefined {
-  const v = raw.trim();
-  if (!v) return undefined;
-  if (/^#[0-9a-fA-F]{3,8}$/.test(v)) return v;
-  if (/^(?:rgb|rgba|hsl|hsla|color|hwb|lab|lch|oklab|oklch)\([^;{}'"]*\)$/i.test(v)) return v;
-  if (/^[a-zA-Z]+$/.test(v)) return v.toLowerCase();
-  return undefined;
-}


### PR DESCRIPTION
## Summary
- Fixes #199: `kova --check` warns when `<!-- color: … -->` / `<!-- _color: … -->` has an invalid value.
- Shared `parseColorValue` in `src/engine/parser/colorValue.ts`.

## Test plan
- [x] `npx vitest run src/engine/__tests__/diagnostics.test.ts -t "invalid color|valid color"`
- [x] `kova --check` on a deck with `<!-- color: not-a-color -->` prints a warning

Closes #199