### PR TITLE
feat(cli): add --export html

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -108,17 +108,19 @@ pub enum ImportFormat {
     Url,
 }
 
-/// Serialises as a bare lowercase string ("pptx"/"pdf") — same reasoning as
-/// `ImportFormat` above.
+/// Serialises as a bare lowercase string ("pptx"/"pdf"/"html") — same
+/// reasoning as `ImportFormat` above.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ExportFormat {
     Pptx,
     Pdf,
+    /// Self-contained interactive HTML deck (the Export → HTML output).
+    Html,
 }
 
 const IMPORT_USAGE: &str = "--import requires: --import <marp|pptx|url> <input> <output>";
-const EXPORT_USAGE: &str = "--export requires: --export <pptx|pdf> <input> <output>";
+const EXPORT_USAGE: &str = "--export requires: --export <pptx|pdf|html> <input> <output>";
 
 const USAGE: &str = "\
 Usage:
@@ -126,7 +128,8 @@ Usage:
   kova --present <FILE.md>                  present FILE directly (.md/.markdown only)
   kova --check <FILE.md>                    validate FILE and exit (.md/.markdown only)
   kova --import <marp|pptx|url> <IN> <OUT>  convert IN to Kova Markdown
-  kova --export <pptx|pdf> <IN> <OUT>       export IN via Kova's engine
+  kova --export <pptx|pdf|html> <IN> <OUT>  export IN via Kova's engine
+                                           (html is a self-contained deck)
 
 Modifiers (combine with an action, any order):
   --theme <NAME|PATH>   override the deck theme for this run; a name is
@@ -315,9 +318,10 @@ pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
                 let format = match format.as_str() {
                     "pptx" => ExportFormat::Pptx,
                     "pdf" => ExportFormat::Pdf,
+                    "html" => ExportFormat::Html,
                     other => {
                         return CliArgs::Error(format!(
-                            "unknown export format '{other}' (expected pptx or pdf)"
+                            "unknown export format '{other}' (expected pptx, pdf, or html)"
                         ))
                     }
                 };
@@ -337,6 +341,7 @@ pub fn parse_cli_args(args: Vec<String>) -> CliArgs {
                 let expected_out = match format {
                     ExportFormat::Pptx => &[".pptx"][..],
                     ExportFormat::Pdf => &[".pdf"][..],
+                    ExportFormat::Html => &[".html"][..],
                 };
                 if !has_extension(&output, expected_out) {
                     return CliArgs::Error(format!(
@@ -502,6 +507,7 @@ fn format_name_export(f: &ExportFormat) -> &'static str {
     match f {
         ExportFormat::Pptx => "pptx",
         ExportFormat::Pdf => "pdf",
+        ExportFormat::Html => "html",
     }
 }
 
@@ -875,6 +881,32 @@ mod tests {
     }
 
     #[test]
+    fn export_html_format_parses() {
+        let run = expect_run(&["--export", "html", "in.md", "out.html"]);
+        assert_eq!(
+            run.action,
+            Some(Action::Export {
+                format: ExportFormat::Html,
+                input: "in.md".into(),
+                output: "out.html".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn export_html_rejects_wrong_output_extension() {
+        let msg = expect_error(&["--export", "html", "in.md", "out.pdf"]);
+        assert!(msg.contains("--export html output must be a .html file"), "{msg}");
+    }
+
+    #[test]
+    fn export_html_rejects_layout_flags() {
+        // --notes / --per-page / --paper are PDF-only; html has no paper model.
+        let msg = expect_error(&["--per-page", "2", "--export", "html", "in.md", "out.html"]);
+        assert!(msg.contains("--notes, --per-page, and --paper require --export pdf"), "{msg}");
+    }
+
+    #[test]
     fn export_pdf_notes_and_layout_flags() {
         let run = expect_run(&[
             "--notes",
@@ -992,7 +1024,7 @@ mod tests {
     fn export_unknown_format() {
         assert_eq!(
             expect_error(&["--export", "docx", "in", "out"]),
-            "unknown export format 'docx' (expected pptx or pdf)"
+            "unknown export format 'docx' (expected pptx, pdf, or html)"
         );
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1697,6 +1697,36 @@ export default function App() {
     });
   }, [aspectRatio, activeTheme]);
 
+  // Shared by the button (handleExportHtml) and the headless CLI export path
+  // (kova --export html): mounts the same off-screen slide list the PDF
+  // capture uses, waits for it to render, and assembles the self-contained
+  // interactive deck. Returns the HTML string; throws on failure — each
+  // caller reports its own way (a dialog here, stderr for the CLI).
+  const runHtmlExportCapture = useCallback((visSlides: Slide[]): Promise<string> => {
+    pdfSlideRefs.current.clear();
+    pdfSlideReadyCount.current = 0;
+    pdfSlideReadyTotal.current = visSlides.length;
+    return new Promise<string>((resolve, reject) => {
+      pdfExportRunnerRef.current = async () => {
+        try {
+          const elements = Array.from(
+            { length: visSlides.length },
+            (_, i) => pdfSlideRefs.current.get(i),
+          ).filter((el): el is HTMLElement => Boolean(el));
+          resolve(await buildInteractiveDocument(elements, aspectRatio, visSlides));
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        } finally {
+          setPdfExportContext(null);
+          pdfSlideRefs.current.clear();
+          pdfExportRunnerRef.current = null;
+        }
+      };
+      // savePath is unused by the off-screen renderer (it reads .slides only).
+      setPdfExportContext({ slides: visSlides, savePath: '' });
+    });
+  }, [aspectRatio]);
+
   const handleExportPdf = useCallback(async (opts: PdfExportOpts = {}) => {
     if (visibleSlides.length === 0) return;
     // The in-window buttons disable while an export is already in flight, but
@@ -1730,13 +1760,14 @@ export default function App() {
     }
   }, [visibleSlides, filePath, runPdfExportCapture, t, pdfExportContext, printContext]);
 
-  // Cold-start export (kova --export pptx|pdf FILE OUT): the load effect
+  // Cold-start export (kova --export pptx|pdf|html FILE OUT): the load effect
   // above applies --theme and loads the deck; this fires once slides are
   // resolved. PPTX needs no rendered DOM (exportToPptx works from slide data
   // directly); PDF reuses the exact capture path the button uses above,
   // native print against the hidden dedicated print window (export_pdf_native
   // already always creates one, whether launched from the GUI or the CLI)
-  // with the same raster fallback on failure.
+  // with the same raster fallback on failure; HTML reuses the same off-screen
+  // capture as the Export → HTML button.
   const coldExportFiredRef = useRef(false);
   useEffect(() => {
     if (!coldExport || coldExportFiredRef.current || !filePath) return;
@@ -1765,6 +1796,12 @@ export default function App() {
           await finish(lines.join('\n'));
           return;
         }
+        if (coldExport.format === 'html') {
+          const html = await runHtmlExportCapture([...visibleSlides]);
+          await invoke('write_file', { path: coldExport.output, content: html });
+          await finish(`wrote '${coldExport.output}'`);
+          return;
+        }
         // Honour CLI --notes / --per-page / --paper; fall back to settings paper (#187 / #200).
         const paper = (coldExport.paper as 'a4' | 'letter' | 'slide' | null)
           ?? settings.pdfPageSize;
@@ -1787,7 +1824,7 @@ export default function App() {
         await fail(err instanceof Error ? err.message : String(err));
       }
     })();
-  }, [coldExport, filePath, visibleSlides, hasPendingLocalMedia, mediaWaitExpired, frontmatter, activeTheme, settings.locale, settings.pdfPageSize, runPdfExportCapture]);
+  }, [coldExport, filePath, visibleSlides, hasPendingLocalMedia, mediaWaitExpired, frontmatter, activeTheme, settings.locale, settings.pdfPageSize, runPdfExportCapture, runHtmlExportCapture]);
 
   const handleExportHtml = useCallback(async () => {
     if (visibleSlides.length === 0) return;
@@ -1801,33 +1838,14 @@ export default function App() {
     });
     if (!target) return;
     const savePath = target.toLowerCase().endsWith('.html') ? target : `${target}.html`;
-    const visSlides = [...visibleSlides];
-    pdfSlideRefs.current.clear();
-    pdfSlideReadyCount.current = 0;
-    pdfSlideReadyTotal.current = visSlides.length;
-    await new Promise<void>(resolve => {
-      pdfExportRunnerRef.current = async () => {
-        try {
-          const elements = Array.from(
-            { length: visSlides.length },
-            (_, i) => pdfSlideRefs.current.get(i),
-          ).filter((el): el is HTMLElement => Boolean(el));
-
-          const html = await buildInteractiveDocument(elements, aspectRatio, visSlides);
-          await invoke('write_file', { path: savePath, content: html });
-        } catch (err) {
-          console.error('HTML export failed:', err);
-          window.alert(t('app.htmlExportFailed', { error: String(err) }));
-        } finally {
-          setPdfExportContext(null);
-          pdfSlideRefs.current.clear();
-          pdfExportRunnerRef.current = null;
-          resolve();
-        }
-      };
-      setPdfExportContext({ slides: visSlides, savePath });
-    });
-  }, [visibleSlides, filePath, aspectRatio, t, pdfExportContext, printContext]);
+    try {
+      const html = await runHtmlExportCapture([...visibleSlides]);
+      await invoke('write_file', { path: savePath, content: html });
+    } catch (err) {
+      console.error('HTML export failed:', err);
+      window.alert(t('app.htmlExportFailed', { error: String(err) }));
+    }
+  }, [visibleSlides, filePath, runHtmlExportCapture, t, pdfExportContext, printContext]);
 
   const handlePrint = useCallback(async () => {
     if (visibleSlides.length === 0) return;

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -17,7 +17,7 @@ export interface PendingImport {
   force: boolean;
 }
 
-export type CliExportFormat = 'pptx' | 'pdf';
+export type CliExportFormat = 'pptx' | 'pdf' | 'html';
 
 export interface PendingExport {
   format: CliExportFormat;


### PR DESCRIPTION
## What

`kova --export html <IN.md> <OUT.html>` writes the self-contained interactive deck (the same output as **File → Export → HTML**, issue #220) from the headless cold-start path, alongside the existing `pptx` / `pdf` export formats.

## Changes

- **`src-tauri/src/cli.rs`** — `ExportFormat::Html`, parser branch, `.html` output-extension guard, help text, `format_name_export`. `--notes` / `--per-page` / `--paper` stay PDF-only via the existing `is_pdf_export` guard (the HTML deck has no paper model and re-derives build-reveal steps from `data-step` itself).
- **`src/App.tsx`** — the Export → HTML button's off-screen capture is extracted into a shared `runHtmlExportCapture` (mirrors `runPdfExportCapture`); the button and the new `coldExport` `html` branch both use it.
- **`src/types/cli.ts`** — `CliExportFormat` gains `'html'`.

The engine side (`buildInteractiveDocument` / `assembleInteractiveDocument`) already shipped with the button and is unit-tested independently.

## Tests

- `cargo test cli::` — 52 pass (3 new: format parses, wrong-extension rejected, layout-flags rejected)
- `tsc --noEmit`, `npm run build`, `npx vitest run src/engine/export` — all green

## Not verified

End-to-end headless HTML export on any platform — needs a real webview (`npm run dev` + a display), the same manual smoke gap `--export pdf` has for automated testing. Worth the macOS / Windows / Linux pass before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)