### PR TITLE
feat: Add check for urls that cannot found or reached

### DIFF
--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -97,3 +97,38 @@ pub async fn fetch_url_text(url: String) -> Result<String, String> {
     }
     Ok(text)
 }
+
+/// Probe whether a remote URL is reachable. Used by `kova --check` to warn on
+/// remote media URLs that cannot be fetched at all (invalid host, 404, etc.).
+#[tauri::command]
+pub async fn probe_url(url: String) -> Result<(), String> {
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        return Err("URL must use HTTP or HTTPS".into());
+    }
+    let parsed = reqwest::Url::parse(&url).map_err(|e| format!("invalid URL: {e}"))?;
+    if crate::net_guard::url_host_is_blocked(&parsed) {
+        return Err("refusing to connect to a non-public address".into());
+    }
+
+    async fn get_probe(client: &reqwest::Client, url: &str) -> Result<(), String> {
+        let resp = client
+            .get(url)
+            .header(reqwest::header::RANGE, "bytes=0-0")
+            .send()
+            .await
+            .map_err(|e| format!("fetch failed: {e}"))?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(format!("fetch failed: HTTP {}", resp.status()))
+        }
+    }
+
+    let client = crate::net_guard::build_ssrf_safe_client()?;
+    match client.head(&url).send().await {
+        Ok(resp) if resp.status().is_success() => Ok(()),
+        Ok(resp) if matches!(resp.status().as_u16(), 405 | 501) => get_probe(&client, &url).await,
+        Ok(resp) => Err(format!("fetch failed: HTTP {}", resp.status())),
+        Err(_) => get_probe(&client, &url).await,
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,7 @@ pub fn run() {
             commands::read_clipboard_text,
             commands::fetch_url_b64,
             commands::fetch_url_text,
+            commands::probe_url,
             commands::confirm_exit,
             commands::cli_exit,
             commands::cli_stdout,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -165,6 +165,13 @@ async function runCliImport(imp: PendingImport, check: boolean): Promise<void> {
     themeIds: await knownThemeIds(),
     fileExists: (p: string) =>
       invoke<boolean>('path_exists', { path: p }).then(Boolean).catch(() => false),
+    urlReachable: (url: string) =>
+      invoke('probe_url', { url })
+        .then(() => null)
+        .catch((e) => {
+          const msg = e instanceof Error ? e.message : String(e);
+          return msg.replace(/^Error invoking command '[^']+':\s*/i, '');
+        }),
   });
   /** Run --check on markdown; returns false when the write must be skipped. */
   const gate = async (markdown: string, label: string, docDir: string): Promise<boolean> => {
@@ -1176,6 +1183,13 @@ export default function App() {
             themeIds: await knownThemeIds(),
             fileExists: (p) =>
               invoke<boolean>('path_exists', { path: p }).then(Boolean).catch(() => false),
+            urlReachable: (url: string) =>
+              invoke('probe_url', { url })
+                .then(() => null)
+                .catch((e) => {
+                  const msg = e instanceof Error ? e.message : String(e);
+                  return msg.replace(/^Error invoking command '[^']+':\s*/i, '');
+                }),
           });
           const { report, errors } = formatCheckReport(target, diags);
           await invoke('cli_stdout', { text: report }).catch(() => {});

--- a/src/engine/__tests__/diagnostics.test.ts
+++ b/src/engine/__tests__/diagnostics.test.ts
@@ -132,6 +132,44 @@ describe('collectDiagnostics', () => {
     expect(diags).toEqual([]);
   });
 
+  it('warns when a visible remote media URL is not reachable', async () => {
+    const doc = `# Slide\n\n![alt](https://random-url.abc.png)\n`;
+    const diags = await collectDiagnostics(doc, ctx({
+      urlReachable: async () => 'fetch failed: HTTP 404 Not Found',
+    }));
+    expect(diags).toHaveLength(1);
+    expect(diags[0]).toMatchObject({
+      line: 3,
+      severity: 'warning',
+    });
+    expect(diags[0].message).toContain("remote media URL not reachable: 'https://random-url.abc.png'");
+    expect(diags[0].message).toContain('HTTP 404');
+  });
+
+  it('dedupes repeated remote URL checks across slides', async () => {
+    const doc = [
+      '# One',
+      '',
+      '![a](https://example.com/img.png)',
+      '',
+      '---',
+      '',
+      '# Two',
+      '',
+      '![b](https://example.com/img.png)',
+      '',
+    ].join('\n');
+    let probes = 0;
+    const diags = await collectDiagnostics(doc, ctx({
+      urlReachable: async () => {
+        probes += 1;
+        return null;
+      },
+    }));
+    expect(diags).toEqual([]);
+    expect(probes).toBe(1);
+  });
+
   it('dedupes a missing file referenced on multiple slides', async () => {
     const doc = `# One\n\n![a](shared.png)\n\n---\n\n# Two\n\n![b](shared.png)\n`;
     const diags = await collectDiagnostics(doc, ctx({ fileExists: async () => false }));

--- a/src/engine/parser/diagnostics.ts
+++ b/src/engine/parser/diagnostics.ts
@@ -25,6 +25,8 @@ export interface CheckContext {
   themeIds: string[];
   /** Existence probe for local media paths (IPC-backed in the app, mocked in tests). */
   fileExists: (path: string) => Promise<boolean>;
+  /** Optional reachability probe for remote HTTP(S) media URLs. */
+  urlReachable?: (url: string) => Promise<string | null>;
 }
 
 const KNOWN_FRONTMATTER_KEYS = new Set([
@@ -69,6 +71,11 @@ function collectHtmlSrcs(html: string, out: string[]): void {
 function collectItemSrcs(item: ListItem, out: string[]): void {
   collectHtmlSrcs(item.html, out);
   item.children.forEach((c) => collectItemSrcs(c, out));
+}
+
+function remoteHttpMediaUrl(src: string): string | null {
+  const trimmed = src.trim();
+  return /^https?:\/\//i.test(trimmed) ? trimmed : null;
 }
 
 /** All raw media srcs referenced by a slide, in source order. */
@@ -168,22 +175,48 @@ export async function collectDiagnostics(content: string, ctx: CheckContext): Pr
     diags.push({ line: 0, severity: 'error', message: 'document contains no visible slides' });
   }
 
-  // Local media existence — hidden slides are skipped (they don't render);
-  // remote/data URLs are skipped (existence is not checkable here). Dedupe by
-  // resolved path so one missing file used on five slides reports once.
-  const seen = new Set<string>();
+  // Local media existence and optional remote URL reachability checks.
+  // Hidden slides are skipped (they don't render). Dedupe by resolved path /
+  // URL so one missing reference used on five slides reports once.
+  const seenLocal = new Set<string>();
+  const seenRemote = new Set<string>();
+  const remoteUrls: string[] = [];
   for (const slide of visible) {
     for (const src of collectSlideSrcs(slide)) {
       const local = localPathFromMediaSrc(src, ctx.docDir);
-      if (!local || seen.has(local)) continue;
-      seen.add(local);
-      if (!(await ctx.fileExists(local))) {
-        diags.push({
-          line: lineOf(content, src),
-          severity: 'error',
-          message: `media file not found: '${src}'`,
-        });
+      if (local) {
+        if (seenLocal.has(local)) continue;
+        seenLocal.add(local);
+        if (!(await ctx.fileExists(local))) {
+          diags.push({
+            line: lineOf(content, src),
+            severity: 'error',
+            message: `media file not found: '${src}'`,
+          });
+        }
+        continue;
       }
+      const remote = remoteHttpMediaUrl(src);
+      if (!remote || seenRemote.has(remote)) continue;
+      seenRemote.add(remote);
+      remoteUrls.push(remote);
+    }
+  }
+
+  if (ctx.urlReachable) {
+    for (const url of remoteUrls) {
+      let reason: string | null;
+      try {
+        reason = await ctx.urlReachable(url);
+      } catch (e) {
+        reason = e instanceof Error ? e.message : String(e);
+      }
+      if (!reason) continue;
+      diags.push({
+        line: lineOf(content, url),
+        severity: 'warning',
+        message: `remote media URL not reachable: '${url}' (${reason})`,
+      });
     }
   }
 


### PR DESCRIPTION
Adds a check on cli, to check if a image link couldn't be found or accessed.

e.g.

```md
---

## Test

![](https://random-url.abc.png)
```

will result in

> warning: `kova` (lib) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.70s
     Running `target\debug\kova.exe --check C:\Users\user\Downloads\tmp\kova_debug.md`
\\?\C:\Users\user\Downloads\tmp\kova_debug.md:57: warning: remote media URL not reachable: 'https://random-url.abc.png' (fetch failed: error sending request for url (https://random-url.abc.png/))
0 error(s), 1 warning(s)

instead of passing silently, without errors or warnings.

Open questions is: Would we like to offer a check/scan on the presentation itself as well and indicate such issues, or e.g. print "file not found" instead of just not loading an image if the URL is not valid?

<img width="1284" height="605" alt="image" src="https://github.com/user-attachments/assets/9ae0ff4b-823b-41b6-ae5d-e446c07d7d08" />
