### PR TITLE
feat: Enables progress bars also inside of tables

### DIFF
--- a/src/components/preview/SlideRenderer.css
+++ b/src/components/preview/SlideRenderer.css
@@ -686,6 +686,8 @@
 
 .sl-progress { padding: 0.35em 0; }
 
+.sl-table .sl-progress { min-width: 8em; padding: 0; }
+
 .sl-progress__header {
   display: flex;
   justify-content: space-between;

--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -360,6 +360,56 @@ describe('element parsing', () => {
     expect(table?.type === 'table' && table.rows[0]).toEqual(['plain', 'text']);
   });
 
+  it('renders !progress directives in table cells as progress bars', () => {
+    const { slides } = parseDocument(doc([
+      '## Slide',
+      '',
+      '| Feature | Status |',
+      '|---------|--------|',
+      '| Preview | !progress[Task Complete](75) |',
+    ].join('\n')));
+    const table = slides[0].elements.find((e) => e.type === 'table');
+    const cell = table?.type === 'table' ? table.rows[0][1] : '';
+    expect(cell).toContain('sl-progress--table');
+    expect(cell).toContain('Task Complete');
+    expect(cell).toContain('width: 75%');
+  });
+
+  it('renders calculated !progress directives in sheet table cells', () => {
+    const { slides } = parseDocument(doc([
+      '## Slide',
+      '',
+      '!let vat = 0.255',
+      '',
+      '!sheet',
+      '| item | qty | unit | total |',
+      '|------|----:|-----:|------:|',
+      '| motor | 3 | 12.50 | =qty * unit |',
+      '| ESC | 2 | 8.00 | =qty * unit |',
+      '| !Total | | | !progress[Done](=sum(total) * (1 + vat)) |',
+    ].join('\n')));
+    const table = slides[0].elements.find((e) => e.type === 'table');
+    const cell = table?.type === 'table' ? table.rows[2][3] : '';
+    expect(cell).toContain('sl-progress--table');
+    expect(cell).toContain('Done');
+    expect(cell).toContain('width: 67.14%');
+  });
+
+  it('does not treat a first-column !progress directive as a sheet footer marker', () => {
+    const { slides } = parseDocument(doc([
+      '## Slide',
+      '',
+      '!sheet',
+      '| status | value |',
+      '|--------|------:|',
+      '| !progress[Done](75) | 1 |',
+    ].join('\n')));
+    const table = slides[0].elements.find((e) => e.type === 'table');
+    const cell = table?.type === 'table' ? table.rows[0][0] : '';
+    expect(cell).toContain('sl-progress--table');
+    expect(cell).toContain('width: 75%');
+  });
+
   it('renders inline formatting in table header cells', () => {
     const { slides } = parseDocument(doc([
       '## Slide',

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -198,6 +198,7 @@ const YOUTUBE_RE      = /^!youtube\[([^\]]*)\]\(([^)]*)\)$/;
 const VIDEO_RE        = /^!video\[([^\]]*)\]\(([^)]*)\)$/;
 const POLL_RE         = /^!poll\[([^\]]*)\]\(([^)]*)\)$/;
 const PROGRESS_RE     = /^!progress\[([^\]]*)\]\((\d+(?:\.\d+)?)\)$/;
+const TABLE_PROGRESS_RE = /^!progress\[([^\]]*)\]\((\d+(?:\.\d+)?)\)$/;
 const CAPTION_RE      = /^!caption\[([^\]]*)\]$/;
 const REF_RE          = /^!ref\[([^\]]*)\]$/;
 const TOC_RE          = /^!toc$/;
@@ -458,8 +459,8 @@ function convertRoot(
       case 'table': {
         const t = node as Table;
         const [headerRow, ...bodyRows] = t.children;
-        const headers = (headerRow?.children ?? []).map((cell) => inlineToHtml(cell.children as Node[]));
-        let rows = bodyRows.map((row) => row.children.map((cell) => inlineToHtml(cell.children as Node[])));
+        const headers = (headerRow?.children ?? []).map((cell) => tableCellHtml(rawText(src, cell), cell.children as Node[]));
+        let rows = bodyRows.map((row) => row.children.map((cell) => tableCellHtml(rawText(src, cell), cell.children as Node[])));
 
         if (pendingSheet) {
           // Raw source, not mdast: remark reads `=a*b*c` as `a<em>b</em>c`.
@@ -468,10 +469,10 @@ function convertRoot(
           rows = bodyRows.map((row, r) =>
             row.children.map((cell, c) => {
               const value = computed[r + 1]?.[c];
-              if (value != null) return escHtml(value);
+              if (value != null) return tableCellHtml(value, []);
               // A literal cell keeps the HTML remark already built for it, so
               // `| !**Total** |` stays bold — minus the footer marker.
-              const html = inlineToHtml(cell.children as Node[]);
+              const html = tableCellHtml(rawText(src, cell), cell.children as Node[]);
               return c === 0 && isFooterRow(rawCells[r + 1] ?? []) ? html.replace(/^!\s*/, '') : html;
             }),
           );
@@ -828,6 +829,27 @@ function inlineToHtml(children: Node[]): string {
       default:            return node.children ? inlineToHtml(node.children) : '';
     }
   }).join('');
+}
+
+function tableCellHtml(raw: string, children: Node[]): string {
+  const progress = raw.trim().match(TABLE_PROGRESS_RE);
+  if (!progress) return children.length ? inlineToHtml(children) : escHtml(raw);
+  return progressHtml(progress[1], parseFloat(progress[2]));
+}
+
+function progressHtml(label: string, value: number): string {
+  const pct = Math.max(0, Math.min(100, value));
+  return [
+    '<div class="sl-progress sl-progress--table">',
+    '<div class="sl-progress__header">',
+    `<span class="sl-progress__label">${escHtml(label)}</span>`,
+    `<span class="sl-progress__pct">${escHtml(String(pct))}%</span>`,
+    '</div>',
+    '<div class="sl-progress__track">',
+    `<div class="sl-progress__fill" style="width: ${pct}%"></div>`,
+    '</div>',
+    '</div>',
+  ].join('');
 }
 
 // Escapes '"' too, not just <>&: this is also used to build attribute values

--- a/src/engine/sheet/sheet.ts
+++ b/src/engine/sheet/sheet.ts
@@ -38,11 +38,12 @@ export function slugify(header: string): string {
 // that starts with `=`. (remark renders `\!` as a plain `!`, so the escape
 // costs the author nothing in a non-Kova viewer.)
 export function isFooterRow(row: string[]): boolean {
-  return (row[0] ?? '').trim().startsWith('!');
+  const first = (row[0] ?? '').trim();
+  return first.startsWith('!') && !isProgressCell(first);
 }
 
 function hasFormula(raw: string[][], r: number): boolean {
-  return (raw[r] ?? []).some((_, c) => cellText(raw, r, c).startsWith('='));
+  return (raw[r] ?? []).some((_, c) => cellFormula(cellText(raw, r, c)) !== null);
 }
 
 export function evaluateSheet(
@@ -86,7 +87,8 @@ export function evaluateSheet(
     if (visiting.has(key)) throw new SheetError(`circular reference in column '${cols[c]}'`);
 
     const text = cellText(raw, r, c);
-    if (!text.startsWith('=')) {
+    const formula = cellFormula(text);
+    if (formula === null) {
       const v = literal(text);
       memo.set(key, v);
       return v;
@@ -100,7 +102,7 @@ export function evaluateSheet(
     visiting.add(key);
     try {
       const scope = footerRows.includes(r) ? footerScope() : rowScope(r);
-      const v = evaluate(parseExpr(text.slice(1)), scope);
+      const v = evaluate(parseExpr(formula), scope);
       if (Array.isArray(v)) throw new SheetError('expected a single value, got a whole column');
       memo.set(key, v);
       return v;
@@ -128,7 +130,15 @@ export function evaluateSheet(
 
   forEachFormula(raw, (r, c) => {
     try {
-      out[r][c] = render(cell(r, c), opts.precision);
+      const text = cellText(raw, r, c);
+      const progress = text.match(PROGRESS_FORMULA_RE);
+      if (progress) {
+        const value = cell(r, c);
+        if (typeof value !== 'number') throw new SheetError(`expected a number, got '${value}'`);
+        out[r][c] = `!progress[${progress[1]}](${render(value, opts.precision)})`;
+      } else {
+        out[r][c] = render(cell(r, c), opts.precision);
+      }
     } catch (err) {
       out[r][c] = `#ERR ${err instanceof SheetError ? err.message : 'evaluation failed'}`;
     }
@@ -140,16 +150,29 @@ export function evaluateSheet(
 // The footer marker is not part of the cell's content.
 function cellText(raw: string[][], r: number, c: number): string {
   const text = (raw[r]?.[c] ?? '').trim();
-  if (r > 0 && c === 0 && text.startsWith('!')) return text.slice(1).trim();
+  if (r > 0 && c === 0 && isFooterRow(raw[r] ?? [])) return text.slice(1).trim();
   return text;
 }
 
 function forEachFormula(raw: string[][], fn: (r: number, c: number) => void): void {
   for (let r = 1; r < raw.length; r++) {
     for (let c = 0; c < raw[r].length; c++) {
-      if (cellText(raw, r, c).startsWith('=')) fn(r, c);
+      if (cellFormula(cellText(raw, r, c)) !== null) fn(r, c);
     }
   }
+}
+
+const PROGRESS_FORMULA_RE = /^!progress\[([^\]]*)\]\(\s*=(.+)\)$/;
+const PROGRESS_CELL_RE = /^!progress\[[^\]]*\]\(.+\)$/;
+
+function isProgressCell(text: string): boolean {
+  return PROGRESS_CELL_RE.test(text);
+}
+
+function cellFormula(text: string): string | null {
+  if (text.startsWith('=')) return text.slice(1);
+  const progress = text.match(PROGRESS_FORMULA_RE);
+  return progress ? progress[2] : null;
 }
 
 function literal(text: string): Value {


### PR DESCRIPTION
Adds the possibility to use progress bars also inside of tables, and even  computed tables.

<img width="965" height="482" alt="image" src="https://github.com/user-attachments/assets/bd273d48-0d10-4718-8064-97ef8f40bb87" />

<img width="949" height="385" alt="image" src="https://github.com/user-attachments/assets/d866016b-d388-4d8f-a448-2ec4e4540a97" />

Can be tested with

[kova_debug.md](https://github.com/user-attachments/files/31727803/kova_debug.md)
