### PR TITLE
feat: Add {author} as template variable

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -107,7 +107,7 @@ following anything else) is a compile error, same as a misplaced `!sheet`.
 
 ### 5. Template variables
 
-`{title}`, `{date}`, `{slide_number}`, `{total}` — text substitution inside
+`{title}`, `{author}`, `{date}`, `{slide_number}`, `{total}` — text substitution inside
 header/footer strings only (`theme_overrides.header.text`,
 `.footer.text`, or a theme's YAML). Resolved in
 [`src/engine/theme.ts`](src/engine/theme.ts) (`resolveTemplate`). Not valid

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -516,6 +516,7 @@ export default function App() {
   // decks only ever get a title via a heading, never via frontmatter, and a
   // silently blank footer segment (issue #55) is worse than this guess.
   const docTitle = frontmatter.title ?? rawSlides.find((s) => !s.hidden && s.titleLevel === 1)?.title ?? '';
+  const docAuthor = (frontmatter.author as string | undefined) ?? '';
   const docDate = (frontmatter.date as string | undefined) ?? formatFallbackDate(settings.locale);
 
   const aspectRatio = useMemo(
@@ -808,6 +809,7 @@ export default function App() {
           index: startIndex,
           aspectRatio,
           docTitle,
+          docAuthor,
           docDate,
         };
 
@@ -2153,6 +2155,7 @@ export default function App() {
           currentIndex={safePresentIndex}
           theme={activeTheme}
           docTitle={docTitle}
+          docAuthor={docAuthor}
           docDate={docDate}
           aspectRatio={aspectRatio}
           laserColor={settings.laserColor}
@@ -2167,6 +2170,7 @@ export default function App() {
           currentIndex={safePresentIndex}
           theme={activeTheme}
           docTitle={docTitle}
+          docAuthor={docAuthor}
           docDate={docDate}
           aspectRatio={aspectRatio}
           showNextSlide={settings.presenterShowNextSlide}
@@ -2499,6 +2503,7 @@ export default function App() {
               onDelete={handleDeleteSlide}
               theme={activeTheme}
               docTitle={docTitle}
+              docAuthor={docAuthor}
               docDate={docDate}
               aspectRatio={aspectRatio}
             />
@@ -2974,6 +2979,7 @@ export default function App() {
                   slideNumber={i + 1}
                   totalSlides={printContext.slides.length}
                   docTitle={docTitle}
+                  docAuthor={docAuthor}
                   docDate={docDate}
                   onAllDiagramsReady={onPrintSlideReady.current}
                 />
@@ -3015,6 +3021,7 @@ export default function App() {
                   slideNumber={i + 1}
                   totalSlides={pdfExportContext.slides.length}
                   docTitle={docTitle}
+                  docAuthor={docAuthor}
                   docDate={docDate}
                   onAllDiagramsReady={onPdfSlideReady.current}
                 />

--- a/src/AudienceApp.tsx
+++ b/src/AudienceApp.tsx
@@ -17,6 +17,7 @@ export interface PresentInitPayload {
   index: number;
   aspectRatio: AspectRatio;
   docTitle?: string;
+  docAuthor?: string;
   docDate?: string;
 }
 
@@ -156,7 +157,7 @@ function AudienceAppInner() {
   }
 
   const slide  = slidesRef.current[currentIndex];
-  const { theme, aspectRatio, docTitle, docDate } = initData;
+  const { theme, aspectRatio, docTitle, docAuthor, docDate } = initData;
   const total  = slidesRef.current.length;
   const slideH = Math.round(SLIDE_W * aspectRatio.h / aspectRatio.w);
 
@@ -186,6 +187,7 @@ function AudienceAppInner() {
                   slideNumber={currentIndex + 1}
                   totalSlides={total}
                   docTitle={docTitle}
+                  docAuthor={docAuthor}
                   docDate={docDate}
                   hideOverflowBadge
                   onNavigateTo={handleNavigateTo}

--- a/src/components/layout/ThumbnailPanel.tsx
+++ b/src/components/layout/ThumbnailPanel.tsx
@@ -18,6 +18,7 @@ interface Props {
   onDelete?: (index: number) => void;
   theme?: Theme;
   docTitle?: string;
+  docAuthor?: string;
   docDate?: string;
   aspectRatio?: AspectRatio;
 }
@@ -25,7 +26,7 @@ interface Props {
 const SLIDE_W = 960;
 const THUMB_W = 140;
 
-export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onDuplicate, onNewSlide, onToggleHidden, onSetBackground, onClearBackground, onDelete, theme = DEFAULT_THEME, docTitle, docDate, aspectRatio = { w: 16, h: 9 } }: Props) {
+export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onDuplicate, onNewSlide, onToggleHidden, onSetBackground, onClearBackground, onDelete, theme = DEFAULT_THEME, docTitle, docAuthor, docDate, aspectRatio = { w: 16, h: 9 } }: Props) {
   const t = useT();
   const slideH = Math.round(SLIDE_W * aspectRatio.h / aspectRatio.w);
 
@@ -228,6 +229,7 @@ export function ThumbnailPanel({ slides, currentIndex, onSelect, onReorder, onDu
                   onContextMenu={handleThumbContextMenu}
                   theme={theme}
                   docTitle={docTitle}
+                  docAuthor={docAuthor}
                   docDate={docDate}
                   scale={scale}
                   slideH={slideH}
@@ -348,6 +350,7 @@ interface ThumbnailProps {
   onContextMenu: (index: number, e: React.MouseEvent) => void;
   theme: Theme;
   docTitle?: string;
+  docAuthor?: string;
   docDate?: string;
   slideH: number;
   scale: number;
@@ -361,7 +364,7 @@ interface ThumbnailProps {
 // keystroke. `onSelect`/`onDragStart` are forwarded as stable function
 // references (bound internally below) rather than passed as pre-bound
 // closures, specifically so they don't defeat this memoization.
-const Thumbnail = memo(function Thumbnail({ slide, index, totalSlides, isActive, isDragSource, isDragging, canDrag, isHidden, onSelect, onToggleHidden, onDragStart, onContextMenu, theme, docTitle, docDate, slideH, scale, thumbH }: ThumbnailProps) {
+const Thumbnail = memo(function Thumbnail({ slide, index, totalSlides, isActive, isDragSource, isDragging, canDrag, isHidden, onSelect, onToggleHidden, onDragStart, onContextMenu, theme, docTitle, docAuthor, docDate, slideH, scale, thumbH }: ThumbnailProps) {
   const t = useT();
   const thumbRef = useRef<HTMLDivElement>(null);
 
@@ -431,6 +434,7 @@ const Thumbnail = memo(function Thumbnail({ slide, index, totalSlides, isActive,
             slide={slide}
             theme={theme}
             docTitle={docTitle}
+            docAuthor={docAuthor}
             docDate={docDate}
             slideNumber={index + 1}
             totalSlides={totalSlides}

--- a/src/components/presentation/PresentationOverlay.tsx
+++ b/src/components/presentation/PresentationOverlay.tsx
@@ -11,6 +11,7 @@ interface Props {
   currentIndex: number;
   theme: Theme;
   docTitle?: string;
+  docAuthor?: string;
   docDate?: string;
   aspectRatio?: AspectRatio;
   laserColor?: string;
@@ -23,7 +24,7 @@ const HUD_H   = 40;   // px — HUD bar height
 const NOTE_H  = 160;  // px — speaker notes panel height
 
 export function PresentationOverlay({
-  slides, currentIndex, theme, docTitle, docDate, aspectRatio = { w: 16, h: 9 }, laserColor = '#ff2020', showTimer = false, onNavigate, onExit,
+  slides, currentIndex, theme, docTitle, docAuthor, docDate, aspectRatio = { w: 16, h: 9 }, laserColor = '#ff2020', showTimer = false, onNavigate, onExit,
 }: Props) {
   const t = useT();
   const slide = slides[currentIndex];
@@ -155,6 +156,7 @@ export function PresentationOverlay({
               slideNumber={currentIndex + 1}
               totalSlides={total}
               docTitle={docTitle}
+              docAuthor={docAuthor}
               docDate={docDate}
               hideOverflowBadge
               onNavigateTo={handleNavigateTo}

--- a/src/components/presentation/PresenterOverlay.tsx
+++ b/src/components/presentation/PresenterOverlay.tsx
@@ -13,6 +13,7 @@ interface Props {
   currentIndex: number;
   theme: Theme;
   docTitle?: string;
+  docAuthor?: string;
   docDate?: string;
   aspectRatio: AspectRatio;
   showNextSlide: boolean;
@@ -30,7 +31,7 @@ const RIGHT_W_MAX     = 600; // px
 const STORAGE_KEY     = 'kova:presenter-right-w';
 
 export function PresenterOverlay({
-  slides, currentIndex, theme, docTitle, docDate, aspectRatio,
+  slides, currentIndex, theme, docTitle, docAuthor, docDate, aspectRatio,
   showNextSlide, showTimer, notesFontSize, laserColor = '#ff2020', onNavigate, onExit,
 }: Props) {
   const t = useT();
@@ -195,6 +196,7 @@ export function PresenterOverlay({
                 slideNumber={currentIndex + 1}
                 totalSlides={total}
                 docTitle={docTitle}
+                docAuthor={docAuthor}
                 docDate={docDate}
                 hideOverflowBadge
                 onNavigateTo={handleNavigateTo}
@@ -239,6 +241,7 @@ export function PresenterOverlay({
                       slideNumber={currentIndex + 2}
                       totalSlides={total}
                       docTitle={docTitle}
+                      docAuthor={docAuthor}
                       docDate={docDate}
                       hideOverflowBadge
                     />

--- a/src/components/preview/SlideRenderer.tsx
+++ b/src/components/preview/SlideRenderer.tsx
@@ -33,6 +33,7 @@ interface Props {
   slideNumber?: number;
   totalSlides?: number;
   docTitle?: string;
+  docAuthor?: string;
   docDate?: string;
   scale?: number;
   isThumbnail?: boolean;
@@ -41,7 +42,7 @@ interface Props {
   onNavigateTo?: (slideIndex: number) => void;
 }
 
-export function SlideRenderer({ slide, theme = DEFAULT_THEME, slideNumber, totalSlides, docTitle = '', docDate = '', scale = 1, isThumbnail: isThumbnailProp, hideOverflowBadge = false, onAllDiagramsReady, onNavigateTo }: Props) {
+export function SlideRenderer({ slide, theme = DEFAULT_THEME, slideNumber, totalSlides, docTitle = '', docAuthor = '', docDate = '', scale = 1, isThumbnail: isThumbnailProp, hideOverflowBadge = false, onAllDiagramsReady, onNavigateTo }: Props) {
   // Per-slide text colour: explicit `<!-- color -->` wins; otherwise a Marp
   // `<!-- _class: invert -->` swaps to the theme's light "text on dark" colour
   // (title_text). `slideTextOverride` stays undefined when neither applies, so
@@ -67,7 +68,7 @@ export function SlideRenderer({ slide, theme = DEFAULT_THEME, slideNumber, total
     if (onAllDiagramsReady && mermaidCount === 0) onAllDiagramsReady();
   }, [onAllDiagramsReady, mermaidCount]);
 
-  const templateVars = { title: docTitle, date: docDate, slideNumber, totalSlides };
+  const templateVars = { title: docTitle, author: docAuthor, date: docDate, slideNumber, totalSlides };
   const headerSegs = theme.header.show
     ? theme.header.text.split('|').map((s) => resolveTemplate(s.trim(), templateVars))
     : null;

--- a/src/engine/__tests__/theme.test.ts
+++ b/src/engine/__tests__/theme.test.ts
@@ -263,6 +263,10 @@ describe('resolveTemplate', () => {
     expect(resolveTemplate('{title}', { title: 'My Talk' })).toBe('My Talk');
   });
 
+  it('replaces {author}', () => {
+    expect(resolveTemplate('{author}', { author: 'Jane Doe' })).toBe('Jane Doe');
+  });
+
   it('replaces {date}', () => {
     expect(resolveTemplate('{date}', { date: '2026' })).toBe('2026');
   });

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -93,7 +93,7 @@ const M = 0.5;     // standard margin
 const HEAD_H = 0.4;
 const FOOT_H = 0.35;
 
-interface Meta { docTitle: string; docDate: string; slideNum: number; totalSlides: number }
+interface Meta { docTitle: string; docAuthor: string; docDate: string; slideNum: number; totalSlides: number }
 interface Area { x: number; y: number; w: number; h: number }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -232,6 +232,7 @@ export async function exportToPptx(
   // explicit `title:` — mirrors the same fallback used for the live preview
   // (see docTitle in App.tsx), so exported footers/headers match what's shown.
   const docTitle = frontmatter.title ?? slides.find((s) => s.titleLevel === 1)?.title ?? '';
+  const docAuthor = frontmatter.author ?? '';
   const docDate  = frontmatter.date != null ? String(frontmatter.date) : formatFallbackDate(locale);
   const warnings: string[] = [];
 
@@ -253,7 +254,7 @@ export async function exportToPptx(
 
   for (let i = 0; i < resolvedSlides.length; i++) {
     const pSlide = pres.addSlide();
-    const meta: Meta = { docTitle, docDate, slideNum: i + 1, totalSlides: slides.length };
+    const meta: Meta = { docTitle, docAuthor, docDate, slideNum: i + 1, totalSlides: slides.length };
     addSlide(pSlide as PS, resolvedSlides[i], theme, meta, H, warnings, logoDataUrl, logoAr);
   }
 
@@ -817,7 +818,7 @@ function addHeaderBar(s: PS, t: Theme, meta: Meta) {
     fill: { color: hex(t.colors.primary) },
     line: { type: 'none' },
   });
-  const vars = { title: meta.docTitle, date: meta.docDate, slideNumber: meta.slideNum, totalSlides: meta.totalSlides };
+  const vars = { title: meta.docTitle, author: meta.docAuthor, date: meta.docDate, slideNumber: meta.slideNum, totalSlides: meta.totalSlides };
   const segs = t.header.text.split('|').map((p) => resolveTemplate(p.trim(), vars));
   if (segs.some(Boolean)) {
     addBarText(s, segs, M, 0, W - M * 2, HEAD_H, 10, hex(t.colors.title_text), firstFont(t.fonts.body), 'kova:header-text');
@@ -834,7 +835,7 @@ function addFooterBar(s: PS, t: Theme, meta: Meta, H: number) {
     line: { type: 'none' },
   });
   const showNum = t.footer.show_slide_number;
-  const vars = { title: meta.docTitle, date: meta.docDate, slideNumber: meta.slideNum, totalSlides: meta.totalSlides };
+  const vars = { title: meta.docTitle, author: meta.docAuthor, date: meta.docDate, slideNumber: meta.slideNum, totalSlides: meta.totalSlides };
   const segs = t.footer.text.split('|').map((p) => resolveTemplate(p.trim(), vars));
   const textW = W - M * 2 - (showNum ? 1.1 : 0);
   if (segs.some(Boolean)) {

--- a/src/engine/theme.ts
+++ b/src/engine/theme.ts
@@ -29,12 +29,12 @@ export interface RemoteFont {
 
 export interface ThemeHeader {
   show: boolean;
-  text: string;
+  text: string;              // supports {title}, {author}, {date}, {slide_number}, {total}
 }
 
 export interface ThemeFooter {
   show: boolean;
-  text: string;              // supports {title}, {date}
+  text: string;              // supports {title}, {author}, {date}, {slide_number}, {total}
   show_slide_number: boolean;
 }
 
@@ -489,10 +489,11 @@ export function themeToVars(
 /** Resolves template variables in header/footer text. */
 export function resolveTemplate(
   template: string,
-  vars: { title?: string; date?: string; slideNumber?: number; totalSlides?: number },
+  vars: { title?: string; author?: string; date?: string; slideNumber?: number; totalSlides?: number },
 ): string {
   return template
     .replace(/{title}/g, vars.title ?? '')
+    .replace(/{author}/g, vars.author ?? '')
     .replace(/{date}/g, vars.date ?? '')
     .replace(/{slide_number}/g, String(vars.slideNumber ?? ''))
     .replace(/{total}/g, String(vars.totalSlides ?? ''));


### PR DESCRIPTION
Adds {author} as template variable.
Needs to be added on Web-repo for documentation as well. PR will be created, if this PR is accepted.

<img width="226" height="49" alt="image" src="https://github.com/user-attachments/assets/38566611-be87-4436-a7d1-751d01db07cd" />

Leads to

<img width="148" height="43" alt="image" src="https://github.com/user-attachments/assets/f6ab0f1d-85c2-4944-837b-ff8f6c419d9e" />

Tested on PDF/PPTX export as well.
Same for header.
