### PR TITLE
fix(nix): enable Tauri production mode

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,11 @@
           src = ./src-tauri;
           cargoLock.lockFile = ./src-tauri/Cargo.lock;
 
+          # `tauri build` enables this feature automatically. Since the Nix
+          # package calls Cargo directly, enable it here so Tauri embeds
+          # frontendDist instead of loading devUrl (localhost:1420).
+          buildFeatures = [ "custom-protocol" ];
+
           # Tauri embeds frontendDist (../dist) at compile time — supply the
           # prebuilt assets instead of letting it shell out to npm.
           preBuild = ''


### PR DESCRIPTION
## Summary

- enable Tauri’s custom-protocol feature in the Nix Cargo build
- embed frontendDist instead of loading the development localhost URL
- document why direct Cargo builds need the feature explicitly

Fixes #233.

## Verification

- nix flake check path:. --no-build --all-systems
- nix build path:.#packages.x86_64-linux.default --no-link --print-build-logs
- 49 Rust tests passed during the Nix build
- packaged kova --version smoke test passed on x86_64-linux (zeus)