### PR TITLE
fix: auto-fit PPTX table export to the slide

### DIFF
--- a/src/engine/export/__tests__/exportPptxTableFit.test.ts
+++ b/src/engine/export/__tests__/exportPptxTableFit.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { exportToPptx } from '../exportPptx';
+import { DEFAULT_THEME } from '../../theme';
+import type { Slide, SlideElement } from '../../types';
+
+// The live preview scales an overflowing table down to fit (OverflowPane's
+// zoom-to-fit). PptxGenJS in autoPage:false mode does no such thing — it emits
+// `<a:tr h="{h/rows}">` (a *minimum* PowerPoint then grows to fit the text) with
+// equal-width columns, so a dense table used to run straight off the slide and
+// wrap into lopsided rows. addTable now estimates the wrapped height and steps
+// the font size down until the table fits its area. See fitTableToArea().
+
+const EMU_PER_INCH = 914400;
+const SLIDE_H_16x9 = 5.625;
+
+function makeSlide(elements: SlideElement[]): Slide {
+  return {
+    index: 0, raw: '', title: 'Results', titleLevel: 2,
+    elements, speakerNotes: '', references: [], layout: 'title-content', hidden: false,
+  };
+}
+
+async function slideXml(slide: Slide): Promise<{ xml: string; warnings: string[] }> {
+  const res = await exportToPptx([slide], {}, DEFAULT_THEME, 'en');
+  const zip = await JSZip.loadAsync(res.base64, { base64: true });
+  const xml = await zip.file('ppt/slides/slide1.xml')!.async('string');
+  return { xml, warnings: res.warnings };
+}
+
+/** Isolate the `<a:tbl>…</a:tbl>` fragment so assertions can't pick up a
+ *  header/footer/caption run elsewhere on the slide. */
+function tableXml(xml: string): string {
+  const m = xml.match(/<a:tbl>[\s\S]*<\/a:tbl>/);
+  if (!m) throw new Error('no table in slide XML');
+  return m[0];
+}
+function rowHeightsInches(xml: string): number[] {
+  return [...tableXml(xml).matchAll(/<a:tr h="(\d+)">/g)].map((m) => Number(m[1]) / EMU_PER_INCH);
+}
+function colWidthsInches(xml: string): number[] {
+  return [...tableXml(xml).matchAll(/<a:gridCol w="(\d+)"\/>/g)].map((m) => Number(m[1]) / EMU_PER_INCH);
+}
+/** Smallest `sz=` (hundredths of a point) inside the table = its shrunk body font. */
+function minFontPt(xml: string): number {
+  const szs = [...tableXml(xml).matchAll(/sz="(\d+)"/g)].map((m) => Number(m[1]) / 100);
+  return Math.min(...szs);
+}
+
+const denseRows = (n: number): string[][] =>
+  Array.from({ length: n }, (_, i) => [
+    `Feature number ${i + 1}`,
+    `A reasonably long sentence describing what feature ${i + 1} does in practice and why it matters.`,
+    i % 2 ? 'In progress' : 'Done',
+    `Person ${String.fromCharCode(65 + i)}`,
+  ]);
+
+describe('exportPptx table auto-fit', () => {
+  it('shrinks a dense 4x8 table so its rows fit within the slide', async () => {
+    const table: SlideElement = {
+      type: 'table',
+      headers: ['Feature', 'Description', 'Status', 'Owner'],
+      rows: denseRows(7),
+    };
+    const { xml } = await slideXml(makeSlide([
+      { type: 'paragraph', text: 'Some intro text about the data below.', html: 'Some intro text about the data below.' },
+      table,
+    ]));
+
+    const rows = rowHeightsInches(xml);
+    expect(rows).toHaveLength(8); // header + 7
+
+    const totalH = rows.reduce((a, b) => a + b, 0);
+    // The whole table must fit inside one slide (it shares the body with a
+    // paragraph, so in practice it gets well under half the slide height).
+    expect(totalH).toBeLessThanOrEqual(SLIDE_H_16x9);
+
+    // A table this dense cannot fit at the 14pt base size — the fitter must
+    // have stepped the font down.
+    expect(minFontPt(xml)).toBeLessThan(14);
+    expect(minFontPt(xml)).toBeGreaterThanOrEqual(7); // never below the floor
+  });
+
+  it('keeps the base font and emits explicit column widths for a small table', async () => {
+    const { xml } = await slideXml(makeSlide([
+      { type: 'table', headers: ['A', 'B'], rows: [['1', '2'], ['3', '4']] },
+    ]));
+
+    expect(minFontPt(xml)).toBe(14);
+
+    const cols = colWidthsInches(xml);
+    expect(cols).toHaveLength(2);
+    // Two short, equal columns → roughly equal widths that sum to the area.
+    expect(Math.abs(cols[0] - cols[1])).toBeLessThan(0.05);
+    const totalW = cols.reduce((a, b) => a + b, 0);
+    expect(totalW).toBeGreaterThan(8); // ~9" content area on a 10" slide
+    expect(totalW).toBeLessThanOrEqual(9.05);
+  });
+
+  it('gives a wide-content column more width than a short-content column', async () => {
+    const { xml } = await slideXml(makeSlide([
+      {
+        type: 'table',
+        headers: ['ID', 'Notes'],
+        rows: [
+          ['1', 'A long free-text note that needs a lot more horizontal room than the id column beside it.'],
+          ['2', 'Another lengthy note explaining the second row in a similarly verbose amount of detail here.'],
+        ],
+      },
+    ]));
+    const cols = colWidthsInches(xml);
+    expect(cols).toHaveLength(2);
+    expect(cols[1]).toBeGreaterThan(cols[0] * 2);
+  });
+
+  it('warns and clamps at the minimum font when a table cannot possibly fit', async () => {
+    const table: SlideElement = {
+      type: 'table',
+      headers: ['Feature', 'Description', 'Status', 'Owner'],
+      rows: denseRows(40),
+    };
+    const { xml, warnings } = await slideXml(makeSlide([table]));
+
+    const totalH = rowHeightsInches(xml).reduce((a, b) => a + b, 0);
+    // Squeezed so the graphic frame still lands on the slide.
+    expect(totalH).toBeLessThanOrEqual(SLIDE_H_16x9);
+    expect(minFontPt(xml)).toBe(7);
+    expect(warnings.some((w) => w.toLowerCase().includes('table too large'))).toBe(true);
+  });
+});

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -1888,9 +1888,12 @@ function addElements(s: PS, elements: SlideElement[], t: Theme, area: Area, warn
       // addTable itself, this was previously never wired to stepTargets at
       // all, so a stepped table rendered fully visible regardless of step.
       const objectName = tableEl.step !== undefined ? stepShapeName(tableArea, 'table') : undefined;
-      addTable(s, tableEl, t, tableArea, tc, objectName);
+      const usedH = addTable(s, tableEl, t, tableArea, tc, objectName, warnings);
       if (objectName) stepTargets.push({ step: tableEl.step!, objectName });
-      addCaption(s, tableEl.caption, t, area.x, belowY + tableH - capH, area.w);
+      // Anchor the caption just under the fitted table (which is usually
+      // shorter than its allotted share) rather than at the bottom of the
+      // share, but never past it — images, if any, start at that boundary.
+      addCaption(s, tableEl.caption, t, area.x, belowY + Math.min(usedH, tableH - capH), area.w);
     }
 
     const mediaY = belowY + belowH * (tableEl?.type === 'table' ? tableFrac : 0);
@@ -1927,6 +1930,107 @@ function addElements(s: PS, elements: SlideElement[], t: Theme, area: Area, warn
   }
 }
 
+// ── Table auto-fit ───────────────────────────────────────────────────────────
+//
+// PptxGenJS with autoPage:false (the mode we use — one slide in, one slide out)
+// does no wrapping maths of its own: it emits `<a:tr h="{h / rowCount}">` and
+// leaves the layout to PowerPoint. But `a:tr/@h` is a *minimum* — PowerPoint
+// grows every row to fit its text and never shrinks the font — so a dense table
+// handed a small area runs straight off the bottom of the slide, and the
+// equal-width columns pptxgenjs assigns by default make a long-text column wrap
+// into tall, lopsided rows. The live preview sidesteps all this by measuring
+// the DOM and zoom-scaling the pane to fit (OverflowPane in layouts.tsx). With
+// no DOM at export time we approximate the same outcome: estimate the wrapped
+// height, step the font size down until it fits, and hand PowerPoint explicit
+// content-weighted column widths and per-row heights so it renders close to
+// what we computed.
+
+const TABLE_MAX_FONT = 14;
+const TABLE_MIN_FONT = 7;
+// Inches of row height per text line, per point of font size. PowerPoint renders
+// table cells at roughly font-size x 1.2 line spacing; the estimate is biased a
+// little high so it errs towards shrinking a touch too much (a slightly smaller
+// table) rather than too little (overflow — the bug this fixes).
+const TABLE_LINE_FACTOR = 1.3 / 72;
+const TABLE_CELL_VMARGIN = 0.04; // in; top and bottom each (pptx "narrow" cell margin)
+const TABLE_CELL_HMARGIN = 0.06; // in; left and right each
+// Average glyph advance as a fraction of the em — 0.5 is the usual rule of
+// thumb for proportional body text and matches the character-per-line constant
+// pptxgenjs itself assumes for auto-paging.
+const TABLE_CHAR_EM = 0.5;
+
+interface TableFit {
+  fontSize: number;
+  colW: number[];
+  rowH: number[];
+  height: number;
+  overflow: boolean;
+}
+
+// `matrix` is the plain-text grid (header row first). Returns the largest font
+// size in [TABLE_MIN_FONT, TABLE_MAX_FONT] whose estimated table height fits
+// `area.h`, plus the column/row geometry to emit for it. `overflow` is true when
+// even the minimum font can't fit — the row heights are then squeezed so the
+// graphic frame still lands on the slide (PowerPoint may nudge them back up a
+// hair, but a tight table beats one hanging off the edge).
+function fitTableToArea(matrix: string[][], area: Area): TableFit {
+  const availH = Math.max(0.5, area.h);
+  const availW = Math.max(1, area.w);
+  const nCols = Math.max(1, ...matrix.map((r) => r.length));
+
+  // Column widths, weighted by each column's longest cell. Clamp every column's
+  // desired width into [8%, 50%] of the total before normalising, so no column
+  // is starved to an unreadable thread and none swallows the whole table.
+  const em = (fs: number) => (fs * TABLE_CHAR_EM) / 72;
+  const clampLo = availW * 0.08;
+  const clampHi = availW * 0.5;
+  const desired: number[] = [];
+  for (let c = 0; c < nCols; c++) {
+    let maxLen = 1;
+    for (const row of matrix) maxLen = Math.max(maxLen, (row[c] ?? '').length);
+    desired.push(Math.min(clampHi, Math.max(clampLo, maxLen * em(TABLE_MAX_FONT))));
+  }
+  const desiredSum = desired.reduce((a, b) => a + b, 0);
+  const colW = desired.map((d) => (d / desiredSum) * availW);
+
+  const linesFor = (text: string, colWidth: number, fs: number): number => {
+    const usable = Math.max(0.2, colWidth - TABLE_CELL_HMARGIN * 2);
+    const cpl = Math.max(1, Math.floor(usable / em(fs)));
+    return (text || ' ')
+      .split('\n')
+      .reduce((sum, seg) => sum + Math.max(1, Math.ceil(seg.trim().length / cpl)), 0);
+  };
+  const rowHeightsFor = (fs: number): number[] =>
+    matrix.map((row) => {
+      let maxLines = 1;
+      for (let c = 0; c < nCols; c++) {
+        maxLines = Math.max(maxLines, linesFor(row[c] ?? '', colW[c], fs));
+      }
+      return maxLines * fs * TABLE_LINE_FACTOR + TABLE_CELL_VMARGIN * 2;
+    });
+
+  let fontSize = TABLE_MAX_FONT;
+  let rowH = rowHeightsFor(fontSize);
+  let total = rowH.reduce((a, b) => a + b, 0);
+  while (total > availH && fontSize > TABLE_MIN_FONT) {
+    fontSize -= 1;
+    rowH = rowHeightsFor(fontSize);
+    total = rowH.reduce((a, b) => a + b, 0);
+  }
+
+  let overflow = false;
+  if (total > availH) {
+    const squeeze = availH / total;
+    rowH = rowH.map((h) => h * squeeze);
+    total = availH;
+    overflow = true;
+  }
+
+  return { fontSize, colW, rowH, height: total, overflow };
+}
+
+/** Renders the table into `area`, auto-fitting font/columns/rows. Returns the
+ *  height actually consumed (<= area.h) so the caller can place a caption. */
 function addTable(
   s: PS,
   el: Extract<SlideElement, { type: 'table' }>,
@@ -1934,30 +2038,49 @@ function addTable(
   area: Area,
   tc: string = hex(t.colors.text),
   objectName?: string,
-) {
+  warnings: string[] = [],
+): number {
   const colAlign = (i: number): 'left' | 'center' | 'right' =>
     (el.align?.[i] as 'left' | 'center' | 'right' | null | undefined) ?? 'left';
 
-  const headerRow = el.headers.map((h, i) => ({
-    text: stripHtml(h),
+  const headerText = el.headers.map(stripHtml);
+  const bodyText = el.rows.map((row) => row.map(stripHtml));
+  const fit = fitTableToArea([headerText, ...bodyText], area);
+
+  if (fit.overflow) {
+    const label = headerText.join(' | ').slice(0, 40);
+    warnings.push(
+      `Table too large for the slide — scaled down to ${fit.fontSize}pt and may still be tight${label ? ` (columns: "${label}")` : ''}`,
+    );
+  }
+
+  const headerRow = headerText.map((h, i) => ({
+    text: h,
     options: {
       bold: true,
       color: hex(t.colors.title_text),
       fill: { color: hex(t.colors.primary) },
       align: colAlign(i),
+      fontSize: fit.fontSize,
     },
   }));
-  const bodyRows = el.rows.map((row) =>
-    row.map((cell, i) => ({ text: stripHtml(cell), options: { color: tc, fontSize: 14, align: colAlign(i) } }))
+  const bodyRows = bodyText.map((row) =>
+    row.map((cell, i) => ({ text: cell, options: { color: tc, fontSize: fit.fontSize, align: colAlign(i) } })),
   );
 
   s.addTable([headerRow, ...bodyRows], {
-    x: area.x, y: area.y, w: area.w, h: area.h,
-    fontSize: 14,
+    x: area.x, y: area.y, w: area.w, h: fit.height,
+    colW: fit.colW,
+    rowH: fit.rowH,
+    fontSize: fit.fontSize,
     fontFace: firstFont(t.fonts.body),
+    valign: 'top',
+    margin: [TABLE_CELL_VMARGIN, TABLE_CELL_HMARGIN, TABLE_CELL_VMARGIN, TABLE_CELL_HMARGIN],
     border: { color: hex(t.colors.accent), pt: 0.5 },
     ...(objectName ? { objectName } : {}),
   });
+
+  return fit.height;
 }
 
 // PptxGenJS `sizing.contain` is broken for pre-encoded data URLs because it


### PR DESCRIPTION
## Problem

A Markdown slide with body text and a 4-column, 7-row table renders fine in the
Kova preview but, when exported to PPTX, the table overruns the bottom of the
slide and its rows come out misshapen.

The preview keeps it in bounds because every body pane is an `OverflowPane` that
measures the rendered height and zoom-scales the content to fit. The exporter has
no equivalent: `addTable` handed PptxGenJS a fixed area and a fixed 14pt font
with `autoPage: false`, in which mode PptxGenJS does no wrapping maths at all -
it emits `<a:tr h="{h / rowCount}">` and leaves layout to PowerPoint. `a:tr/@h`
is a *minimum*, so PowerPoint grows every row to fit its text and never shrinks
the font, and the columns are split equally regardless of content, so a
long-text column wraps into tall, uneven rows.

## Change

New `fitTableToArea()` helper, the export-time analogue of `OverflowPane`:

1. Content-weighted column widths, each clamped to 8-50% of the width then
   normalised, replacing PptxGenJS's equal split.
2. Estimates wrapped line count per cell and steps the font size from 14pt down
   to a 7pt floor until the estimated table height fits its area.
3. Passes explicit per-row heights and total height through, so PowerPoint
   renders close to what was computed rather than growing rows off the slide.
4. If even 7pt cannot fit, row heights are squeezed so the frame still lands on
   the slide and a warning is surfaced through the export's `warnings[]`.

`addTable` now returns the height it consumed so the caller anchors the table
caption directly under the fitted table. Cell margins set to narrow,
`valign: 'top'` set explicitly.

Observed on the reported case (body text plus a 4x7 table): shrinks to about
8pt, the description column gets roughly 5.1" and the owner column about 0.9",
total height about 1.8" - fits under the paragraph with no overflow.

## Out of scope

The `textFrac` heuristic that decides how much of the body a table gets when
mixed with text is untouched; it is a little generous to the text, so a table
next to a short paragraph can end up smaller than necessary. Worth a follow-up.

## Tests

- New `exportPptxTableFit.test.ts`: dense table fits within the slide and shrinks
  below 14pt; small table stays at 14pt with equal columns; wide-content column
  gets more than twice the width of a short one; oversized table clamps at 7pt
  and warns.
- `tsc` clean; full export suite and layout tests pass. Two pre-existing failures
  in `src/engine/sheet/__tests__/evaluate.test.ts` are unrelated (confirmed by
  stashing this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)