### PR TITLE
refactor: address #240 progress-bar follow-ups

### DIFF
--- a/src/components/preview/SlideRenderer.css
+++ b/src/components/preview/SlideRenderer.css
@@ -686,7 +686,7 @@
 
 .sl-progress { padding: 0.35em 0; }
 
-.sl-table .sl-progress { min-width: 8em; padding: 0; }
+.sl-progress--table { min-width: 8em; padding: 0; }
 
 .sl-progress__header {
   display: flex;

--- a/src/components/preview/elements.tsx
+++ b/src/components/preview/elements.tsx
@@ -6,6 +6,7 @@ import 'katex/dist/katex.min.css';
 import { QRCode } from 'react-qr-code';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import type { SlideElement, ListItem } from '../../engine/types';
+import { progressBarInnerHtml } from '../../engine/progressBar';
 import { mermaidSvgCache } from '../../engine/export/mermaidSvgCache';
 import { buildMermaidRenderSource } from '../../engine/export/mermaidSource';
 import { queuedMermaidRender } from '../../engine/export/mermaidRenderQueue';
@@ -401,17 +402,11 @@ export function CodeBlock({ lang, value }: { lang: string; value: string }) {
 // ── Progress bar ──────────────────────────────────────────────────────────────
 
 function ProgressBar({ el }: { el: Extract<SlideElement, { type: 'progress' }> }) {
-  const pct = Math.max(0, Math.min(100, el.value));
   return (
-    <div className="sl-progress">
-      <div className="sl-progress__header">
-        <span className="sl-progress__label">{el.label}</span>
-        <span className="sl-progress__pct">{pct}%</span>
-      </div>
-      <div className="sl-progress__track">
-        <div className="sl-progress__fill" style={{ width: `${pct}%` }} />
-      </div>
-    </div>
+    <div
+      className="sl-progress"
+      dangerouslySetInnerHTML={{ __html: progressBarInnerHtml(el.label, el.value) }}
+    />
   );
 }
 

--- a/src/engine/export/__tests__/exportPptxTableProgress.test.ts
+++ b/src/engine/export/__tests__/exportPptxTableProgress.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { exportToPptx } from '../exportPptx';
+import { DEFAULT_THEME } from '../../theme';
+import { parseDocument } from '../../parser/markdownToSlides';
+
+// PptxGenJS table cells can't hold shapes, so a `!progress` bar in a table
+// cell exports as a text meter instead of the block bar's rects. The bug it
+// guards against is stripHtml() flattening the bar to run-together "Done70%".
+
+async function slideXml(md: string): Promise<string> {
+  const { slides, frontmatter } = parseDocument(md);
+  const res = await exportToPptx(slides, frontmatter, DEFAULT_THEME, 'en');
+  const zip = await JSZip.loadAsync(res.base64, { base64: true });
+  return zip.file('ppt/slides/slide1.xml')!.async('string');
+}
+
+const tableXml = (xml: string) => xml.match(/<a:tbl>[\s\S]*<\/a:tbl>/)?.[0] ?? '';
+
+describe('exportPptx progress bar in a table cell', () => {
+  it('renders a literal !progress cell as a text meter, keeping label and percent apart', async () => {
+    const xml = tableXml(await slideXml([
+      '## Status',
+      '',
+      '| Feature | Progress |',
+      '|---------|----------|',
+      '| Preview | !progress[Done](70) |',
+    ].join('\n')));
+
+    expect(xml).toContain('Done');
+    expect(xml).toContain('70%');
+    expect(xml).not.toContain('Done70%');
+    expect(xml).toMatch(/[█░]/);
+  });
+
+  it('renders a computed !sheet !progress cell as a text meter', async () => {
+    const xml = tableXml(await slideXml([
+      '## Status',
+      '',
+      '!sheet',
+      '| item | qty | unit | done |',
+      '|------|----:|-----:|-----:|',
+      '| a | 3 | 10 | =qty * unit |',
+      '| !Total | | | !progress[Total](=sum(done)) |',
+    ].join('\n')));
+
+    expect(xml).toContain('Total');
+    expect(xml).toContain('30%');
+    expect(xml).not.toContain('Total30%');
+  });
+});

--- a/src/engine/export/exportPptx.ts
+++ b/src/engine/export/exportPptx.ts
@@ -2043,8 +2043,9 @@ function addTable(
   const colAlign = (i: number): 'left' | 'center' | 'right' =>
     (el.align?.[i] as 'left' | 'center' | 'right' | null | undefined) ?? 'left';
 
-  const headerText = el.headers.map(stripHtml);
-  const bodyText = el.rows.map((row) => row.map(stripHtml));
+  const cellText = (html: string) => progressBarText(html) ?? stripHtml(html);
+  const headerText = el.headers.map(cellText);
+  const bodyText = el.rows.map((row) => row.map(cellText));
   const fit = fitTableToArea([headerText, ...bodyText], area);
 
   if (fit.overflow) {
@@ -2286,6 +2287,25 @@ const NAMED_COLORS: Record<string, string> = {
 
 function firstFont(stack: string): string {
   return stack.split(',')[0].trim().replace(/['"]/g, '');
+}
+
+// A `!progress` directive in a table cell is rendered as an HTML bar (see
+// progressBar.ts). PptxGenJS table cells can't hold shapes, so the block
+// `!progress` path's rect drawing isn't available here — fall back to a text
+// meter (label · filled/empty blocks · percent) rather than stripHtml's
+// run-together "Done75%".
+function progressBarText(cellHtml: string): string | null {
+  if (!cellHtml.includes('sl-progress')) return null;
+  const div = document.createElement('div');
+  div.innerHTML = cellHtml;
+  const bar = div.querySelector('.sl-progress');
+  if (!bar) return null;
+  const label = (bar.querySelector('.sl-progress__label')?.textContent ?? '').trim();
+  const pctText = (bar.querySelector('.sl-progress__pct')?.textContent ?? '').trim();
+  const pct = Math.max(0, Math.min(100, parseFloat(pctText) || 0));
+  const filled = Math.round(pct / 10);
+  const meter = '█'.repeat(filled) + '░'.repeat(10 - filled);
+  return [label, meter, pctText].filter(Boolean).join('  ');
 }
 
 function stripHtml(html: string): string {

--- a/src/engine/parser/markdownToSlides.ts
+++ b/src/engine/parser/markdownToSlides.ts
@@ -9,6 +9,7 @@ import type { Root, Node, Paragraph, List, ListItem as MdastListItem, Code, Bloc
 
 import type { Slide, SlideElement, ListItem, LayoutType, Frontmatter, ParsedDocument } from '../types';
 import { detectLayout } from '../layout/autoLayout';
+import { progressBarInnerHtml } from '../progressBar';
 import { extractFrontmatter } from './frontmatter';
 import { extractSpeakerNotes } from './speakerNotes';
 import { extractBgImage } from './bgImage';
@@ -237,7 +238,6 @@ const YOUTUBE_RE      = /^!youtube\[([^\]]*)\]\(([^)]*)\)$/;
 const VIDEO_RE        = /^!video\[([^\]]*)\]\(([^)]*)\)$/;
 const POLL_RE         = /^!poll\[([^\]]*)\]\(([^)]*)\)$/;
 const PROGRESS_RE     = /^!progress\[([^\]]*)\]\((\d+(?:\.\d+)?)\)$/;
-const TABLE_PROGRESS_RE = /^!progress\[([^\]]*)\]\((\d+(?:\.\d+)?)\)$/;
 const CAPTION_RE      = /^!caption\[([^\]]*)\]$/;
 const REF_RE          = /^!ref\[([^\]]*)\]$/;
 const TOC_RE          = /^!toc$/;
@@ -871,24 +871,9 @@ function inlineToHtml(children: Node[]): string {
 }
 
 function tableCellHtml(raw: string, children: Node[]): string {
-  const progress = raw.trim().match(TABLE_PROGRESS_RE);
+  const progress = raw.trim().match(PROGRESS_RE);
   if (!progress) return children.length ? inlineToHtml(children) : escHtml(raw);
-  return progressHtml(progress[1], parseFloat(progress[2]));
-}
-
-function progressHtml(label: string, value: number): string {
-  const pct = Math.max(0, Math.min(100, value));
-  return [
-    '<div class="sl-progress sl-progress--table">',
-    '<div class="sl-progress__header">',
-    `<span class="sl-progress__label">${escHtml(label)}</span>`,
-    `<span class="sl-progress__pct">${escHtml(String(pct))}%</span>`,
-    '</div>',
-    '<div class="sl-progress__track">',
-    `<div class="sl-progress__fill" style="width: ${pct}%"></div>`,
-    '</div>',
-    '</div>',
-  ].join('');
+  return `<div class="sl-progress sl-progress--table">${progressBarInnerHtml(progress[1], parseFloat(progress[2]))}</div>`;
 }
 
 // Escapes '"' too, not just <>&: this is also used to build attribute values

--- a/src/engine/progressBar.ts
+++ b/src/engine/progressBar.ts
@@ -1,0 +1,33 @@
+// One source of truth for progress-bar markup. Two call sites render it: the
+// block `!progress` element (the React <ProgressBar> in elements.tsx) and a
+// `!progress` directive inside a table cell (an HTML string the parser emits
+// in markdownToSlides.ts). Keeping the inner markup here stops the two drifting
+// — the PPTX exporter reverse-engineers a table cell by looking for these exact
+// class names (see progressBarText in exportPptx.ts).
+
+/** Clamp a raw progress value to the displayable 0–100 range. */
+export function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/**
+ * Inner markup of a progress bar — the header row (label + percent) and the
+ * track/fill — without the outer `.sl-progress` element. Each call site adds
+ * that wrapper itself, plus any variant class (`.sl-progress--table`).
+ */
+export function progressBarInnerHtml(label: string, value: number): string {
+  const pct = clampPercent(value);
+  return (
+    '<div class="sl-progress__header">' +
+    `<span class="sl-progress__label">${esc(label)}</span>` +
+    `<span class="sl-progress__pct">${pct}%</span>` +
+    '</div>' +
+    '<div class="sl-progress__track">' +
+    `<div class="sl-progress__fill" style="width: ${pct}%"></div>` +
+    '</div>'
+  );
+}


### PR DESCRIPTION
Addresses the four follow-up notes left on #240.

1. **Shared markup.** `progressBarInnerHtml()` in a new `src/engine/progressBar.ts` is the one source of truth for the bar's inner structure (header + track). The block `<ProgressBar>` element and the table-cell HTML string both render from it, so they can no longer drift.
2. **`TABLE_PROGRESS_RE` removed** — it was byte-identical to `PROGRESS_RE`.
3. **CSS hook fixed.** The table variant's rule now targets `.sl-progress--table`, the class the parser actually emits, instead of the `.sl-table .sl-progress` descendant selector that nothing was keyed to.
4. **PPTX export.** PptxGenJS table cells can't hold shapes, so a `!progress` cell now exports as a text meter (`Done  ███████░░░  70%`) rather than `stripHtml` flattening it to the run-together `Done70%`. New test in `exportPptxTableProgress.test.ts` covers both the literal and computed-`!sheet` cases.

`tsc` clean. Full suite green apart from the two pre-existing `evaluate.test.ts` failures on `main`.

The block progress bar's rendered DOM is unchanged (same classes, same structure, same computed `width`); it just builds via `dangerouslySetInnerHTML`, matching how `.sl-para`, callouts and table cells already render in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)