### PR TITLE
fix: Fixes alignment between markdown and slides

### DIFF
--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -28,6 +28,7 @@ import { useMediaDragAndDrop } from '../editor/useMediaDragAndDrop';
 import { useMediaPaste } from '../editor/useMediaPaste';
 import { ModalShell } from '../ModalShell';
 import { isMac } from '../../engine/keybindings';
+import { slideStartLines } from '../../engine/parser/markdownToSlides';
 import { spellCheckExtension } from '../../engine/spellcheck/spellCheckExtension';
 import { initSpellChecker } from '../../engine/spellcheck/spellChecker';
 import type { SpellCheckLanguage } from '../../engine/spellcheck/spellChecker';
@@ -221,30 +222,9 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
     scrollToSlide(index: number) {
       const view = viewRef.current;
       if (!view) return;
-      const doc = view.state.doc.toString();
-
-      // Skip past the frontmatter block
-      const fmMatch = doc.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/);
-      const bodyStart = fmMatch ? fmMatch[0].length : 0;
-
-      let pos = bodyStart;
-
-      if (index > 0) {
-        // Find the index-th standalone --- separator in the body
-        const body = doc.slice(bodyStart);
-        const sep = /^---$/gm;
-        let found = 0;
-        let m: RegExpExecArray | null;
-        while ((m = sep.exec(body)) !== null) {
-          found++;
-          if (found === index) {
-            // Place cursor on the line after the --- separator
-            const afterSep = bodyStart + m.index + m[0].length;
-            pos = afterSep + (doc[afterSep] === '\r' ? 2 : doc[afterSep] === '\n' ? 1 : 0);
-            break;
-          }
-        }
-      }
+      const starts = slideStartLines(view.state.doc.toString());
+      const line = starts[index] ?? starts[starts.length - 1] ?? 1;
+      const pos = view.state.doc.line(Math.min(line, view.state.doc.lines)).from;
 
       view.dispatch({
         selection: EditorSelection.cursor(pos),
@@ -282,11 +262,12 @@ export const EditorPanel = forwardRef<EditorHandle, Props>(function EditorPanel(
         onChangeRef.current(update.state.doc.toString());
       }
       if (update.selectionSet || update.docChanged) {
-        const pos = update.state.selection.main.head;
-        const raw = update.state.doc.toString().slice(0, pos);
-        // Strip frontmatter block so its --- delimiters aren't counted as slide separators
-        const stripped = raw.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '');
-        const slideIndex = (stripped.match(/^---$/gm) ?? []).length;
+        const cursorLine = update.state.doc.lineAt(update.state.selection.main.head).number;
+        const starts = slideStartLines(update.state.doc.toString());
+        let slideIndex = 0;
+        for (let i = 0; i < starts.length; i++) {
+          if (starts[i] <= cursorLine) slideIndex = i; else break;
+        }
         onCursorSlideRef.current?.(slideIndex);
       }
     });

--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseDocument, computeNextStep } from '../parser/markdownToSlides';
+import { parseDocument, computeNextStep, slideStartLines } from '../parser/markdownToSlides';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -782,6 +782,35 @@ describe('computeNextStep', () => {
   it('scopes to the containing slide, ignoring markers on other slides', () => {
     const content = doc('## First\n\n- A <!-- step -->\n\n---\n\n## Second\n\n- B');
     expect(computeNextStep(content, 13)).toBe(1);
+  });
+});
+
+describe('slideStartLines', () => {
+  it('matches parseDocument slide count and points at each slide body', () => {
+    const content = '---\ntitle: T\n---\n\n## One\n\n---\n\n## Two\n';
+    const starts = slideStartLines(content);
+    expect(starts).toHaveLength(parseDocument(content).slides.length);
+    expect(content.split('\n')[starts[0] - 1]).toBe('');
+    expect(content.split('\n')[starts[1] - 1]).toBe('');
+  });
+
+  it('ignores --- lines inside a fenced code block', () => {
+    const content = '## One\n\n```mermaid\n---\nconfig: x\n---\nflowchart TD\n```\n\n---\n\n## Two\n';
+    const starts = slideStartLines(content);
+    expect(starts).toHaveLength(2);
+    expect(starts[1]).toBe(11);
+  });
+
+  it('skips empty slides, as parseDocument does', () => {
+    const content = '## One\n\n---\n\n---\n\n## Two\n';
+    const starts = slideStartLines(content);
+    expect(starts).toHaveLength(parseDocument(content).slides.length);
+    expect(starts).toEqual([1, 6]);
+  });
+
+  it('keeps line numbers correct with CRLF line endings', () => {
+    const content = '## One\r\n\r\n---\r\n\r\n## Two\r\n';
+    expect(slideStartLines(content)).toEqual([1, 4]);
   });
 });
 

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -59,6 +59,45 @@ export function splitIntoRawSlides(body: string): string[] {
   return slides;
 }
 
+/**
+ * 1-based line numbers of the first body line of every slide parseDocument
+ * would produce, for the raw (un-normalised) editor content. The editor uses
+ * this to map cursor position ↔ slide index; it must apply exactly the same
+ * fenced-code and empty-slide rules as parseDocument, otherwise a '---' inside
+ * a fenced block (e.g. a mermaid front-matter config) shifts the mapping.
+ */
+export function slideStartLines(rawContent: string): number[] {
+  // \r\n → \n is 1:1 per line, so line numbers are unaffected by normalising.
+  const normalised = rawContent.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const { body } = extractFrontmatter(normalised);
+  const frontmatterLineCount = normalised.slice(0, normalised.length - body.length).split('\n').length - 1;
+
+  const starts: number[] = [];
+  const lines = body.split('\n');
+  let inFencedCode = false;
+  let segmentStart = 0;
+  let segment: string[] = [];
+
+  const flush = () => {
+    if (segment.join('\n').trim()) starts.push(frontmatterLineCount + segmentStart + 1);
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (/^(`{3,}|~{3,})/.test(t)) inFencedCode = !inFencedCode;
+    if (!inFencedCode && t === '---') {
+      flush();
+      segment = [];
+      segmentStart = i + 1;
+      continue;
+    }
+    segment.push(lines[i]);
+  }
+  flush();
+
+  return starts;
+}
+
 // A step-marker occurrence found anywhere on a line — unanchored, so it
 // matches both the trailing-inline form and the own-line-after form alike;
 // this only needs to *find* markers in document order, not validate their


### PR DESCRIPTION
If mermaid config is used, 

like e.g.

```
```mermaid
---
config:
  theme: 'base'
---
mindmap
```

the '---' have been counted as slide start lines. So an Offset between the slides and the markdown was created. This PR fixes this, as the parser checks for fenced blocks.

Can be tested with e.g.

[kova_debug.md](https://github.com/user-attachments/files/31727896/kova_debug.md)

